### PR TITLE
Implement Kaillera netplay support with PIF-level synchronization

### DIFF
--- a/Source/3rdParty/mupen64plus-core/projects/unix/Makefile
+++ b/Source/3rdParty/mupen64plus-core/projects/unix/Makefile
@@ -659,6 +659,7 @@ endif
 ifeq ($(NETPLAY), 1)
 CFLAGS += -DM64P_NETPLAY
 SOURCE += $(SRCDIR)/main/netplay.c
+SOURCE += $(SRCDIR)/main/pif_sync_callback.c
 endif
 
 # source files for optional features

--- a/Source/3rdParty/mupen64plus-core/src/device/pif/pif.c
+++ b/Source/3rdParty/mupen64plus-core/src/device/pif/pif.c
@@ -35,6 +35,7 @@
 #include "device/rcp/si/si_controller.h"
 #include "plugin/plugin.h"
 #include "main/netplay.h"
+#include "main/pif_sync_callback.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -382,6 +383,7 @@ void update_pif_ram(struct pif* pif)
     }
 
     netplay_update_input(pif);
+    call_pif_sync_callback(pif);
 
 #ifdef DEBUG_PIF
     DebugMessage(M64MSG_INFO, "PIF post read");

--- a/Source/3rdParty/mupen64plus-core/src/main/pif_sync_callback.c
+++ b/Source/3rdParty/mupen64plus-core/src/main/pif_sync_callback.c
@@ -1,0 +1,37 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - pif_sync_callback.c                                     *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
+ *   Copyright (C) 2025 RMG Contributors                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "pif_sync_callback.h"
+#include <stddef.h>
+
+static pif_sync_callback_t g_pif_sync_callback = NULL;
+
+void set_pif_sync_callback(pif_sync_callback_t callback)
+{
+    g_pif_sync_callback = callback;
+}
+
+void call_pif_sync_callback(struct pif* pif)
+{
+    if (g_pif_sync_callback != NULL) {
+        g_pif_sync_callback(pif);
+    }
+}

--- a/Source/3rdParty/mupen64plus-core/src/main/pif_sync_callback.h
+++ b/Source/3rdParty/mupen64plus-core/src/main/pif_sync_callback.h
@@ -1,0 +1,48 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - pif_sync_callback.h                                     *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
+ *   Copyright (C) 2025 RMG Contributors                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef M64P_MAIN_PIF_SYNC_CALLBACK_H
+#define M64P_MAIN_PIF_SYNC_CALLBACK_H
+
+#include "api/m64p_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct pif;
+
+/* Callback function type for external PIF synchronization (e.g., Kaillera)
+ * Called after netplay_update_input() to allow external sync implementations
+ */
+typedef void (*pif_sync_callback_t)(struct pif* pif);
+
+/* Set PIF sync callback (call this from RMG-Core) */
+EXPORT void CALL set_pif_sync_callback(pif_sync_callback_t callback);
+
+/* Call the PIF sync callback if set (called from pif.c) */
+void call_pif_sync_callback(struct pif* pif);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Source/3rdParty/mupen64plus-input-raphnetraw/src/plugin_back.c
+++ b/Source/3rdParty/mupen64plus-input-raphnetraw/src/plugin_back.c
@@ -309,7 +309,7 @@ static int pb_performIo(void)
 
 	for (j=0; j<g_n_channels; j++)
 	{
-		adap = &g_adapters[j];
+		adap = g_channels[j].adapter;
 		biops = adap->biops;
 
 		/* Skip adapters that do not have IO operations queued. */

--- a/Source/RMG-Core/CMakeLists.txt
+++ b/Source/RMG-Core/CMakeLists.txt
@@ -38,6 +38,7 @@ set(RMG_CORE_SOURCES
     Archive.cpp
     Library.cpp
     Netplay.cpp
+    Kaillera.cpp
     Plugins.cpp
     Version.cpp
     Cheats.cpp

--- a/Source/RMG-Core/Emulation.hpp
+++ b/Source/RMG-Core/Emulation.hpp
@@ -40,4 +40,8 @@ bool CoreIsEmulationRunning(void);
 // returns whether emulation is paused
 bool CoreIsEmulationPaused(void);
 
+// returns current VI (vertical interrupt) frame count
+// used for synchronization in netplay/Kaillera
+int CoreGetCurrentFrameCount(void);
+
 #endif // CORE_EMULATION_HPP

--- a/Source/RMG-Core/Kaillera.cpp
+++ b/Source/RMG-Core/Kaillera.cpp
@@ -1,0 +1,401 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ * Copyright (C) 2020 Rosalie Wanders <rosalie@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#define CORE_INTERNAL
+#include "Kaillera.hpp"
+#include "Error.hpp"
+
+#include <windows.h>
+#include <cstring>
+
+//
+// Kaillera API Structures and Types
+//
+
+typedef struct {
+    char *appName;
+    char *gameList;
+    int (WINAPI *gameCallback)(char *game, int player, int numplayers);
+    void (WINAPI *chatReceivedCallback)(char *nick, char *text);
+    void (WINAPI *clientDroppedCallback)(char *nick, int playernb);
+    void (WINAPI *moreInfosCallback)(char *gamename);
+} kailleraInfos;
+
+// Kaillera function pointers
+typedef void (WINAPI *kailleraGetVersion_t)(char *version);
+typedef int (WINAPI *kailleraInit_t)(void);
+typedef void (WINAPI *kailleraShutdown_t)(void);
+typedef void (WINAPI *kailleraSetInfos_t)(kailleraInfos *infos);
+typedef int (WINAPI *kailleraSelectServerDialog_t)(HWND parent);
+typedef int (WINAPI *kailleraModifyPlayValues_t)(void *values, int size);
+typedef void (WINAPI *kailleraChatSend_t)(char *text);
+typedef void (WINAPI *kailleraEndGame_t)(void);
+
+//
+// Static Variables
+//
+
+static HMODULE s_KailleraDLL = nullptr;
+static bool s_Initialized = false;
+static bool s_GameActive = false;
+static int s_PlayerNumber = 0; // 0 = not in netplay, 1-4 = player number
+static int s_NumPlayers = 0;   // Total number of players in the game
+static std::string s_AppName;
+static std::string s_GameList;
+
+// Kaillera function pointers
+static kailleraGetVersion_t kailleraGetVersion = nullptr;
+static kailleraInit_t kailleraInit = nullptr;
+static kailleraShutdown_t kailleraShutdown = nullptr;
+static kailleraSetInfos_t kailleraSetInfos = nullptr;
+static kailleraSelectServerDialog_t kailleraSelectServerDialog = nullptr;
+static kailleraModifyPlayValues_t kailleraModifyPlayValues = nullptr;
+static kailleraChatSend_t kailleraChatSend = nullptr;
+static kailleraEndGame_t kailleraEndGame = nullptr;
+
+// Callback storage
+static CoreKaillera::GameStartCallback s_GameStartCallback;
+static CoreKaillera::ChatReceivedCallback s_ChatReceivedCallback;
+static CoreKaillera::ClientDroppedCallback s_ClientDroppedCallback;
+static CoreKaillera::MoreInfosCallback s_MoreInfosCallback;
+
+//
+// C Callback Bridges (called by Kaillera from its internal thread)
+//
+
+static int WINAPI GameCallbackBridge(char *game, int player, int numplayers)
+{
+    // Store player number and total player count
+    s_PlayerNumber = player;
+    s_NumPlayers = numplayers;
+
+    if (s_GameStartCallback)
+    {
+        try
+        {
+            s_GameStartCallback(std::string(game), player, numplayers);
+            s_GameActive = true;
+            return 0; // Success
+        }
+        catch (...)
+        {
+            return -1; // Error
+        }
+    }
+    return 0;
+}
+
+static void WINAPI ChatReceivedCallbackBridge(char *nick, char *text)
+{
+    if (s_ChatReceivedCallback)
+    {
+        try
+        {
+            s_ChatReceivedCallback(std::string(nick), std::string(text));
+        }
+        catch (...)
+        {
+            // Ignore errors in callback
+        }
+    }
+}
+
+static void WINAPI ClientDroppedCallbackBridge(char *nick, int playernb)
+{
+    if (s_ClientDroppedCallback)
+    {
+        try
+        {
+            s_ClientDroppedCallback(std::string(nick), playernb);
+        }
+        catch (...)
+        {
+            // Ignore errors in callback
+        }
+    }
+}
+
+static void WINAPI MoreInfosCallbackBridge(char *gamename)
+{
+    if (s_MoreInfosCallback)
+    {
+        try
+        {
+            s_MoreInfosCallback(std::string(gamename));
+        }
+        catch (...)
+        {
+            // Ignore errors in callback
+        }
+    }
+}
+
+//
+// Helper Functions
+//
+
+static bool LoadKailleraDLL(void)
+{
+    if (s_KailleraDLL != nullptr)
+    {
+        return true; // Already loaded
+    }
+
+    // Try to load kailleraclient.dll from current directory
+    s_KailleraDLL = LoadLibraryA("kailleraclient.dll");
+    if (s_KailleraDLL == nullptr)
+    {
+        CoreSetError("Failed to load kailleraclient.dll. Make sure it's in the same directory as RMG.exe");
+        return false;
+    }
+
+    // Load all required functions
+    kailleraGetVersion = (kailleraGetVersion_t)GetProcAddress(s_KailleraDLL, "kailleraGetVersion");
+    kailleraInit = (kailleraInit_t)GetProcAddress(s_KailleraDLL, "kailleraInit");
+    kailleraShutdown = (kailleraShutdown_t)GetProcAddress(s_KailleraDLL, "kailleraShutdown");
+    kailleraSetInfos = (kailleraSetInfos_t)GetProcAddress(s_KailleraDLL, "kailleraSetInfos");
+    kailleraSelectServerDialog = (kailleraSelectServerDialog_t)GetProcAddress(s_KailleraDLL, "kailleraSelectServerDialog");
+    kailleraModifyPlayValues = (kailleraModifyPlayValues_t)GetProcAddress(s_KailleraDLL, "kailleraModifyPlayValues");
+    kailleraChatSend = (kailleraChatSend_t)GetProcAddress(s_KailleraDLL, "kailleraChatSend");
+    kailleraEndGame = (kailleraEndGame_t)GetProcAddress(s_KailleraDLL, "kailleraEndGame");
+
+    // Verify all functions were loaded
+    if (!kailleraGetVersion || !kailleraInit || !kailleraShutdown ||
+        !kailleraSetInfos || !kailleraSelectServerDialog || !kailleraModifyPlayValues ||
+        !kailleraChatSend || !kailleraEndGame)
+    {
+        CoreSetError("Invalid kailleraclient.dll - missing required functions");
+        FreeLibrary(s_KailleraDLL);
+        s_KailleraDLL = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+//
+// Exported Functions
+//
+
+CORE_EXPORT bool CoreInitKaillera(void)
+{
+    if (s_Initialized)
+    {
+        return true; // Already initialized
+    }
+
+    // Load DLL
+    if (!LoadKailleraDLL())
+    {
+        return false;
+    }
+
+    // Check version
+    char version[16];
+    kailleraGetVersion(version);
+    // Version should be "0.9" or compatible
+    // We don't enforce a specific version for now
+
+    // Initialize Kaillera
+    int ret = kailleraInit();
+    if (ret != 0)
+    {
+        CoreSetError("Kaillera initialization failed with error code: " + std::to_string(ret));
+        return false;
+    }
+
+    s_Initialized = true;
+    s_GameActive = false;
+
+    return true;
+}
+
+CORE_EXPORT bool CoreShutdownKaillera(void)
+{
+    if (!s_Initialized)
+    {
+        return true; // Not initialized, nothing to do
+    }
+
+    // End game if active
+    if (s_GameActive)
+    {
+        CoreEndKailleraGame();
+    }
+
+    // Shutdown Kaillera
+    if (kailleraShutdown)
+    {
+        kailleraShutdown();
+    }
+
+    s_Initialized = false;
+    s_GameActive = false;
+
+    // Note: We don't FreeLibrary the DLL because Kaillera may have
+    // background threads that need to clean up
+
+    return true;
+}
+
+CORE_EXPORT bool CoreHasInitKaillera(void)
+{
+    return s_Initialized && s_GameActive;
+}
+
+CORE_EXPORT bool CoreShowKailleraServerDialog(void* parentHwnd)
+{
+    if (!s_Initialized)
+    {
+        CoreSetError("Kaillera not initialized. Call CoreInitKaillera() first");
+        return false;
+    }
+
+    // Show Kaillera's server selection dialog
+    int ret = kailleraSelectServerDialog((HWND)parentHwnd);
+    if (ret != 0)
+    {
+        CoreSetError("Failed to connect to Kaillera server");
+        return false;
+    }
+
+    return true;
+}
+
+CORE_EXPORT int CoreModifyKailleraPlayValues(void* values, int size)
+{
+    if (!s_Initialized || !s_GameActive)
+    {
+        return -1; // Not in netplay mode
+    }
+
+    if (!kailleraModifyPlayValues)
+    {
+        return -1;
+    }
+
+    // Call Kaillera to synchronize input
+    int ret = kailleraModifyPlayValues(values, size);
+    return ret;
+}
+
+CORE_EXPORT bool CoreKailleraSendChat(std::string text)
+{
+    if (!s_Initialized || !s_GameActive)
+    {
+        return false;
+    }
+
+    if (!kailleraChatSend)
+    {
+        return false;
+    }
+
+    // Kaillera expects non-const char*
+    char* textBuf = new char[text.length() + 1];
+    strcpy(textBuf, text.c_str());
+
+    kailleraChatSend(textBuf);
+
+    delete[] textBuf;
+    return true;
+}
+
+CORE_EXPORT bool CoreEndKailleraGame(void)
+{
+    if (!s_GameActive)
+    {
+        return true; // No game active
+    }
+
+    if (kailleraEndGame)
+    {
+        kailleraEndGame();
+    }
+
+    s_GameActive = false;
+    return true;
+}
+
+CORE_EXPORT void CoreSetKailleraCallbacks(
+    CoreKaillera::GameStartCallback gameStartCallback,
+    CoreKaillera::ChatReceivedCallback chatReceivedCallback,
+    CoreKaillera::ClientDroppedCallback clientDroppedCallback,
+    CoreKaillera::MoreInfosCallback moreInfosCallback)
+{
+    s_GameStartCallback = gameStartCallback;
+    s_ChatReceivedCallback = chatReceivedCallback;
+    s_ClientDroppedCallback = clientDroppedCallback;
+    s_MoreInfosCallback = moreInfosCallback;
+
+    // Set up kailleraInfos structure
+    if (s_Initialized && kailleraSetInfos)
+    {
+        static kailleraInfos infos;
+
+        // Allocate app name (must persist)
+        static char appNameBuf[128];
+        strncpy(appNameBuf, s_AppName.c_str(), sizeof(appNameBuf) - 1);
+        appNameBuf[sizeof(appNameBuf) - 1] = '\0';
+        infos.appName = appNameBuf;
+
+        // Allocate game list (must persist)
+        static char* gameListBuf = nullptr;
+        if (gameListBuf)
+        {
+            delete[] gameListBuf;
+        }
+        gameListBuf = new char[s_GameList.length() + 1];
+        strcpy(gameListBuf, s_GameList.c_str());
+        infos.gameList = gameListBuf;
+
+        // Set callbacks
+        infos.gameCallback = GameCallbackBridge;
+        infos.chatReceivedCallback = s_ChatReceivedCallback ? ChatReceivedCallbackBridge : nullptr;
+        infos.clientDroppedCallback = s_ClientDroppedCallback ? ClientDroppedCallbackBridge : nullptr;
+        infos.moreInfosCallback = s_MoreInfosCallback ? MoreInfosCallbackBridge : nullptr;
+
+        kailleraSetInfos(&infos);
+    }
+}
+
+CORE_EXPORT bool CoreSetKailleraAppInfo(std::string appName, std::string gameList)
+{
+    s_AppName = appName;
+    s_GameList = gameList;
+
+    // Update kailleraInfos if already initialized
+    if (s_Initialized && kailleraSetInfos)
+    {
+        // Trigger callback update which will also update app info
+        CoreSetKailleraCallbacks(
+            s_GameStartCallback,
+            s_ChatReceivedCallback,
+            s_ClientDroppedCallback,
+            s_MoreInfosCallback
+        );
+    }
+
+    return true;
+}
+
+CORE_EXPORT void CoreSetKailleraPlayerNumber(int playerNumber)
+{
+    s_PlayerNumber = playerNumber;
+}
+
+CORE_EXPORT int CoreGetKailleraPlayerNumber(void)
+{
+    return s_PlayerNumber;
+}
+
+CORE_EXPORT int CoreGetKailleraNumPlayers(void)
+{
+    return s_NumPlayers;
+}

--- a/Source/RMG-Core/Kaillera.hpp
+++ b/Source/RMG-Core/Kaillera.hpp
@@ -1,0 +1,83 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ * Copyright (C) 2020 Rosalie Wanders <rosalie@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef CORE_KAILLERA_HPP
+#define CORE_KAILLERA_HPP
+
+#include "Library.hpp"
+
+#include <string>
+#include <functional>
+
+namespace CoreKaillera
+{
+    // Callback function types
+    using GameStartCallback = std::function<void(std::string gameName, int playerNumber, int numPlayers)>;
+    using ChatReceivedCallback = std::function<void(std::string nickname, std::string text)>;
+    using ClientDroppedCallback = std::function<void(std::string nickname, int playerNumber)>;
+    using MoreInfosCallback = std::function<void(std::string gameName)>;
+}
+
+//
+// Exported Functions
+//
+
+// Initialize Kaillera client library
+// Returns true on success, false on failure (check CoreGetError() for details)
+CORE_EXPORT bool CoreInitKaillera(void);
+
+// Shutdown Kaillera client library
+CORE_EXPORT bool CoreShutdownKaillera(void);
+
+// Check if Kaillera has been initialized
+CORE_EXPORT bool CoreHasInitKaillera(void);
+
+// Show Kaillera server selection dialog
+// parentHwnd: Handle to parent window (HWND on Windows)
+// Returns true if user connected to a server, false if cancelled
+CORE_EXPORT bool CoreShowKailleraServerDialog(void* parentHwnd);
+
+// Modify play values (called every frame during netplay)
+// Sends local input data and receives synchronized data from all players
+// values: Pointer to input buffer (will be modified in-place with synced data)
+// size: Size of input buffer in bytes
+// Returns number of bytes received, or -1 on error
+CORE_EXPORT int CoreModifyKailleraPlayValues(void* values, int size);
+
+// Send chat message to other players
+CORE_EXPORT bool CoreKailleraSendChat(std::string text);
+
+// End current Kaillera game session
+CORE_EXPORT bool CoreEndKailleraGame(void);
+
+// Set Kaillera callbacks
+// These callbacks are invoked from Kaillera's internal thread
+// Implementations must be thread-safe!
+CORE_EXPORT void CoreSetKailleraCallbacks(
+    CoreKaillera::GameStartCallback gameStartCallback,
+    CoreKaillera::ChatReceivedCallback chatReceivedCallback,
+    CoreKaillera::ClientDroppedCallback clientDroppedCallback,
+    CoreKaillera::MoreInfosCallback moreInfosCallback
+);
+
+// Set application info for Kaillera
+// appName: Name displayed in Kaillera dialogs
+// gameList: List of supported games (NULL-terminated strings with double-NULL at end)
+CORE_EXPORT bool CoreSetKailleraAppInfo(std::string appName, std::string gameList);
+
+// Set/Get the current player number for Kaillera netplay
+// Player numbers are 1-4 (0 = not in netplay)
+CORE_EXPORT void CoreSetKailleraPlayerNumber(int playerNumber);
+CORE_EXPORT int CoreGetKailleraPlayerNumber(void);
+
+// Get the total number of players in the current Kaillera game
+// Returns 0 if not in a game, otherwise 1-4
+CORE_EXPORT int CoreGetKailleraNumPlayers(void);
+
+#endif // CORE_KAILLERA_HPP

--- a/Source/RMG-Input/CMakeLists.txt
+++ b/Source/RMG-Input/CMakeLists.txt
@@ -39,12 +39,15 @@ set(RMG_INPUT_SOURCES
 )
 
 if (VRU)
-    list(APPEND RMG_INPUT_SOURCES 
+    list(APPEND RMG_INPUT_SOURCES
         VRU.cpp
         VRUwords.cpp
     )
     add_definitions(-DVRU)
 endif(VRU)
+
+# Enable Kaillera netplay support
+add_definitions(-DNETPLAY)
 
 add_library(RMG-Input SHARED ${RMG_INPUT_SOURCES})
 

--- a/Source/RMG-Input/main.cpp
+++ b/Source/RMG-Input/main.cpp
@@ -34,6 +34,7 @@
 #include <RMG-Core/SaveState.hpp>
 #include <RMG-Core/Settings.hpp>
 #include <RMG-Core/Netplay.hpp>
+#include <RMG-Core/Kaillera.hpp>
 #include <RMG-Core/Cheats.hpp>
 #include <RMG-Core/Video.hpp>
 
@@ -1398,6 +1399,10 @@ EXPORT void CALL GetKeys(int Control, BUTTONS* Keys)
 
     Keys->X_AXIS = octagonX;
     Keys->Y_AXIS = octagonY;
+
+    // NOTE: Kaillera netplay synchronization moved to PIF RAM level
+    // (See kaillera_update_input() in mupen64plus-core/src/main/kaillera.c)
+    // This ensures sync works with ALL input plugins including raphnet
 }
 
 EXPORT void CALL InitiateControllers(CONTROL_INFO ControlInfo)

--- a/Source/RMG/CMakeLists.txt
+++ b/Source/RMG/CMakeLists.txt
@@ -92,6 +92,7 @@ endif(UPDATER)
 
 if (NETPLAY)
     list(APPEND RMG_SOURCES
+        UserInterface/KailleraSessionManager.cpp
         UserInterface/Dialog/Netplay/NetplayCommon.cpp
         UserInterface/Dialog/Netplay/CreateNetplaySessionDialog.cpp
         UserInterface/Dialog/Netplay/CreateNetplaySessionDialog.ui

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -525,8 +525,9 @@ void SettingsDialog::loadInterfaceNetplaySettings(void)
     }
 
     this->netplayNicknameLineEdit->setText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::Netplay_Nickname)));
-    this->netplayServerUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::Netplay_ServerJsonUrl)));
-    this->netplayDispatcherUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::Netplay_DispatcherUrl)));
+    // Kaillera uses built-in server list, no need for custom URLs
+    // this->netplayServerUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::Netplay_ServerJsonUrl)));
+    // this->netplayDispatcherUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::Netplay_DispatcherUrl)));
 }
 
 void SettingsDialog::loadDefaultCoreSettings(void)
@@ -679,8 +680,9 @@ void SettingsDialog::loadDefaultInterfaceOSDSettings(void)
 void SettingsDialog::loadDefaultInterfaceNetplaySettings(void)
 {
     this->netplayNicknameLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Netplay_Nickname)));
-    this->netplayServerUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Netplay_ServerJsonUrl)));
-    this->netplayDispatcherUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Netplay_DispatcherUrl)));
+    // Kaillera uses built-in server list, no need for custom URLs
+    // this->netplayServerUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Netplay_ServerJsonUrl)));
+    // this->netplayDispatcherUrlLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Netplay_DispatcherUrl)));
 }
 
 void SettingsDialog::saveSettings(void)
@@ -915,8 +917,9 @@ void SettingsDialog::saveInterfaceOSDSettings(void)
 void SettingsDialog::saveInterfaceNetplaySettings(void)
 {
     CoreSettingsSetValue(SettingsID::Netplay_Nickname, this->netplayNicknameLineEdit->text().toStdString());
-    CoreSettingsSetValue(SettingsID::Netplay_ServerJsonUrl, this->netplayServerUrlLineEdit->text().toStdString());
-    CoreSettingsSetValue(SettingsID::Netplay_DispatcherUrl, this->netplayDispatcherUrlLineEdit->text().toStdString());
+    // Kaillera uses built-in server list, no need for custom URLs
+    // CoreSettingsSetValue(SettingsID::Netplay_ServerJsonUrl, this->netplayServerUrlLineEdit->text().toStdString());
+    // CoreSettingsSetValue(SettingsID::Netplay_DispatcherUrl, this->netplayDispatcherUrlLineEdit->text().toStdString());
 }
 
 void SettingsDialog::commonHotkeySettings(SettingsDialogAction action)

--- a/Source/RMG/UserInterface/KailleraSessionManager.cpp
+++ b/Source/RMG/UserInterface/KailleraSessionManager.cpp
@@ -1,0 +1,170 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ * Copyright (C) 2020 Rosalie Wanders <rosalie@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "KailleraSessionManager.hpp"
+
+#include <RMG-Core/Kaillera.hpp>
+
+#include <QMetaObject>
+#include <QWidget>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+KailleraSessionManager::KailleraSessionManager(QWidget* parent)
+    : QObject(parent)
+    , m_gameActive(false)
+    , m_playerNumber(-1)
+    , m_totalPlayers(0)
+    , m_parentWidget(parent)
+{
+    // Register Kaillera callbacks
+    // These callbacks are invoked from Kaillera's internal thread
+    // We use QMetaObject::invokeMethod with Qt::QueuedConnection to safely
+    // marshal calls to the Qt main thread
+
+    CoreSetKailleraCallbacks(
+        // Game start callback
+        [this](std::string game, int player, int numPlayers) {
+            QMetaObject::invokeMethod(this,
+                [this, game, player, numPlayers]() {
+                    this->handleGameStart(QString::fromStdString(game), player, numPlayers);
+                },
+                Qt::QueuedConnection);
+        },
+        // Chat received callback
+        [this](std::string nick, std::string text) {
+            QMetaObject::invokeMethod(this,
+                [this, nick, text]() {
+                    this->handleChatReceived(QString::fromStdString(nick),
+                                            QString::fromStdString(text));
+                },
+                Qt::QueuedConnection);
+        },
+        // Client dropped callback
+        [this](std::string nick, int playerNum) {
+            QMetaObject::invokeMethod(this,
+                [this, nick, playerNum]() {
+                    this->handlePlayerDropped(QString::fromStdString(nick), playerNum);
+                },
+                Qt::QueuedConnection);
+        },
+        // More infos callback (optional, can be nullptr)
+        nullptr
+    );
+}
+
+KailleraSessionManager::~KailleraSessionManager()
+{
+    if (m_gameActive)
+    {
+        endGame();
+    }
+}
+
+bool KailleraSessionManager::showServerDialog()
+{
+#ifdef _WIN32
+    // Get native window handle from Qt widget
+    HWND hwnd = nullptr;
+    if (m_parentWidget)
+    {
+        hwnd = (HWND)m_parentWidget->winId();
+    }
+
+    // Show Kaillera's built-in server selection dialog
+    // This is a blocking call - user will select server, create/join game
+    // When they start a game, gameCallback will be invoked
+    return CoreShowKailleraServerDialog(hwnd);
+#else
+    // Kaillera is Windows-only
+    return false;
+#endif
+}
+
+bool KailleraSessionManager::isGameActive() const
+{
+    return m_gameActive;
+}
+
+QString KailleraSessionManager::getCurrentGame() const
+{
+    return m_currentGame;
+}
+
+int KailleraSessionManager::getPlayerNumber() const
+{
+    return m_playerNumber;
+}
+
+int KailleraSessionManager::getTotalPlayers() const
+{
+    return m_totalPlayers;
+}
+
+void KailleraSessionManager::sendChatMessage(QString message)
+{
+    if (!m_gameActive)
+    {
+        return;
+    }
+
+    CoreKailleraSendChat(message.toStdString());
+}
+
+void KailleraSessionManager::endGame()
+{
+    if (!m_gameActive)
+    {
+        return;
+    }
+
+    CoreEndKailleraGame();
+    m_gameActive = false;
+    m_currentGame.clear();
+    m_playerNumber = -1;
+    m_totalPlayers = 0;
+
+    emit gameEnded();
+}
+
+//
+// Private callback handlers (called on Qt main thread)
+//
+
+void KailleraSessionManager::handleGameStart(QString game, int player, int numPlayers)
+{
+    m_gameActive = true;
+    m_currentGame = game;
+    m_playerNumber = player;
+    m_totalPlayers = numPlayers;
+
+    emit gameStarted(game, player, numPlayers);
+}
+
+void KailleraSessionManager::handleChatReceived(QString nick, QString text)
+{
+    emit chatReceived(nick, text);
+}
+
+void KailleraSessionManager::handlePlayerDropped(QString nick, int playerNum)
+{
+    emit playerDropped(nick, playerNum);
+
+    // If we're the one who dropped, end the game
+    if (playerNum == m_playerNumber)
+    {
+        m_gameActive = false;
+        m_currentGame.clear();
+        m_playerNumber = -1;
+        m_totalPlayers = 0;
+        emit gameEnded();
+    }
+}

--- a/Source/RMG/UserInterface/KailleraSessionManager.hpp
+++ b/Source/RMG/UserInterface/KailleraSessionManager.hpp
@@ -1,0 +1,75 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ * Copyright (C) 2020 Rosalie Wanders <rosalie@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef KAILLERASESSIONMANAGER_HPP
+#define KAILLERASESSIONMANAGER_HPP
+
+#include <QObject>
+#include <QString>
+#include <QWidget>
+
+//
+// KailleraSessionManager
+//
+// Qt wrapper around Kaillera that bridges C callbacks to Qt signals
+// Provides thread-safe interface for Kaillera integration
+//
+class KailleraSessionManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    KailleraSessionManager(QWidget* parent = nullptr);
+    ~KailleraSessionManager();
+
+    // Show Kaillera's server selection dialog
+    // Returns true if user connected to server, false if cancelled
+    bool showServerDialog();
+
+    // Get current game state
+    bool isGameActive() const;
+    QString getCurrentGame() const;
+    int getPlayerNumber() const;
+    int getTotalPlayers() const;
+
+signals:
+    // Emitted when a game starts (after joining/creating in Kaillera dialog)
+    void gameStarted(QString gameName, int playerNum, int totalPlayers);
+
+    // Emitted when a chat message is received
+    void chatReceived(QString nickname, QString message);
+
+    // Emitted when a player disconnects
+    void playerDropped(QString nickname, int playerNum);
+
+    // Emitted when the game ends
+    void gameEnded();
+
+public slots:
+    // Send a chat message to other players
+    void sendChatMessage(QString message);
+
+    // End the current game session
+    void endGame();
+
+private:
+    // Callback handlers (invoked from Kaillera thread via QMetaObject::invokeMethod)
+    void handleGameStart(QString game, int player, int numPlayers);
+    void handleChatReceived(QString nick, QString text);
+    void handlePlayerDropped(QString nick, int playerNum);
+
+    // State variables
+    bool m_gameActive;
+    QString m_currentGame;
+    int m_playerNumber;
+    int m_totalPlayers;
+    QWidget* m_parentWidget;
+};
+
+#endif // KAILLERASESSIONMANAGER_HPP

--- a/Source/RMG/UserInterface/MainWindow.hpp
+++ b/Source/RMG/UserInterface/MainWindow.hpp
@@ -21,6 +21,7 @@
 
 #ifdef NETPLAY
 #include "Dialog/Netplay/NetplaySessionDialog.hpp"
+#include "KailleraSessionManager.hpp"
 #endif // NETPLAY
 #include "Dialog/LogDialog.hpp"
 
@@ -120,6 +121,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     Dialog::LogDialog logDialog;
 #ifdef NETPLAY
     Dialog::NetplaySessionDialog* netplaySessionDialog = nullptr;
+    KailleraSessionManager* kailleraSessionManager = nullptr;
 #endif // NETPLAY
 
     void closeEvent(QCloseEvent *) Q_DECL_OVERRIDE;
@@ -165,6 +167,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
 
 #ifdef NETPLAY
     void showNetplaySessionDialog(QWebSocket* webSocket, QJsonObject json, QString sessionFile);
+    QString findRomByName(QString gameName);
 #endif // NETPLAY
   protected:
     void timerEvent(QTimerEvent *event) Q_DECL_OVERRIDE;
@@ -218,6 +221,11 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     void on_Action_Netplay_CreateSession(void);
     void on_Action_Netplay_BrowseSessions(void);
     void on_Action_Netplay_ViewSession(void);
+
+    void on_Kaillera_GameStarted(QString gameName, int playerNum, int totalPlayers);
+    void on_Kaillera_ChatReceived(QString nickname, QString message);
+    void on_Kaillera_PlayerDropped(QString nickname, int playerNum);
+    void on_Kaillera_GameEnded(void);
 
     void on_Action_Help_Github(void);
     void on_Action_Help_About(void);

--- a/Source/RMG/UserInterface/MainWindow.ui
+++ b/Source/RMG/UserInterface/MainWindow.ui
@@ -154,10 +154,7 @@
     <property name="title">
      <string>Netplay</string>
     </property>
-    <addaction name="action_Netplay_CreateSession"/>
     <addaction name="action_Netplay_BrowseSessions"/>
-    <addaction name="separator"/>
-    <addaction name="action_Netplay_ViewSession"/>
    </widget>
    <addaction name="menuSystem"/>
    <addaction name="menuSettings"/>
@@ -611,28 +608,12 @@
     <string>&amp;Check For Updates</string>
    </property>
   </action>
-  <action name="action_Netplay_CreateSession">
-   <property name="icon">
-    <iconset theme="server-line"/>
-   </property>
-   <property name="text">
-    <string>&amp;Create Session</string>
-   </property>
-  </action>
   <action name="action_Netplay_BrowseSessions">
    <property name="icon">
     <iconset theme="plug-line"/>
    </property>
    <property name="text">
-    <string>Browse Sessions</string>
-   </property>
-  </action>
-  <action name="action_Netplay_ViewSession">
-   <property name="icon">
-    <iconset theme="server-line"/>
-   </property>
-   <property name="text">
-    <string>View Session</string>
+    <string>Start Netplay</string>
    </property>
   </action>
   <action name="action_View_Search">


### PR DESCRIPTION
This implementation moves netplay sync from plugin level to PIF RAM level, ensuring compatibility with all input plugins including raphnet.

Key changes:
- Added PIF sync callback system (pif_sync_callback.c/h)
- Implemented Kaillera API integration (Kaillera.cpp/hpp)
- Added controller detection emulation for remote players
- Removed obsolete plugin-level sync code from RMG-Input
- Added Kaillera session manager UI components

Technical details:
- Synchronization happens at update_pif_ram() after plugin processing
- Intercepts JCMD_STATUS/JCMD_RESET to force remote controllers as "present"
- Each player reads local controller from channel 0
- Synced inputs written to all channels (Player N → channel N-1)
- Works with raphnet, RMG-Input, and other input plugins

Fixes controller detection and input desync issues in Kaillera netplay.