### PR TITLE
Fix Kaillera duplicate input and add deterministic settings

### DIFF
--- a/Source/RMG-Core/Kaillera.cpp
+++ b/Source/RMG-Core/Kaillera.cpp
@@ -399,3 +399,22 @@ CORE_EXPORT int CoreGetKailleraNumPlayers(void)
 {
     return s_NumPlayers;
 }
+
+CORE_EXPORT int CoreGetKailleraFrameDelay(void)
+{
+    if (!s_Initialized || !s_GameActive)
+    {
+        return 0;
+    }
+
+    typedef int (WINAPI *kailleraGetFrameDelay_t)();
+    kailleraGetFrameDelay_t kailleraGetFrameDelay =
+        (kailleraGetFrameDelay_t)GetProcAddress(s_KailleraDLL, "kailleraGetFrameDelay");
+
+    if (kailleraGetFrameDelay)
+    {
+        return kailleraGetFrameDelay();
+    }
+
+    return 0; // Fallback if function not available
+}

--- a/Source/RMG-Core/Kaillera.hpp
+++ b/Source/RMG-Core/Kaillera.hpp
@@ -77,7 +77,11 @@ CORE_EXPORT void CoreSetKailleraPlayerNumber(int playerNumber);
 CORE_EXPORT int CoreGetKailleraPlayerNumber(void);
 
 // Get the total number of players in the current Kaillera game
-// Returns 0 if not in a game, otherwise 1-4
+// Returns 0 if not in a game, otherwise 1-8
 CORE_EXPORT int CoreGetKailleraNumPlayers(void);
+
+// Get the frame delay assigned by the Kaillera server
+// Returns the number of frames to buffer inputs (0 if not in game)
+CORE_EXPORT int CoreGetKailleraFrameDelay(void);
 
 #endif // CORE_KAILLERA_HPP


### PR DESCRIPTION
- Fix duplicate input issue by only syncing on JCMD_CONTROLLER_READ commands, not on JCMD_STATUS or other PIF polling
- Add s_SyncedThisFrame flag to ensure exactly one Kaillera sync per frame, reset in FrameCallback
- Cache synced inputs to handle multiple PIF polls within same frame
- Add apply_kaillera_deterministic_settings() to force:
  - Pure Interpreter CPU (prevents desync from dynamic recompiler)
  - Static Interpreter RSP (mupen64plus-rsp-cxd4 for determinism)
  - Disabled random interrupt timing
- Add CoreGetKailleraFrameDelay() API function

