### PR TITLE
Keep Kaillera connection alive for game restart after drops

### DIFF
--- a/Source/RMG-Core/Emulation.cpp
+++ b/Source/RMG-Core/Emulation.cpp
@@ -133,7 +133,8 @@ static void KailleraPifSyncCallback(struct pif* pif)
         int ret = CoreModifyKailleraPlayValues(sync_buffer, sizeof(uint32_t));
 
         if (ret <= 0) {
-            // Network error - cache zeros to avoid garbage data
+            // Game ended or network error - cache zeros and continue
+            // Don't stop emulation - let user click Start to restart or manually stop
             s_CachedNumReceived = 0;
             for (int i = 0; i < MAX_PLAYERS; i++) {
                 s_CachedSyncBuffer[i] = 0;
@@ -522,8 +523,8 @@ CORE_EXPORT bool CoreStartEmulation(std::filesystem::path n64rom, std::filesyste
         // Check if we used Kaillera or legacy netplay
         if (address == "KAILLERA")
         {
-            CoreEndKailleraGame();
-            CoreShutdownKaillera();
+            // Don't shutdown Kaillera here - keep connection alive for restart
+            // Kaillera will be shutdown when user leaves the server dialog
         }
         else
         {

--- a/Source/RMG-Core/Kaillera.cpp
+++ b/Source/RMG-Core/Kaillera.cpp
@@ -75,16 +75,19 @@ static int WINAPI GameCallbackBridge(char *game, int player, int numplayers)
     s_PlayerNumber = player;
     s_NumPlayers = numplayers;
 
+    // Set game active BEFORE callback so emulation thread sees it immediately
+    s_GameActive = true;
+
     if (s_GameStartCallback)
     {
         try
         {
             s_GameStartCallback(std::string(game), player, numplayers);
-            s_GameActive = true;
             return 0; // Success
         }
         catch (...)
         {
+            s_GameActive = false;
             return -1; // Error
         }
     }

--- a/Source/RMG/UserInterface/KailleraSessionManager.cpp
+++ b/Source/RMG/UserInterface/KailleraSessionManager.cpp
@@ -158,13 +158,32 @@ void KailleraSessionManager::handlePlayerDropped(QString nick, int playerNum)
 {
     emit playerDropped(nick, playerNum);
 
-    // If we're the one who dropped, end the game
+    if (!m_gameActive)
+    {
+        return;
+    }
+
+    // Player 1 (host) dropping ends the game for everyone
+    if (playerNum == 1)
+    {
+        m_gameActive = false;
+        emit gameEnded();
+        return;
+    }
+
+    // Players 2-4 dropping only ends the game for themselves
+    // If it's the local player who dropped, end our game
     if (playerNum == m_playerNumber)
     {
         m_gameActive = false;
-        m_currentGame.clear();
-        m_playerNumber = -1;
-        m_totalPlayers = 0;
         emit gameEnded();
+        return;
+    }
+
+    // Remote non-host player dropped - game continues without them
+    // Just update total players count
+    if (m_totalPlayers > 1)
+    {
+        m_totalPlayers--;
     }
 }


### PR DESCRIPTION
- Don't shutdown Kaillera after emulation ends, keep connection alive
- This allows players to restart games after dropping without reconnecting to the server
- Kaillera cleanup now only happens when leaving the server dialog