### PR TITLE
Fix Kaillera game list handling and ROM name matching

### DIFF
--- a/Source/RMG-Core/Kaillera.cpp
+++ b/Source/RMG-Core/Kaillera.cpp
@@ -355,7 +355,7 @@ CORE_EXPORT void CoreSetKailleraCallbacks(
             delete[] gameListBuf;
         }
         gameListBuf = new char[s_GameList.length() + 1];
-        strcpy(gameListBuf, s_GameList.c_str());
+        memcpy(gameListBuf, s_GameList.c_str(), s_GameList.length() + 1);
         infos.gameList = gameListBuf;
 
         // Set callbacks


### PR DESCRIPTION
- Use memcpy instead of strcpy to preserve null bytes in game list
- Strip "(unknown rom)" suffix from game names for Kaillera compatibility
- Improve ROM name matching with case-insensitive and normalized comparisons
- Fix game list encoding to properly handle embedded nulls