### PR TITLE
Change Kaillera app name to RMG-K, remove extra v

### DIFF
--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -2083,7 +2083,7 @@ void MainWindow::on_Action_Netplay_BrowseSessions(void)
     }
 
     // Set Kaillera app info (app name and game list)
-    std::string appName = "RMG v" + CoreGetVersion();
+    std::string appName = "RMG-K " + CoreGetVersion();
     // Build game list from ROM browser (null-terminated strings with double-null at end)
     // Must use std::string directly to preserve embedded null characters
     std::string gameList;


### PR DESCRIPTION
Currently, app name is still branded as just RMG, and there's an extra 'v' preceding the version:
<img width="135" height="49" alt="Latest RMG-K release" src="https://github.com/user-attachments/assets/206f2ba5-2674-4de0-b23f-24c4b1de4c07" />

PR changes this to RMG-K to follow earlier rebranding and removes the 'v'
(version shown as git hash below, but release versions should look right too)
<img width="135" height="49" alt="RMG-K from PR action workflow" src="https://github.com/user-attachments/assets/d4a1b9b3-95c3-4b51-824f-1d5f27ac885f" />