### PR TITLE
Add auto-start netplay on startup setting

### DIFF
--- a/Source/RMG-Core/Settings.cpp
+++ b/Source/RMG-Core/Settings.cpp
@@ -136,6 +136,9 @@ static l_Setting get_setting(SettingsID settingId)
     case SettingsID::GUI_OnScreenDisplayDuration:
         setting = {SETTING_SECTION_GUI, "OnScreenDisplayDuration", 3};
         break;
+    case SettingsID::GUI_AutoStartNetplayOnStartup:
+        setting = {SETTING_SECTION_GUI, "AutoStartNetplayOnStartup", false};
+        break;
     case SettingsID::GUI_Toolbar:
         setting = {SETTING_SECTION_GUI, "Toolbar", true};
         break;

--- a/Source/RMG-Core/Settings.hpp
+++ b/Source/RMG-Core/Settings.hpp
@@ -32,6 +32,7 @@ enum class SettingsID
     GUI_OnScreenDisplayBackgroundColor,
     GUI_OnScreenDisplayTextColor,
     GUI_OnScreenDisplayDuration,
+    GUI_AutoStartNetplayOnStartup,
     GUI_Toolbar,
     GUI_ToolbarArea,
     GUI_StatusBar,

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -124,6 +124,10 @@ SettingsDialog::SettingsDialog(QWidget *parent, QString file) : QDialog(parent)
 #ifndef UPDATER
     this->checkForUpdatesCheckBox->setHidden(true);
 #endif // !UPDATER
+
+#ifndef NETPLAY
+    this->autoStartNetplayOnStartupCheckBox->setHidden(true);
+#endif // !NETPLAY
 }
 
 SettingsDialog::~SettingsDialog(void)
@@ -460,6 +464,7 @@ void SettingsDialog::loadInterfaceGeneralSettings(void)
     // select currently chosen theme in UI
     this->themeComboBox->setCurrentText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::GUI_Theme)));
     this->iconThemeComboBox->setCurrentText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::GUI_IconTheme)));
+    this->autoStartNetplayOnStartupCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::GUI_AutoStartNetplayOnStartup));
 #ifdef UPDATER
     this->checkForUpdatesCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::GUI_CheckForUpdates));
 #endif // UPDATER
@@ -624,6 +629,7 @@ void SettingsDialog::loadDefaultInterfaceGeneralSettings(void)
 {
     this->themeComboBox->setCurrentText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::GUI_Theme)));
     this->iconThemeComboBox->setCurrentText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::GUI_IconTheme)));
+    this->autoStartNetplayOnStartupCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::GUI_AutoStartNetplayOnStartup));
 #ifdef UPDATER
     this->checkForUpdatesCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::GUI_CheckForUpdates));
 #endif // UPDATER
@@ -865,6 +871,7 @@ void SettingsDialog::saveInterfaceGeneralSettings(void)
 {
     CoreSettingsSetValue(SettingsID::GUI_Theme, this->themeComboBox->currentText().toStdString());
     CoreSettingsSetValue(SettingsID::GUI_IconTheme, this->iconThemeComboBox->currentText().toStdString());
+    CoreSettingsSetValue(SettingsID::GUI_AutoStartNetplayOnStartup, this->autoStartNetplayOnStartupCheckBox->isChecked());
 #ifdef UPDATER
     CoreSettingsSetValue(SettingsID::GUI_CheckForUpdates, this->checkForUpdatesCheckBox->isChecked());
 #endif // UPDATER

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
@@ -124,6 +124,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="autoStartNetplayOnStartupCheckBox">
+                 <property name="text">
+                  <string>Start netplay automatically on application start</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <spacer name="verticalSpacer_6">
                  <property name="orientation">
                   <enum>Qt::Orientation::Vertical</enum>

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -154,6 +154,15 @@ bool MainWindow::Init(QApplication* app, bool showUI, bool launchROM)
         this->addActions();
     }
 
+#ifdef NETPLAY
+    if (showUI && !launchROM && CoreSettingsGetBoolValue(SettingsID::GUI_AutoStartNetplayOnStartup))
+    {
+        QTimer::singleShot(0, this, [this]() {
+            this->on_Action_Netplay_BrowseSessions();
+        });
+    }
+#endif // NETPLAY
+
     return true;
 }
 


### PR DESCRIPTION
Pretty straightforward, adds a setting to automatically launch netplay when booting up the emulator

<img width="450" height="131" alt="image" src="https://github.com/user-attachments/assets/326a3e5e-2ed4-4599-a01b-de074f478a91" />
