### PR TITLE
Delay auto-start netplay until ROM scan completes

### DIFF
--- a/Source/RMG/UserInterface/MainWindow.hpp
+++ b/Source/RMG/UserInterface/MainWindow.hpp
@@ -122,6 +122,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
 #ifdef NETPLAY
     Dialog::NetplaySessionDialog* netplaySessionDialog = nullptr;
     KailleraSessionManager* kailleraSessionManager = nullptr;
+    bool ui_AutoStartNetplayOnStartupPending = false;
 #endif // NETPLAY
 
     void closeEvent(QCloseEvent *) Q_DECL_OVERRIDE;
@@ -168,6 +169,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
 #ifdef NETPLAY
     void showNetplaySessionDialog(QWebSocket* webSocket, QJsonObject json, QString sessionFile);
     QString findRomByName(QString gameName);
+    void tryAutoStartNetplayOnStartup(void);
 #endif // NETPLAY
   protected:
     void timerEvent(QTimerEvent *event) Q_DECL_OVERRIDE;
@@ -227,6 +229,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     void on_Kaillera_ChatReceived(QString nickname, QString message);
     void on_Kaillera_PlayerDropped(QString nickname, int playerNum);
     void on_Kaillera_GameEnded(void);
+    void on_RomBrowser_RomListRefreshFinished(bool canceled);
 #endif
 
     void on_Action_Help_Github(void);

--- a/Source/RMG/UserInterface/Widget/RomBrowser/RomBrowserWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowser/RomBrowserWidget.cpp
@@ -1069,12 +1069,14 @@ void RomBrowserWidget::on_RomBrowserThread_Finished(bool canceled)
     // later on anyways
     if (canceled)
     {
+        emit this->RomListRefreshFinished(true);
         return;
     }
 
     if (this->listViewModel->rowCount() == 0)
     {
         this->stackedWidget->setCurrentWidget(this->emptyWidget);
+        emit this->RomListRefreshFinished(false);
         return;
     }
 
@@ -1084,11 +1086,13 @@ void RomBrowserWidget::on_RomBrowserThread_Finished(bool canceled)
     if (elapsedTime < 300)
     {
         this->startTimer(300 - elapsedTime);
+        emit this->RomListRefreshFinished(false);
         return;
     }
 
     this->stackedWidget->setCurrentWidget(this->currentViewWidget);
     this->searchWidget->setVisible(this->showSearchWidget);
+    emit this->RomListRefreshFinished(false);
 }
 
 void RomBrowserWidget::on_Action_PlayGame(void)

--- a/Source/RMG/UserInterface/Widget/RomBrowser/RomBrowserWidget.hpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowser/RomBrowserWidget.hpp
@@ -169,6 +169,8 @@ class RomBrowserWidget : public QWidget
     void RomInformation(QString file);
 
     void FileDropped(QDropEvent* event);
+
+    void RomListRefreshFinished(bool canceled);
 };
 } // namespace Widget
 } // namespace UserInterface


### PR DESCRIPTION
Adds a RomListRefreshFinished signal and waits to create the netplay window until it fires. Fixes an issue where the netplay window could spawn with an empty ROM list.

A nice stress test is to go to `View -> Clear ROM Cache`, then restart the emulator, which should cause a long ROM scan.