### PR TITLE
Increase maximum overclock factor from 20 to 31

### DIFF
--- a/Source/3rdParty/mupen64plus-core/src/main/main.c
+++ b/Source/3rdParty/mupen64plus-core/src/main/main.c
@@ -1648,8 +1648,8 @@ m64p_error main_run(void)
     if (count_per_op <= 0)
         count_per_op = ROM_SETTINGS.countperop;
 
-    if (count_per_op_denom_pot > 20)
-        count_per_op_denom_pot = 20;
+    if (count_per_op_denom_pot > 31)
+        count_per_op_denom_pot = 31;
 
     si_dma_duration = ConfigGetParamInt(g_CoreConfig, "SiDmaDuration");
     if (si_dma_duration < 0)

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
@@ -2356,7 +2356,7 @@
                     <item>
                      <widget class="QSpinBox" name="gameOverclockingFactorSpinBox">
                       <property name="maximum">
-                       <number>20</number>
+                       <number>31</number>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
Allows higher CPU overclock values for games that struggle to hit 60fps. The previous limit of 20 was arbitrary; 31 is the safe maximum before undefined behavior in the bit shift operation.