### PR TITLE
Fix update checker only working when version number is 6 chars

### DIFF
--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -1436,11 +1436,15 @@ void MainWindow::checkForUpdates(bool silent, bool force)
         return;
     }
 
-    // only check for updates on the stable versions unless forced
+    // only check for updates on stable versions unless forced
     QString currentVersion = QString::fromStdString(CoreGetVersion());
-    if (!force && currentVersion.size() != 6)
+    if (!force)
     {
-        return;
+        static const QRegularExpression stableVersionRegex("^v?\\d+(?:\\.\\d+){0,2}$");
+        if (!stableVersionRegex.match(currentVersion).hasMatch())
+        {
+            return;
+        }
     }
 
     QString dateTimeFormat = "dd-MM-yyyy_hh:mm";


### PR DESCRIPTION
Previously would only check for updates when the current version number was 6 characters, so "v0.8.9" worked, but "v0.8.18" did not. 

New regex matches:
  - v1 / 1
  - v1.2 / 1.2
  - v1.2.3 / 1.2.3

  And does not match:

  - v1.2.3-foo (suffix)
  - v1.2.3rc1 (suffix)
  - v1.2.3.4 (too many segments)