### PR TITLE
Send Kaillera drop on shutdown and host drop

### DIFF
--- a/Source/RMG-Core/Kaillera.cpp
+++ b/Source/RMG-Core/Kaillera.cpp
@@ -328,9 +328,9 @@ CORE_EXPORT bool CoreKailleraSendChat(std::string text)
 
 CORE_EXPORT bool CoreEndKailleraGame(void)
 {
-    if (!s_GameActive)
+    if (!s_Initialized)
     {
-        return true; // No game active
+        return false;
     }
 
     if (kailleraEndGame)

--- a/Source/RMG/UserInterface/KailleraSessionManager.cpp
+++ b/Source/RMG/UserInterface/KailleraSessionManager.cpp
@@ -166,6 +166,10 @@ void KailleraSessionManager::handlePlayerDropped(QString nick, int playerNum)
     // Player 1 (host) dropping ends the game for everyone
     if (playerNum == 1)
     {
+        if (playerNum != m_playerNumber && CoreHasInitKaillera())
+        {
+            CoreEndKailleraGame();
+        }
         m_gameActive = false;
         emit gameEnded();
         return;

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -964,7 +964,7 @@ void MainWindow::updateActions(bool inEmulation, bool isPaused)
     keyBinding = QString::fromStdString(CoreSettingsGetStringValue(SettingsID::KeyBinding_Shutdown));
     this->action_System_Shutdown->setShortcut(QKeySequence(keyBinding));
 #ifdef NETPLAY
-    this->action_System_Shutdown->setEnabled(inEmulation && !CoreHasInitNetplay() && this->kailleraSessionManager == nullptr);
+    this->action_System_Shutdown->setEnabled(inEmulation && !CoreHasInitNetplay());
 #else
     this->action_System_Shutdown->setEnabled(inEmulation && !CoreHasInitNetplay());
 #endif
@@ -1883,6 +1883,18 @@ void MainWindow::on_Action_System_Shutdown(void)
     {
         return;
     }
+
+#ifdef NETPLAY
+    if (this->kailleraSessionManager != nullptr && this->kailleraSessionManager->isGameActive())
+    {
+        this->kailleraSessionManager->endGame();
+        return;
+    }
+    if (CoreHasInitKaillera())
+    {
+        CoreEndKailleraGame();
+    }
+#endif
 
     if (!CoreStopEmulation())
     {


### PR DESCRIPTION
Paired with https://github.com/Jay-Day/n02-rmg/pull/23

Resolves an issue with netplay: when the host dropped, non-host users's emulation would end, but they wouldn't be marked as dropped. If the host attempted to start the game again in this state, it can cause a strange desynced state as the host's emulator starts alone. This is no longer possible, non-hosts will send the dropped message immediately.

These PRs also re-enable the Shutdown button while netplay is open. Shutdown functions as a drop, and allows for closing out of emulation if it ends up in a bad state (e.g. Kaillera thinks game has ended and refuses to drop but emulator is still running)