### PR TITLE
Fallback for missing goodnames

### DIFF
--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -44,6 +44,7 @@
 #include <QStyleFactory>
 #include <QActionGroup> 
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QSettings>
@@ -2317,8 +2318,9 @@ void MainWindow::on_Action_Netplay_BrowseSessions(void)
     std::string gameList;
     QMap<QString, CoreRomSettings> romData = this->ui_Widget_RomBrowser->GetModelData();
 
-    // Collect and sort GoodNames alphabetically for Kaillera
-    // (n02 creates submenus by first letter, so games must be sorted by name)
+    // Collect and sort game names alphabetically for Kaillera.
+    // Fallback to filename when GoodName is empty/invalid to avoid creating
+    // an empty first entry in the null-delimited list.
     std::vector<std::string> goodNames;
     for (auto it = romData.begin(); it != romData.end(); ++it)
     {
@@ -2330,7 +2332,22 @@ void MainWindow::on_Action_Netplay_BrowseSessions(void)
         {
             goodName = goodName.substr(0, goodName.size() - suffix.size());
         }
-        goodNames.push_back(goodName);
+
+        QString displayName = QString::fromStdString(goodName).trimmed();
+        if (displayName.isEmpty())
+        {
+            QFileInfo fileInfo(it.key());
+            displayName = fileInfo.completeBaseName().trimmed();
+            if (displayName.isEmpty())
+            {
+                displayName = fileInfo.fileName().trimmed();
+            }
+        }
+
+        if (!displayName.isEmpty())
+        {
+            goodNames.push_back(displayName.toStdString());
+        }
     }
     std::sort(goodNames.begin(), goodNames.end(), [](const std::string& a, const std::string& b) {
         return QString::fromStdString(a).compare(QString::fromStdString(b), Qt::CaseInsensitive) < 0;


### PR DESCRIPTION
Currently if a single rom is missing a goodname (string in the first few bytes of the rom) the rom list won't be passed to Kaillera correctly, preventing the user from creating games. This fixes that issue and defaults to the filename if goodname is missing.

Before:
<img width="263" height="71" alt="RMG-K_O551LH8zex" src="https://github.com/user-attachments/assets/e9d84b47-94c9-414b-b2e7-cd5e9886eee5" />

After
<img width="254" height="129" alt="RMG-K_xGTa1bVky7" src="https://github.com/user-attachments/assets/c58c7690-7ba8-4068-98db-d9d03b7ecea2" />
