### PR TITLE
Fix toolbar buttons appearing hovered on Windows

### DIFF
--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -136,17 +136,6 @@ public:
             QProxyStyle::drawControl(element, &opt, painter, widget);
             return;
         }
-        // Strip the raised state from toolbar buttons so they appear flat
-        if (element == CE_ToolButtonStyle)
-        {
-            QStyleOptionToolButton opt(*qstyleoption_cast<const QStyleOptionToolButton*>(option));
-            if (!(opt.state & (State_MouseOver | State_Sunken)))
-            {
-                opt.state &= ~State_Raised;
-            }
-            QProxyStyle::drawControl(element, &opt, painter, widget);
-            return;
-        }
         QProxyStyle::drawControl(element, option, painter, widget);
     }
 };

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -648,10 +648,7 @@ void MainWindow::configureTheme(QApplication* app)
     QString fallbackThemeName = defaultFallbackThemeName;
 
     // set theme style
-    QString fallbackStyleSheet = "QTableView { border: none; color: #0096d3; selection-color: #FFFFFF; selection-background-color: #0096d3; }"
-                                 " QToolBar QToolButton { border: none; background: transparent; padding: 4px; }"
-                                 " QToolBar QToolButton:hover { background: rgba(128, 128, 128, 40); border-radius: 4px; }"
-                                 " QToolBar QToolButton:pressed { background: rgba(128, 128, 128, 80); border-radius: 4px; }";
+    QString fallbackStyleSheet = "QTableView { border: none; color: #0096d3; selection-color: #FFFFFF; selection-background-color: #0096d3; }";
     this->setStyleSheet(fallbackStyleSheet);
 
     app->setStyleSheet(defaultStyleSheet);
@@ -670,6 +667,13 @@ void MainWindow::configureTheme(QApplication* app)
             app->setStyle(style);
         }
         app->setPalette(defaultPalette);
+
+        // Flatten toolbar buttons on the native Windows style to avoid
+        // them appearing permanently hovered/bordered in some builds
+        this->setStyleSheet(this->styleSheet() +
+            " QToolBar QToolButton { border: none; background: transparent; }"
+            " QToolBar QToolButton:hover { background: rgba(128, 128, 128, 40); border-radius: 4px; }"
+            " QToolBar QToolButton:pressed { background: rgba(128, 128, 128, 80); border-radius: 4px; }");
     }
 #ifdef _WIN32
     else if (theme == "Windows Vista")

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -114,6 +114,14 @@ public:
         {
             return;
         }
+        // Suppress the raised panel/border on toolbar buttons when not hovered/pressed
+        if (element == PE_PanelButtonTool)
+        {
+            if (!(option->state & (State_MouseOver | State_Sunken)))
+            {
+                return;
+            }
+        }
         QProxyStyle::drawPrimitive(element, option, painter, widget);
     }
 
@@ -125,6 +133,17 @@ public:
             // Strip focus only — keep Selected so text color changes correctly
             QStyleOptionViewItem opt(*qstyleoption_cast<const QStyleOptionViewItem*>(option));
             opt.state &= ~State_HasFocus;
+            QProxyStyle::drawControl(element, &opt, painter, widget);
+            return;
+        }
+        // Strip the raised state from toolbar buttons so they appear flat
+        if (element == CE_ToolButtonStyle)
+        {
+            QStyleOptionToolButton opt(*qstyleoption_cast<const QStyleOptionToolButton*>(option));
+            if (!(opt.state & (State_MouseOver | State_Sunken)))
+            {
+                opt.state &= ~State_Raised;
+            }
             QProxyStyle::drawControl(element, &opt, painter, widget);
             return;
         }
@@ -669,18 +688,6 @@ void MainWindow::configureTheme(QApplication* app)
         app->setPalette(defaultPalette);
     }
 
-    if (theme == "Modern")
-    {
-        // Flatten toolbar buttons to avoid them appearing permanently
-        // hovered/bordered on some Windows Qt style backends
-        bool isDark = app->palette().window().color().value() < 128;
-        QString hoverBg = isDark ? "rgba(255, 255, 255, 30)" : "rgba(0, 0, 0, 20)";
-        QString pressBg = isDark ? "rgba(255, 255, 255, 60)" : "rgba(0, 0, 0, 40)";
-        this->setStyleSheet(this->styleSheet() +
-            " QToolBar QToolButton { border: none; background: transparent; border-radius: 4px; }"
-            " QToolBar QToolButton:hover { background: " + hoverBg + "; }"
-            " QToolBar QToolButton:pressed { background: " + pressBg + "; }");
-    }
 #ifdef _WIN32
     else if (theme == "Windows Vista")
     {

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -648,7 +648,10 @@ void MainWindow::configureTheme(QApplication* app)
     QString fallbackThemeName = defaultFallbackThemeName;
 
     // set theme style
-    QString fallbackStyleSheet = "QTableView { border: none; color: #0096d3; selection-color: #FFFFFF; selection-background-color: #0096d3; }";
+    QString fallbackStyleSheet = "QTableView { border: none; color: #0096d3; selection-color: #FFFFFF; selection-background-color: #0096d3; }"
+                                 " QToolBar QToolButton { border: none; background: transparent; padding: 4px; }"
+                                 " QToolBar QToolButton:hover { background: rgba(128, 128, 128, 40); border-radius: 4px; }"
+                                 " QToolBar QToolButton:pressed { background: rgba(128, 128, 128, 80); border-radius: 4px; }";
     this->setStyleSheet(fallbackStyleSheet);
 
     app->setStyleSheet(defaultStyleSheet);

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -667,13 +667,19 @@ void MainWindow::configureTheme(QApplication* app)
             app->setStyle(style);
         }
         app->setPalette(defaultPalette);
+    }
 
-        // Flatten toolbar buttons on the native Windows style to avoid
-        // them appearing permanently hovered/bordered in some builds
+    if (theme == "Modern")
+    {
+        // Flatten toolbar buttons to avoid them appearing permanently
+        // hovered/bordered on some Windows Qt style backends
+        bool isDark = app->palette().window().color().value() < 128;
+        QString hoverBg = isDark ? "rgba(255, 255, 255, 30)" : "rgba(0, 0, 0, 20)";
+        QString pressBg = isDark ? "rgba(255, 255, 255, 60)" : "rgba(0, 0, 0, 40)";
         this->setStyleSheet(this->styleSheet() +
-            " QToolBar QToolButton { border: none; background: transparent; }"
-            " QToolBar QToolButton:hover { background: rgba(128, 128, 128, 40); border-radius: 4px; }"
-            " QToolBar QToolButton:pressed { background: rgba(128, 128, 128, 80); border-radius: 4px; }");
+            " QToolBar QToolButton { border: none; background: transparent; border-radius: 4px; }"
+            " QToolBar QToolButton:hover { background: " + hoverBg + "; }"
+            " QToolBar QToolButton:pressed { background: " + pressBg + "; }");
     }
 #ifdef _WIN32
     else if (theme == "Windows Vista")


### PR DESCRIPTION
Force toolbar buttons to be flat with no border/background by default via stylesheet, with subtle hover and press effects. Fixes inconsistent appearance between debug and release builds on Windows where the native style renders toolbar buttons with visible borders.