### PR TITLE
raphnetraw: don't warn on PIF polling unmapped slots

### DIFF
--- a/Source/3rdParty/mupen64plus-input-raphnetraw/src/plugin_back.c
+++ b/Source/3rdParty/mupen64plus-input-raphnetraw/src/plugin_back.c
@@ -404,8 +404,17 @@ static int pb_performIo(void)
 
 static int pb_commandIsValid(int Control, unsigned char *Command)
 {
-	if (Control < 0 || Control >= g_n_channels) {
+	// A negative Control is genuinely malformed and worth flagging.
+	if (Control < 0) {
 		DebugMessage(PB_MSG_WARNING, "pb_readController called with Control=%d", Control);
+		return 0;
+	}
+
+	// Control >= g_n_channels means the PIF is polling a slot beyond what
+	// this adapter has channels for. InitiateControllers already declared
+	// those slots Present=0, so the poll happening is expected hardware
+	// behavior (N64 PIF polls all 4 slots every frame) — not an error.
+	if (Control >= g_n_channels) {
 		return 0;
 	}
 


### PR DESCRIPTION
InitiateControllers already sets Present=0 for slots beyond the adapter's channel count, so the per-frame PIF poll of those slots is expected hardware behavior, not an error. Skip the warning for the Control >= g_n_channels case (negative Control and NULL Command still warn — those are genuinely bad).

Fixes ~180 lines/sec of "pb_readController called with Control=N" spam introduced when the GetKeys polling path was wired up.