### PR TITLE
Record per-frame inputs from the P2P rollback path

### DIFF
--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -21,6 +21,10 @@
 #endif
 #endif
 
+// Recording hooks live in n02. The rollback flow needs to append per-frame
+// synced inputs to the open .krec because it bypasses n02's normal frame loop.
+#include "n02_client.h"
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -564,6 +568,14 @@ bool latch_gekko_input(const GekkoGameEvent* event)
                 &debugInputs[static_cast<size_t>(player)],
                 std::min(g_GekkoInputSize, static_cast<int>(sizeof(uint32_t))));
         }
+    }
+
+    // Mirror the per-frame input record that modifyPlayValues normally writes
+    // for non-rollback Kaillera/P2P play. Only commit on settled frames —
+    // rolled-back / run-ahead frames are speculative and would double-record.
+    if (!event->data.adv.rolling_back && !event->data.adv.running_ahead)
+    {
+        n02::recordingWriteInputs(g_GekkoLatchedInput.data(), static_cast<int>(g_GekkoLatchedInput.size()));
     }
 
     if (g_GekkoLogEnabled &&

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -23,7 +23,9 @@
 
 // Recording hooks live in n02. The rollback flow needs to append per-frame
 // synced inputs to the open .krec because it bypasses n02's normal frame loop.
+#ifdef RMGK_HAVE_P2P_TRANSPORT
 #include "n02_client.h"
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -573,10 +575,12 @@ bool latch_gekko_input(const GekkoGameEvent* event)
     // Mirror the per-frame input record that modifyPlayValues normally writes
     // for non-rollback Kaillera/P2P play. Only commit on settled frames —
     // rolled-back / run-ahead frames are speculative and would double-record.
+#ifdef RMGK_HAVE_P2P_TRANSPORT
     if (!event->data.adv.rolling_back && !event->data.adv.running_ahead)
     {
         n02::recordingWriteInputs(g_GekkoLatchedInput.data(), static_cast<int>(g_GekkoLatchedInput.size()));
     }
+#endif
 
     if (g_GekkoLogEnabled &&
         (g_GekkoLogFrames < kGekkoMaxLoggedFrames || g_GekkoLatchedInput != g_GekkoLastLatchedInput))

--- a/Source/n02/n02_client.cpp
+++ b/Source/n02/n02_client.cpp
@@ -781,6 +781,17 @@ int modifyPlayValues(void *values, int size) {
     return -1;
 }
 
+void recordingWriteInputs(const void* values, int size) {
+    if (!recording_file.is_open() || values == nullptr || size <= 0) {
+        return;
+    }
+    const short siz = (size > 0x7FFF) ? 0x7FFF : (short)size;
+    RecordingBuffer.put_char(0x12);
+    RecordingBuffer.put_short(siz);
+    RecordingBuffer.put_bytes((char*)values, siz);
+    RecordingBuffer.write();
+}
+
 void chatSend(char *text) {
     if (active_mod.ChatSend)
         active_mod.ChatSend(text);

--- a/Source/n02/n02_client.h
+++ b/Source/n02/n02_client.h
@@ -35,6 +35,13 @@ void selectServerDialog(void* parent);
 // Returns: number of bytes of synced data, 0 during delay frames, -1 on error
 int modifyPlayValues(void *values, int size);
 
+// Append a synchronized-inputs record (0x12 marker + size + bytes) to the
+// open recording. Mirrors what modifyPlayValues writes for normal play,
+// but is callable from outside n02's frame loop — the P2P rollback path
+// uses GekkoNet for input sync so it never reaches modifyPlayValues.
+// No-op if no recording is open.
+void recordingWriteInputs(const void* values, int size);
+
 // Send chat message to other players
 void chatSend(char *text);
 


### PR DESCRIPTION
P2P rollback wrote the 400-byte krec header but never any frame data — modifyPlayValues (Kaillera's per-frame sync point + recording write) is bypassed entirely, because rollback handles input sync through GekkoNet. Recent rollback recordings are exactly 400 bytes, just the header.

Add a small n02 API — recordingWriteInputs — that appends the same 0x12 + size + bytes record modifyPlayValues writes for non-rollback play. Call it from latch_gekko_input, where GekkoNet has just produced the post-sync inputs for the frame. Gate on !rolling_back && !running_ahead so speculative re-runs don't double-record; this gives the same 1:1 frame-to-record ratio as Kaillera, with byte-identical record format, so the existing playback code handles either source.

The lobby flow is unaffected — it doesn't initialize n02 so the recording file is never open, and the new function silently no-ops.