### PR TITLE
Fix AMD h264_amf probe failing on undersized test frame

### DIFF
--- a/Source/RMG/Utilities/KailleraExport/FfmpegEncoder.cpp
+++ b/Source/RMG/Utilities/KailleraExport/FfmpegEncoder.cpp
@@ -126,14 +126,21 @@ static bool runCommandWithCapturedOutput(const std::string& command,
 
 static bool probeVideoEncoder(const std::string& ffmpegPath, const char* codec)
 {
+    // AMD AMF requires at least 128x96 to initialize; 64x64 silently fails on
+    // AMD systems even when the driver is fine. 320x240 clears all known
+    // hardware-encoder minimums (NVENC, QSV, AMF). yuv420p is forced because
+    // the real export pipeline converts to it and some hardware encoders
+    // refuse lavfi's default surface format. The 10s timeout covers AMF's
+    // cold-init latency on first launch.
     char command[512];
     snprintf(command,
              sizeof(command),
-             "\"%s\" -v error -f lavfi -i color=black:s=64x64:d=0.1 -frames:v 1 -c:v %s -f null -",
+             "\"%s\" -v error -f lavfi -i color=black:s=320x240:r=30:d=0.1 -frames:v 1 "
+             "-pix_fmt yuv420p -c:v %s -f null -",
              ffmpegPath.c_str(),
              codec);
 
-    return runCommandWithCapturedOutput(command, 5000, false, nullptr);
+    return runCommandWithCapturedOutput(command, 10000, false, nullptr);
 }
 
 static std::string chooseVideoEncoder(const std::string& ffmpegPath, bool* hardwareAccelerated)


### PR DESCRIPTION
h264_amf was already in the candidate list, but the 64x64 test frame sits below AMF's documented 128x96 minimum encode resolution, so the probe failed on AMD systems even with a healthy driver and the chooser fell back to libx264. Bump the probe to 320x240, force yuv420p to match the real export pipeline, and raise the timeout to cover AMF cold-init.