### PR TITLE
Sample GekkoNet frames_ahead every 30 frames instead of per-frame

### DIFF
--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -52,6 +52,12 @@ constexpr double kGekkoTimesyncStrength = 0.002;
 constexpr double kGekkoTimesyncMinScale = 0.99;
 constexpr double kGekkoTimesyncMaxScale = 1.01;
 constexpr double kGekkoTimesyncLerp = 0.15;
+// Sample gekko_frames_ahead() this often when recomputing the target
+// emulation speed. Mirrors Slippi's SLIPPI_ONLINE_LOCKSTEP_INTERVAL (30
+// frames @ 60Hz = once per ~500ms) — single-frame jitter spikes no
+// longer kick the speed scale around; the lerp keeps speed_scale
+// converging toward the cached target on every frame in between.
+constexpr int kGekkoTimesyncIntervalFrames = 30;
 constexpr size_t kGekkoClientReplayFrames = 600;
 
 #ifdef RMGK_HAVE_GEKKONET
@@ -98,6 +104,11 @@ int g_GekkoWaitingLoops = 0;
 int g_GekkoLocalInputLogRepeats = 0;
 int g_GekkoPacingLogFrames = 0;
 double g_GekkoSpeedScale = 1.0;
+// Timesync sample state. Counter wraps every kGekkoTimesyncIntervalFrames
+// to trigger a fresh frames_ahead sample. TargetScale is what g_GekkoSpeedScale
+// lerps toward between samples.
+int g_GekkoTimesyncSampleCounter = 0;
+double g_GekkoTimesyncTargetScale = 1.0;
 bool g_GekkoLogEnabled = false;
 std::mutex g_GekkoClientReplayMutex;
 ClientInputReplayMode g_GekkoClientReplayMode = ClientInputReplayMode::Off;
@@ -145,6 +156,8 @@ void reset_gekko_log()
         g_GekkoLocalInputLogRepeats = 0;
         g_GekkoPacingLogFrames = 0;
         g_GekkoSpeedScale = 1.0;
+        g_GekkoTimesyncSampleCounter = 0;
+        g_GekkoTimesyncTargetScale = 1.0;
         g_GekkoLastLoadStateUs = 0;
         g_GekkoLastSaveStateUs = 0;
         g_GekkoLastRunFrameUs = 0;
@@ -163,6 +176,8 @@ void reset_gekko_log()
     g_GekkoLocalInputLogRepeats = 0;
     g_GekkoPacingLogFrames = 0;
     g_GekkoSpeedScale = 1.0;
+    g_GekkoTimesyncSampleCounter = 0;
+    g_GekkoTimesyncTargetScale = 1.0;
     g_GekkoLastLoadStateUs = 0;
     g_GekkoLastSaveStateUs = 0;
     g_GekkoLastRunFrameUs = 0;
@@ -660,24 +675,36 @@ bool process_pending_saves()
 
 void apply_gekko_frame_pacing()
 {
+    // Read frames_ahead every call (cheap, just a member access in
+    // GekkoSession) but only recompute the target scale once per
+    // sampling interval. The per-frame lerp below carries the speed scale
+    // toward the cached target between samples.
     const float framesAhead = gekko_frames_ahead(g_GekkoSession);
-    double targetScale = 1.0;
-    if (framesAhead >= kGekkoTimesyncDeadzone || framesAhead <= -kGekkoTimesyncDeadzone)
+    const bool isSampleFrame =
+        (g_GekkoTimesyncSampleCounter % kGekkoTimesyncIntervalFrames) == 0;
+    if (isSampleFrame)
     {
-        targetScale = 1.0 - (static_cast<double>(framesAhead) * kGekkoTimesyncStrength);
-        targetScale = std::clamp(targetScale, kGekkoTimesyncMinScale, kGekkoTimesyncMaxScale);
+        double newTarget = 1.0;
+        if (framesAhead >= kGekkoTimesyncDeadzone || framesAhead <= -kGekkoTimesyncDeadzone)
+        {
+            newTarget = 1.0 - (static_cast<double>(framesAhead) * kGekkoTimesyncStrength);
+            newTarget = std::clamp(newTarget, kGekkoTimesyncMinScale, kGekkoTimesyncMaxScale);
+        }
+        g_GekkoTimesyncTargetScale = newTarget;
     }
+    g_GekkoTimesyncSampleCounter++;
 
-    g_GekkoSpeedScale += (targetScale - g_GekkoSpeedScale) * kGekkoTimesyncLerp;
+    g_GekkoSpeedScale += (g_GekkoTimesyncTargetScale - g_GekkoSpeedScale) * kGekkoTimesyncLerp;
     CoreRollbackSetTimesyncScale(g_GekkoSpeedScale);
 
     g_GekkoPacingLogFrames++;
     if (g_GekkoLogEnabled &&
-        (targetScale != 1.0 || g_GekkoPacingLogFrames <= 10 || (g_GekkoPacingLogFrames % 60) == 0))
+        (g_GekkoTimesyncTargetScale != 1.0 || g_GekkoPacingLogFrames <= 10 || (g_GekkoPacingLogFrames % 60) == 0))
     {
         std::ostringstream stream;
         stream << "pacing frames_ahead=" << std::fixed << std::setprecision(2) << framesAhead
-               << " target_scale=" << std::setprecision(4) << targetScale
+               << " sample=" << (isSampleFrame ? 1 : 0)
+               << " target_scale=" << std::setprecision(4) << g_GekkoTimesyncTargetScale
                << " speed_scale=" << g_GekkoSpeedScale;
 
         if (g_GekkoRemoteHandle >= 0)
@@ -1434,6 +1461,8 @@ CORE_EXPORT void rmgk_gekko::close_session()
         g_GekkoClientReplayIndex = 0;
     }
     g_GekkoSpeedScale = 1.0;
+    g_GekkoTimesyncSampleCounter = 0;
+    g_GekkoTimesyncTargetScale = 1.0;
     CoreRollbackSetTimesyncScale(1.0);
 #ifdef RMGK_HAVE_P2P_TRANSPORT
     g_GekkoP2PRemoteAddress.clear();


### PR DESCRIPTION
apply_gekko_frame_pacing() previously read gekko_frames_ahead() on every emulation frame, which let single-frame jitter spikes (one peer's GPU stutter, one delayed packet) kick the timesync speed scale around. Move the target-scale recomputation behind a fixed sampling cadence (kGekkoTimesyncIntervalFrames = 30, mirroring Slippi's SLIPPI_ONLINE_LOCKSTEP_INTERVAL) and keep the existing 0.15 lerp running every frame so the live speed scale still converges smoothly toward the cached target between samples.

Tuning constants (deadzone, strength, clamp range, lerp rate) unchanged. This is purely a cadence shift - drift caused by short jitter bursts is now averaged out, while sustained drift over a ~500ms window still gets corrected at the same rate as before. Pacing log lines now carry a sample= flag so the cadence is visible during playback.