### PR TITLE
0.9.6 RC - hotfixes

### DIFF
--- a/Source/RMG-Core/Emulation.cpp
+++ b/Source/RMG-Core/Emulation.cpp
@@ -209,13 +209,18 @@ static void KailleraPifSyncCallback(struct pif* pif)
         int ret = CoreModifyKailleraPlayValues(sync_buffer, sizeof(uint32_t));
 
         if (ret < 0) {
-            // Game ended or network error - cache zeros and continue
-            // Don't stop emulation - let user manually stop
-            // Mark game as inactive so UI buttons are re-enabled
+            // Game ended or network error. For live netplay we keep emulation
+            // running so the user can manually exit; for krec playback there
+            // are no more inputs to feed, so stop emulation here (the dialog
+            // timer would otherwise only catch this while the dialog is open).
+            const bool wasPlayback = CoreIsKailleraPlaybackMode();
             CoreMarkKailleraGameInactive();
             s_CachedNumReceived = 0;
             for (int i = 0; i < MAX_PLAYERS; i++) {
                 s_CachedSyncBuffer[i] = 0;
+            }
+            if (wasPlayback) {
+                CoreStopEmulation();
             }
             return;
         }

--- a/Source/RMG-Core/Kaillera.cpp
+++ b/Source/RMG-Core/Kaillera.cpp
@@ -66,7 +66,7 @@ static std::filesystem::path getKailleraRecordsDirectoryPath()
     return pathFromUtf8String(recordsDirectory);
 }
 
-static uint64_t computeDirectorySizeBytes(const std::filesystem::path& directory)
+static uint64_t computeKrecDirectorySizeBytes(const std::filesystem::path& directory)
 {
     std::error_code ec;
     if (!std::filesystem::exists(directory, ec))
@@ -82,7 +82,8 @@ static uint64_t computeDirectorySizeBytes(const std::filesystem::path& directory
     while (!ec && it != end)
     {
         const auto& entry = *it;
-        if (entry.is_regular_file(ec))
+        // Only count .krec files — the cap manages recordings, not exported MP4s or other files.
+        if (entry.is_regular_file(ec) && entry.path().extension() == ".krec")
         {
             uintmax_t fileSize = entry.file_size(ec);
             if (!ec)
@@ -417,7 +418,7 @@ CORE_EXPORT bool CoreRefreshKailleraRecordingStorageStatus(void)
         return false;
     }
 
-    s_RecordingStorageBytes = computeDirectorySizeBytes(getKailleraRecordsDirectoryPath());
+    s_RecordingStorageBytes = computeKrecDirectorySizeBytes(getKailleraRecordsDirectoryPath());
     s_RecordingStorageStatusInitialized = true;
 
     int capMB = CoreSettingsGetIntValue(SettingsID::Kaillera_RecordingCapMB);

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -89,10 +89,16 @@ std::vector<int> g_GekkoPlayerHandles;
 std::vector<int> g_GekkoLocalHandles;
 std::vector<unsigned char> g_GekkoLatchedInput;
 bool g_GekkoHasLatchedInput = false;
-// Per-frame input buffer for rollback-aware krec recording. Buffered until
-// each frame ages past the rollback window so that rolling-back re-sims can
-// overwrite the initial speculative entry with the corrected input before
-// it gets committed to the .krec file.
+// Frame number / flags associated with the most recent latch_gekko_input
+// call. Used by synchronize_input to push the right key into the recording
+// buffer once a PIF controller-read actually consumes the latched input.
+int g_GekkoLatchedFrame = -1;
+bool g_GekkoLatchedRunningAhead = false;
+// Per-frame input buffer for rollback-aware krec recording. Pushed by
+// synchronize_input (i.e. only when the game actually polled the controller
+// that frame) and held until each frame ages past the rollback window, so
+// rolling-back re-sims can overwrite the initial speculative entry with the
+// corrected input before it gets committed to the .krec file.
 std::map<int, std::vector<unsigned char>> g_GekkoFrameInputBuffer;
 int g_GekkoMaxObservedFrame = -1;
 constexpr int kGekkoRecordingRollbackHorizon = 32;
@@ -686,35 +692,15 @@ bool latch_gekko_input(const GekkoGameEvent* event)
         }
     }
 
-    // Mirror the per-frame input record that modifyPlayValues normally writes
-    // for non-rollback Kaillera/P2P play. The initial speculative advance for
-    // frame K can carry predicted inputs that GekkoNet later corrects via a
-    // rolling-back re-sim of frame K. To keep the .krec deterministic, buffer
-    // by frame number (latest write wins) and commit only once the frame ages
-    // past the rollback window. Run-ahead advances are skipped — GekkoNet
-    // resets the sync frame after run-ahead, so those frames are advanced
-    // again later as settled or rolling-back.
-#ifdef RMGK_HAVE_P2P_TRANSPORT
-    if (!event->data.adv.running_ahead)
-    {
-        const int frame = event->data.adv.frame;
-        g_GekkoFrameInputBuffer[frame] = g_GekkoLatchedInput;
-        if (frame > g_GekkoMaxObservedFrame)
-        {
-            g_GekkoMaxObservedFrame = frame;
-        }
-        while (!g_GekkoFrameInputBuffer.empty())
-        {
-            auto it = g_GekkoFrameInputBuffer.begin();
-            if (g_GekkoMaxObservedFrame - it->first <= kGekkoRecordingRollbackHorizon)
-            {
-                break;
-            }
-            n02::recordingWriteInputs(it->second.data(), static_cast<int>(it->second.size()));
-            g_GekkoFrameInputBuffer.erase(it);
-        }
-    }
-#endif
+    // Remember which frame/flags this latched input belongs to so that
+    // synchronize_input — invoked from the rollback PIF callback only when
+    // the game actually issues a JCMD_CONTROLLER_READ that frame — can push
+    // it to the per-frame recording buffer. Pushing here instead would record
+    // one entry per gekko advance regardless of whether the emulator polled
+    // the controller, which drifts against playback (PlaybackBuffer consumes
+    // one entry per PIF poll) and silently desyncs the .krec.
+    g_GekkoLatchedFrame = event->data.adv.frame;
+    g_GekkoLatchedRunningAhead = event->data.adv.running_ahead;
 
     if (g_GekkoLogEnabled &&
         (g_GekkoLogFrames < kGekkoMaxLoggedFrames || g_GekkoLatchedInput != g_GekkoLastLatchedInput))
@@ -1316,6 +1302,8 @@ CORE_EXPORT bool rmgk_gekko::start_p2p_session(const char* gameName, int players
     g_GekkoLocalHandles.assign(static_cast<size_t>(players), -1);
     g_GekkoLatchedInput.assign(static_cast<size_t>(players * inputSize), 0);
     g_GekkoHasLatchedInput = false;
+    g_GekkoLatchedFrame = -1;
+    g_GekkoLatchedRunningAhead = false;
     g_GekkoFrameInputBuffer.clear();
     g_GekkoMaxObservedFrame = -1;
     g_GekkoPendingSaves.clear();
@@ -1463,6 +1451,8 @@ CORE_EXPORT bool rmgk_gekko::start_local_session(const char* gameName, int playe
     g_GekkoLocalHandles.assign(static_cast<size_t>(players), -1);
     g_GekkoLatchedInput.assign(static_cast<size_t>(players * inputSize), 0);
     g_GekkoHasLatchedInput = false;
+    g_GekkoLatchedFrame = -1;
+    g_GekkoLatchedRunningAhead = false;
     g_GekkoFrameInputBuffer.clear();
     g_GekkoMaxObservedFrame = -1;
     g_GekkoPendingSaves.clear();
@@ -1529,6 +1519,8 @@ CORE_EXPORT void rmgk_gekko::close_session()
     g_GekkoLocalHandles.clear();
     g_GekkoLatchedInput.clear();
     g_GekkoHasLatchedInput = false;
+    g_GekkoLatchedFrame = -1;
+    g_GekkoLatchedRunningAhead = false;
 #ifdef RMGK_HAVE_P2P_TRANSPORT
     // Flush any remaining frames still inside the rollback window at teardown.
     for (auto& entry : g_GekkoFrameInputBuffer)
@@ -1637,6 +1629,34 @@ CORE_EXPORT bool rmgk_gekko::synchronize_input(void* values, int size, int playe
 
         std::memset(values, 0, static_cast<size_t>(size) * static_cast<size_t>(players));
         std::memcpy(values, g_GekkoLatchedInput.data(), static_cast<size_t>(expectedBytes));
+
+        // Recording push happens here (not in latch_gekko_input) because this
+        // callback only fires when the emulator actually issued a controller
+        // read this frame — matching what playback consumes. Skipping the
+        // push for frames the game didn't poll keeps the .krec consume/produce
+        // cadences in lockstep and prevents the silent off-by-one drift that
+        // would otherwise compound into a mid-session desync.
+#ifdef RMGK_HAVE_P2P_TRANSPORT
+        if (g_GekkoLatchedFrame >= 0 && !g_GekkoLatchedRunningAhead)
+        {
+            const int frame = g_GekkoLatchedFrame;
+            g_GekkoFrameInputBuffer[frame] = g_GekkoLatchedInput;
+            if (frame > g_GekkoMaxObservedFrame)
+            {
+                g_GekkoMaxObservedFrame = frame;
+            }
+            while (!g_GekkoFrameInputBuffer.empty())
+            {
+                auto it = g_GekkoFrameInputBuffer.begin();
+                if (g_GekkoMaxObservedFrame - it->first <= kGekkoRecordingRollbackHorizon)
+                {
+                    break;
+                }
+                n02::recordingWriteInputs(it->second.data(), static_cast<int>(it->second.size()));
+                g_GekkoFrameInputBuffer.erase(it);
+            }
+        }
+#endif
         return true;
     }
 #endif

--- a/Source/RMG-Input-GCA/UserInterface/MainDialog.ui
+++ b/Source/RMG-Input-GCA/UserInterface/MainDialog.ui
@@ -103,6 +103,106 @@
     </layout>
    </item>
    <item>
+    <widget class="QGroupBox" name="axisReadoutGroupBox">
+     <property name="title">
+      <string>Stick Range Readout</string>
+     </property>
+     <layout class="QGridLayout" name="axisReadoutGridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="axisReadoutXLabel">
+        <property name="text">
+         <string>X:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="axisReadoutXValue">
+        <property name="text">
+         <string>0</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>35</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QProgressBar" name="axisReadoutXBar">
+        <property name="minimum">
+         <number>-128</number>
+        </property>
+        <property name="maximum">
+         <number>127</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="textVisible">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="axisReadoutYLabel">
+        <property name="text">
+         <string>Y:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="axisReadoutYValue">
+        <property name="text">
+         <string>0</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>35</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QProgressBar" name="axisReadoutYBar">
+        <property name="minimum">
+         <number>-128</number>
+        </property>
+        <property name="maximum">
+         <number>127</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="textVisible">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QLabel" name="axisReadoutTipLabel">
+        <property name="text">
+         <string>Tip: adjust Stick Sensitivity so each cardinal direction reads about 85.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="styleSheet">
+         <string>font-style: italic;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="buttonsGroupBox">
      <property name="title">
       <string>Buttons</string>
@@ -548,93 +648,6 @@
         </property>
         <property name="checked">
          <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="axisReadoutGroupBox">
-     <property name="title">
-      <string>Stick Range Readout</string>
-     </property>
-     <layout class="QGridLayout" name="axisReadoutGridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="axisReadoutXLabel">
-        <property name="text">
-         <string>X:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="axisReadoutXValue">
-        <property name="text">
-         <string>0</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>35</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QProgressBar" name="axisReadoutXBar">
-        <property name="minimum">
-         <number>-128</number>
-        </property>
-        <property name="maximum">
-         <number>127</number>
-        </property>
-        <property name="value">
-         <number>0</number>
-        </property>
-        <property name="textVisible">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="axisReadoutYLabel">
-        <property name="text">
-         <string>Y:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="axisReadoutYValue">
-        <property name="text">
-         <string>0</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignVCenter</set>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>35</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QProgressBar" name="axisReadoutYBar">
-        <property name="minimum">
-         <number>-128</number>
-        </property>
-        <property name="maximum">
-         <number>127</number>
-        </property>
-        <property name="value">
-         <number>0</number>
-        </property>
-        <property name="textVisible">
-         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/Source/RMG/UserInterface/Dialog/Kaillera/KailleraPlaybackDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Kaillera/KailleraPlaybackDialog.cpp
@@ -923,7 +923,7 @@ void KailleraPlaybackDialog::populatePlaybackList()
         // Column 4: Size
         QString sizeStr;
         {
-            qint64 sz = fi.size();
+            qint64 sz = static_cast<qint64>(len);
             if (sz <= 1024)
                 sizeStr = QString::number(sz) + " B";
             else if (sz < 1024 * 1000)


### PR DESCRIPTION
- Show real krec file size in Playback dialog (was always "0 B" due to stale QFileInfo cache; use the length from the ifstream we already opened).
- Exclude non-.krec files from the recording-folder cap calculation so exported MP4s don't push the cap over its limit.
- Stop emulation when a krec playback reaches EOF even if the Playback dialog has been closed (previously only the dialog's 50ms timer caught end-of-recording, so closing the dialog mid-playback left emulation spinning forever with zero inputs).
- Gate .krec recording push on actual PIF poll instead of every GekkoNet advance. Frames the game advanced without polling the controller previously left stray entries in the recording, which drifted against playback's per-poll consumption and silently desynced sessions mid-playthrough. Recording now matches playback's cadence so both peers produce byte-identical .krec files that replay correctly.
- Reposition the GameCube adapter "Stick Range Readout" so it sits directly under the deadzone / sensitivity / trigger threshold sliders (above the Buttons group), and add an italic tip recommending users tune Stick Sensitivity so each cardinal direction reads about 85. Tip uses the default palette text color so it stays readable in dark mode.