### PR TITLE
Fix desktop file entry to use proper executable name

### DIFF
--- a/Package/com.github.Rosalie241.RMG.desktop
+++ b/Package/com.github.Rosalie241.RMG.desktop
@@ -2,8 +2,8 @@
 Type=Application
 Name=Rosalie's Mupen GUI
 Comment=An easy to use &amp; cross-platform mupen64plus front-end written in C++ & Qt
-Exec=RMG %f
-TryExec=RMG
+Exec=RMG-K %f
+TryExec=RMG-K
 Icon=com.github.Rosalie241.RMG
 Terminal=false
 Categories=Game;Emulator;Qt;


### PR DESCRIPTION
- Ensure the desktop file entry uses the proper executable name, allowing it to load without being invalidated
