### PR TITLE
More reasonable gcc defaults

### DIFF
--- a/Source/RMG-Core/Settings.cpp
+++ b/Source/RMG-Core/Settings.cpp
@@ -1552,7 +1552,7 @@ static l_Setting get_setting(SettingsID settingId)
         break;
 
     case SettingsID::GCAInput_Deadzone:
-        setting = {SETTING_SECTION_GCA, "Deadzone", 9};
+        setting = {SETTING_SECTION_GCA, "Deadzone", 5};
         break;
     case SettingsID::GCAInput_Sensitivity:
         setting = {SETTING_SECTION_GCA, "Sensitivity", 100};
@@ -2110,6 +2110,29 @@ CORE_EXPORT bool CoreSettingsUpgrade(void)
 
         CoreSettingsSetValue(SettingsID::Rollback_EnableLocalTesting, false);
         CoreSettingsSetValue(SettingsID::Kaillera_FlashOnJoin, true);
+    }
+
+    if (settingsVersion.empty() || settings_version_at_or_before(settingsVersionRaw, 0, 9, 7))
+    {
+        constexpr int oldEquivalentSensitivityAtSliderZero = 90;
+        constexpr int oldEquivalentSensitivityPerHundredSlider = 45;
+        constexpr int minMigratedSensitivity = 100;
+        constexpr int maxMigratedSensitivity = 200;
+        const l_Setting gcaSensitivity = get_setting(SettingsID::GCAInput_Sensitivity);
+
+        if (config_key_exists(gcaSensitivity.Section, gcaSensitivity.Key))
+        {
+            const int sensitivity = CoreSettingsGetIntValue(SettingsID::GCAInput_Sensitivity);
+            if (sensitivity > minMigratedSensitivity)
+            {
+                const int migratedSensitivity =
+                    (((sensitivity - oldEquivalentSensitivityAtSliderZero) * 100) +
+                    (oldEquivalentSensitivityPerHundredSlider / 2)) /
+                    oldEquivalentSensitivityPerHundredSlider;
+                CoreSettingsSetValue(SettingsID::GCAInput_Sensitivity,
+                    std::clamp(migratedSensitivity, minMigratedSensitivity, maxMigratedSensitivity));
+            }
+        }
     }
 
     // save core version

--- a/Source/RMG-Input-GCA/GCInput.hpp
+++ b/Source/RMG-Input-GCA/GCInput.hpp
@@ -13,6 +13,16 @@
 #include <QString>
 #include "Adapter.hpp"
 
+// Keep the practical default at 100%, with extra headroom up to 200%.
+constexpr double GCA_N64_AXIS_PEAK = 85.0;
+constexpr double GCA_SENSITIVITY_OFFSET = 0.90;
+constexpr double GCA_SENSITIVITY_PER_PERCENT = 0.0045;
+
+inline double GCASensitivityPercentToScale(int sensitivityPercent)
+{
+    return GCA_SENSITIVITY_OFFSET + (static_cast<double>(sensitivityPercent) * GCA_SENSITIVITY_PER_PERCENT);
+}
+
 enum class GCInput : int
 {
     None = -1,

--- a/Source/RMG-Input-GCA/UserInterface/MainDialog.cpp
+++ b/Source/RMG-Input-GCA/UserInterface/MainDialog.cpp
@@ -10,6 +10,7 @@
 #include "MainDialog.hpp"
 
 #include <RMG-Core/Settings.hpp>
+#include <algorithm>
 #include <cmath>
 #include <climits>
 
@@ -325,14 +326,15 @@ void MainDialog::updateAxisReadout()
 
     // Apply deadzone and sensitivity (same formula as main.cpp GetKeys)
     const double deadzone = static_cast<double>(this->deadZoneSlider->value()) / 100.0;
-    const double sensitivity = static_cast<double>(this->sensitivitySlider->value()) / 100.0;
-    const double n64Max = 85.0 * sensitivity;
+    const double sensitivity = GCASensitivityPercentToScale(this->sensitivitySlider->value());
+    const double n64Max = GCA_N64_AXIS_PEAK * sensitivity;
 
     auto scaleAxis = [](double input, double dz, double max) -> int {
         double absInput = std::abs(input);
         if (absInput <= dz) return 0;
         double scaled = (absInput - dz) / (1.0 - dz) * max;
-        int result = static_cast<int>(std::min(scaled, max));
+        double axisMax = std::min(max, static_cast<double>(INT8_MAX));
+        int result = static_cast<int>(std::min(scaled, axisMax));
         return (input >= 0) ? result : -result;
     };
 

--- a/Source/RMG-Input-GCA/main.cpp
+++ b/Source/RMG-Input-GCA/main.cpp
@@ -35,8 +35,6 @@
 //
 
 #define NUM_CONTROLLERS    4
-#define N64_AXIS_PEAK      85
-
 #define GCA_VENDOR_ID  0x057e
 #define GCA_PRODUCT_ID 0x0337
 
@@ -276,7 +274,7 @@ static void gca_poll_thread(void)
 static void load_settings(void)
 {
     l_Settings.DeadzoneValue = static_cast<double>(CoreSettingsGetIntValue(SettingsID::GCAInput_Deadzone)) / 100.0;
-    l_Settings.SensitivityValue = static_cast<double>(CoreSettingsGetIntValue(SettingsID::GCAInput_Sensitivity)) / 100.0;
+    l_Settings.SensitivityValue = GCASensitivityPercentToScale(CoreSettingsGetIntValue(SettingsID::GCAInput_Sensitivity));
     l_Settings.CButtonTreshold = static_cast<double>(CoreSettingsGetIntValue(SettingsID::GCAInput_CButtonTreshold)) / 100.0;
     l_Settings.TriggerTreshold = static_cast<double>(CoreSettingsGetIntValue(SettingsID::GCAInput_TriggerTreshold)) / 100.0;
     l_Settings.PortEnabled[0] = CoreSettingsGetBoolValue(SettingsID::GCAInput_Port1Enabled);
@@ -313,7 +311,8 @@ static int scale_axis(const double input, const double deadzone, const double n6
     const double deadzoneRelation = 1.0 / (1.0 - deadzone);
     const double scaled = (inputAbs - deadzone) * deadzoneRelation * n64Max;
 
-    const int result = static_cast<int>(std::min(scaled, n64Max));
+    const double axisMax = std::min(n64Max, static_cast<double>(INT8_MAX));
+    const int result = static_cast<int>(std::min(scaled, axisMax));
     return (input >= 0) ? result : -result;
 }
 
@@ -513,7 +512,7 @@ EXPORT void CALL GetKeys(int Control, BUTTONS* Keys)
 
     const double inputX = static_cast<double>(x) / static_cast<double>(INT8_MAX);
     const double inputY = static_cast<double>(y) / static_cast<double>(INT8_MAX);
-    const double n64Max = N64_AXIS_PEAK * l_Settings.SensitivityValue;
+    const double n64Max = GCA_N64_AXIS_PEAK * l_Settings.SensitivityValue;
 
     Keys->X_AXIS = scale_axis(inputX, l_Settings.DeadzoneValue, n64Max);
     Keys->Y_AXIS = scale_axis(inputY, l_Settings.DeadzoneValue, n64Max);


### PR DESCRIPTION
Changes scaling on the gamecube plugin to be more reasonable.

- 100% = old 135%
- 200% = old 180%
- 0% = old 90%

With this, 100% should be roughly 85 n64 range.

Users without settings will use the new better range; users that had previously set a >100% range will be migrated to the equivalent in the new system.