### PR TITLE
Properly reset n02 state when hosting

### DIFF
--- a/Source/RMG/UserInterface/Dialog/Kaillera/KailleraNetplayDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Kaillera/KailleraNetplayDialog.cpp
@@ -4307,6 +4307,7 @@ void KailleraNetplayDialog::hostP2P(bool showOnPublicList)
     int port = CoreSettingsGetIntValue(SettingsID::Kaillera_Port);
     if (port <= 0 || port > 65535) port = 27886;
 
+    n02::resetStateMachine();
     if (p2p_core_initialize(true, port, APP, gameBytes.data(), usernameBytes.data()))
     {
         const bool stateTimerWasRunning =
@@ -4470,6 +4471,7 @@ void KailleraNetplayDialog::onP2PJoin()
     bool isCode = looksLikeTraversalCode(addrText);
     const QString normalizedCode = isCode ? normalizeTraversalCode(addrText) : QString();
 
+    n02::resetStateMachine();
     if (p2p_core_initialize(false, 0, APP, (char*)"", usernameBytes.data()))
     {
         const bool stateTimerWasRunning =

--- a/Source/RMG/UserInterface/Dialog/Kaillera/KailleraP2PDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Kaillera/KailleraP2PDialog.cpp
@@ -1554,12 +1554,27 @@ void KailleraP2PDialog::cleanupSessionForClose()
     m_peerReady = false;
     if (m_btnReady) m_btnReady->setChecked(false);
 
-    if (isRollbackMode() && m_rollbackGameActive)
+    const bool n02GameRunning = n02::isGameRunning();
+    const bool p2pGameStateActive = m_gameActive || m_rollbackGameActive || n02GameRunning;
+    if (p2pGameStateActive)
     {
+        const bool rollbackSessionWasActive = isRollbackMode() && (m_rollbackGameActive || n02GameRunning);
         m_rollbackGameActive = false;
         m_gameActive = false;
-        emit rollbackSessionEnded();
+        if (rollbackSessionWasActive)
+        {
+            emit rollbackSessionEnded();
+        }
+        else
+        {
+            CoreMarkKailleraGameInactive();
+        }
         CoreStopEmulation();
+        n02::resetStateMachine();
+    }
+    else if (n02::getState() != 0)
+    {
+        n02::resetStateMachine();
     }
 
     // Remove from public game list

--- a/Source/n02/core/p2p_core.cpp
+++ b/Source/n02/core/p2p_core.cpp
@@ -190,9 +190,38 @@ static void p2p_mark_lobby_ping_alive() {
 	P2PCORE.last_ping_echo_time = now;
 }
 
+static bool p2p_reset_lobby_after_peer_left_locked() {
+	P2PCORE.CONNECTED = false;
+	P2PCORE.status = P2PCORE.HOST ? 1 : 0;
+	P2PCORE.ping = -1;
+	P2PCORE.USERREADY = false;
+	P2PCORE.PEERREADY = false;
+	P2PCORE.USERLOADED = false;
+	P2PCORE.PEERLOADED = false;
+	P2PCORE.last_ping_sent_time = 0;
+	P2PCORE.last_ping_echo_time = 0;
+	p2p_clear_rollback_packets_locked(false);
+
+	if (!P2PCORE.HOST)
+		return true;
+
+	p2p_core_debug("reinitializing server...");
+	delete P2PCORE.connection;
+	P2PCORE.connection = new p2p_message;
+	if (!P2PCORE.connection->initialize(P2PCORE.PORT)){
+		p2p_core_debug("Error initializing socket at specified port");
+		P2PCORE.status = 0;
+		return false;
+	}
+
+	P2PCORE.PORT = P2PCORE.connection->get_port();
+	p2p_core_debug("Done");
+	return true;
+}
+
 bool p2p_is_connected(){
 	std::lock_guard<std::recursive_mutex> lock(p2p_transport_mutex);
-	return P2PCORE.status != 0 && P2PCORE.ping != -1 && P2PCORE.connection;
+	return P2PCORE.CONNECTED && P2PCORE.status != 0 && P2PCORE.ping != -1 && P2PCORE.connection;
 }
 int p2p_get_frames_count(){
 	std::lock_guard<std::recursive_mutex> lock(p2p_transport_mutex);
@@ -547,11 +576,7 @@ bool p2p_rollback_process_control(){
 			break;
 		case EXIT:
 			p2p_peer_left_callback();
-			P2PCORE.status = P2PCORE.HOST?1:0;
-			P2PCORE.CONNECTED = false;
-			P2PCORE.last_ping_sent_time = 0;
-			P2PCORE.last_ping_echo_time = 0;
-			p2p_clear_rollback_packets_locked(false);
+			p2p_reset_lobby_after_peer_left_locked();
 			p2p_end_game_callback();
 			ended_game = true;
 			break;

--- a/Source/n02/n02_client.cpp
+++ b/Source/n02/n02_client.cpp
@@ -847,6 +847,12 @@ void setStateInput(int input) {
     KSSDFA.input = input;
 }
 
+void resetStateMachine() {
+    close_recording();
+    KSSDFA.state = 0;
+    KSSDFA.input = 0;
+}
+
 void setUICallbacks(const UICallbacks& callbacks) {
     s_uiCallbacks = callbacks;
 }

--- a/Source/n02/n02_client.h
+++ b/Source/n02/n02_client.h
@@ -74,6 +74,9 @@ int getState();
 // Set KSSDFA input to trigger state transition
 void setStateInput(int input);
 
+// Reset the n02 state machine to lobby/polling state without emitting game lifecycle callbacks.
+void resetStateMachine();
+
 // Process one step of the state machine (non-blocking)
 // Returns true if state machine is still active (state != 3)
 bool processStateMachineStep();


### PR DESCRIPTION
Previously when a game was shutdown improperly (for example one player just left), n02 could end up in a split state where it thought the game was still running. The effect was that hosting would fail because the host would not listen to replies from the NAT server.

This PR properly resets n02 state when rehosting to clear