### PR TITLE
Fix build when SDL3 is in a non-standard prefix

### DIFF
--- a/Source/3rdParty/CMakeLists.txt
+++ b/Source/3rdParty/CMakeLists.txt
@@ -61,8 +61,13 @@ set(SDL3NET_SOURCES
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDL3 REQUIRED sdl3)
 add_library(SDL3_net STATIC ${SDL3NET_SOURCES})
-target_include_directories(SDL3_net PRIVATE ${SDL3NET_DIR}/include)
-set(SDL3NET_CFLAGS "-DUSE_SDL3NET -I${SDL3NET_DIR}/include")
+# SDL_net.c includes <SDL3/SDL.h>, so SDL3's own headers must be on the
+# search path. Required when SDL3 lives in a non-standard prefix; with a
+# system install the compiler finds them anyway, which masks the omission.
+target_include_directories(SDL3_net PRIVATE ${SDL3NET_DIR}/include ${SDL3_INCLUDE_DIRS})
+# SDL3_CFLAGS carries SDL3's -I flags for the mupen64plus-core Makefile build,
+# which compiles against SDL3 outside CMake's target model.
+set(SDL3NET_CFLAGS "-DUSE_SDL3NET -I${SDL3NET_DIR}/include ${SDL3_CFLAGS}")
 # for some reason MingW needs SDL3 to be linked after SDL3_net,
 # else we get a lot of missing symbol errors, should be harmless
 # on other platforms

--- a/Source/RMG/CMakeLists.txt
+++ b/Source/RMG/CMakeLists.txt
@@ -175,6 +175,11 @@ target_include_directories(RMG PRIVATE
 
 target_link_libraries(RMG Qt6::Gui Qt6::Widgets ${HIDAPI_LIBRARIES})
 
+# RMG sources (e.g. QtKeyToSdl3Key.cpp, VidExtProxy.cpp) include <SDL3/SDL.h>
+# on every platform, so link SDL3 unconditionally. The imported target also
+# carries SDL3's include dirs, which matters when SDL3 is in a custom prefix.
+target_link_libraries(RMG SDL3::SDL3)
+
 if (WIN32)
     target_link_libraries(RMG opengl32 gdi32 user32)
 endif(WIN32)
@@ -194,7 +199,7 @@ endif(KCA_DRAG_DROP)
 if (NETPLAY)
     target_link_libraries(RMG Qt6::WebSockets Qt6::Network)
     if (WIN32)
-        target_link_libraries(RMG SDL3::SDL3 OpenGL::GL)
+        target_link_libraries(RMG OpenGL::GL)
         target_include_directories(RMG PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/../n02
         )


### PR DESCRIPTION
## Why

Building with SDL3 installed under a non-standard prefix (e.g. `~/.local`, a from-source install) fails:

```
SDL_net.h:115:10: fatal error: SDL3/SDL.h: No such file or directory   # SDL3_net target
QtKeyToSdl3Key.cpp:12:10: fatal error: SDL3/SDL.h: No such file or directory   # RMG app
```

Two targets compile SDL3-using sources but never had SDL3's include dirs on their search path. This only worked when SDL3 lived in a default system include path (e.g. `libsdl3-dev` → `/usr/include`), which masked the omission. With a custom prefix the headers aren't found.

## How

Two small, independent commits:

1. **SDL3_net** — propagate SDL3's include dirs to the target via `target_include_directories`, and append `${SDL3_CFLAGS}` to `SDLNET_CFLAGS` so the mupen64plus-core Makefile build (a non-CMake boundary) gets the `-I` too.
2. **RMG app** — `SDL3::SDL3` was linked only under `NETPLAY+WIN32`, but `QtKeyToSdl3Key.cpp` / `VidExtProxy.cpp` include `<SDL3/SDL.h>` on every platform. Link `SDL3::SDL3` unconditionally (the imported target carries the include dirs); drop the now-redundant entry from the `NETPLAY+WIN32` block.

## Effects

- Builds with SDL3 in a custom prefix (point at it via `PKG_CONFIG_PATH` / `CMAKE_PREFIX_PATH`, as usual).
- No change for system-SDL3 installs — the added include dirs are already on the default path there.
- Windows/MinGW link path unchanged (SDL3 still linked; only de-duplicated).

## Testing

Clean from-scratch Release build on Ubuntu 24.04 with SDL3 3.4.0 in `~/.local` and **no** `CPATH` workaround: succeeds, producing `RMG-K` + 9 plugins.