### PR TITLE
Write config atomically to prevent mupen64plus.cfg being wiped

### DIFF
--- a/Source/3rdParty/mupen64plus-core/src/api/config.c
+++ b/Source/3rdParty/mupen64plus-core/src/api/config.c
@@ -371,9 +371,10 @@ static m64p_error write_configlist_file(void)
     config_section *curr_section;
     const char *configpath;
     char *filepath;
+    char *temppath;
     FILE *fPtr;
 
-    /* get the full pathname to the config file and try to open it */
+    /* get the full pathname to the config file */
     configpath = ConfigGetUserConfigPath();
     if (configpath == NULL)
         return M64ERR_FILES;
@@ -382,14 +383,27 @@ static m64p_error write_configlist_file(void)
     if (filepath == NULL)
         return M64ERR_NO_MEMORY;
 
-    fPtr = osal_file_open(filepath, "wb");
+    /* Write to a temporary file and atomically move it over the real config file
+     * once it is fully written. Opening the real file directly in "wb" truncates
+     * it to zero bytes up front, so any interruption mid-write (crash, forced exit,
+     * power loss, antivirus/cloud-sync lock) would leave the user with an empty or
+     * half-written config. Committing via a temp file guarantees the existing good
+     * config is never destroyed -- only the throwaway temp file is ever at risk. */
+    temppath = combinepath(configpath, MUPEN64PLUS_CFG_NAME ".tmp");
+    if (temppath == NULL)
+    {
+        free(filepath);
+        return M64ERR_NO_MEMORY;
+    }
+
+    fPtr = osal_file_open(temppath, "wb");
     if (fPtr == NULL)
     {
-        DebugMessage(M64MSG_ERROR, "Couldn't open configuration file '%s' for writing.", filepath);
+        DebugMessage(M64MSG_ERROR, "Couldn't open configuration file '%s' for writing.", temppath);
+        free(temppath);
         free(filepath);
         return M64ERR_FILES;
     }
-    free(filepath);
 
     /* write out header */
     fprintf(fPtr, "# Mupen64Plus Configuration File\n");
@@ -421,7 +435,31 @@ static m64p_error write_configlist_file(void)
         curr_section = curr_section->next;
     }
 
+    /* make sure the full config actually reached disk before we commit it;
+     * if anything went wrong, keep the existing config untouched */
+    if (fflush(fPtr) != 0 || ferror(fPtr) != 0)
+    {
+        DebugMessage(M64MSG_ERROR, "Error while writing configuration file '%s'.", temppath);
+        fclose(fPtr);
+        unlink(temppath);
+        free(temppath);
+        free(filepath);
+        return M64ERR_FILES;
+    }
     fclose(fPtr);
+
+    /* atomically replace the real config file with the fully-written temp file */
+    if (osal_file_replace(temppath, filepath) != 0)
+    {
+        DebugMessage(M64MSG_ERROR, "Couldn't commit configuration file '%s'.", filepath);
+        unlink(temppath);
+        free(temppath);
+        free(filepath);
+        return M64ERR_FILES;
+    }
+
+    free(temppath);
+    free(filepath);
     return M64ERR_SUCCESS;
 }
 

--- a/Source/3rdParty/mupen64plus-core/src/osal/files.h
+++ b/Source/3rdParty/mupen64plus-core/src/osal/files.h
@@ -67,5 +67,12 @@ extern const char * osal_get_user_cachepath(void);
 extern FILE * osal_file_open (const char *filename, const char *mode);
 extern gzFile osal_gzopen(const char *filename, const char *mode);
 
+/* Atomically replace the file at dstpath with the file at srcpath (a move/rename).
+ * If dstpath already exists it is overwritten. Returns zero on success, nonzero on
+ * failure. Used to commit a fully-written temp file over a config file without ever
+ * leaving the destination truncated if the process is interrupted mid-write.
+ */
+extern int osal_file_replace(const char *srcpath, const char *dstpath);
+
 #endif /* OSAL_FILES_H */
 

--- a/Source/3rdParty/mupen64plus-core/src/osal/files_macos.c
+++ b/Source/3rdParty/mupen64plus-core/src/osal/files_macos.c
@@ -232,3 +232,9 @@ gzFile osal_gzopen(const char *filename, const char *mode)
 {
     return gzopen(filename, mode);
 }
+
+int osal_file_replace(const char *srcpath, const char *dstpath)
+{
+    /* POSIX rename() atomically replaces an existing destination on the same filesystem */
+    return rename(srcpath, dstpath);
+}

--- a/Source/3rdParty/mupen64plus-core/src/osal/files_unix.c
+++ b/Source/3rdParty/mupen64plus-core/src/osal/files_unix.c
@@ -241,3 +241,9 @@ gzFile osal_gzopen(const char *filename, const char *mode)
 {
     return gzopen(filename, mode);
 }
+
+int osal_file_replace(const char *srcpath, const char *dstpath)
+{
+    /* POSIX rename() atomically replaces an existing destination on the same filesystem */
+    return rename(srcpath, dstpath);
+}

--- a/Source/3rdParty/mupen64plus-core/src/osal/files_win32.c
+++ b/Source/3rdParty/mupen64plus-core/src/osal/files_win32.c
@@ -220,3 +220,14 @@ gzFile osal_gzopen(const char *filename, const char *mode)
     MultiByteToWideChar(CP_UTF8, 0, filename, -1, wstr_filename, PATH_MAX);
     return gzopen_w(wstr_filename, mode);
 }
+
+int osal_file_replace(const char *srcpath, const char *dstpath)
+{
+    wchar_t wstr_src[PATH_MAX];
+    wchar_t wstr_dst[PATH_MAX];
+    MultiByteToWideChar(CP_UTF8, 0, srcpath, -1, wstr_src, PATH_MAX);
+    MultiByteToWideChar(CP_UTF8, 0, dstpath, -1, wstr_dst, PATH_MAX);
+    /* plain rename() fails on Win32 when the destination exists; MoveFileExW with
+     * MOVEFILE_REPLACE_EXISTING overwrites it, and is atomic on the same volume */
+    return MoveFileExW(wstr_src, wstr_dst, MOVEFILE_REPLACE_EXISTING) ? 0 : 1;
+}


### PR DESCRIPTION
write_configlist_file() opened mupen64plus.cfg directly in "wb" mode, which truncates it to zero bytes before the replacement is written. Any interruption during serialization (crash on exit, forced quit, power loss, antivirus/cloud-sync file lock) therefore left users with an empty or half-written config -- the "settings got wiped" reports on both the installer and portable builds.

Write to mupen64plus.cfg.tmp, verify the stream is healthy (fflush + ferror), then atomically replace the real file with it via a new osal_file_replace() helper (MoveFileExW + MOVEFILE_REPLACE_EXISTING on Win32, rename() on POSIX). Every failure path now leaves the existing config untouched instead of destroying it.