### PR TITLE
Default OSD and GCN buttons

### DIFF
--- a/Source/3rdParty/mupen64plus-video-GLideN64/src/Config.cpp
+++ b/Source/3rdParty/mupen64plus-video-GLideN64/src/Config.cpp
@@ -143,12 +143,12 @@ void Config::resetToDefaults()
 	gammaCorrection.level = 2.0f;
 
 	onScreenDisplay.vis = 0;
-	onScreenDisplay.fps = 0;
+	onScreenDisplay.fps = 1;
 	onScreenDisplay.percent = 0;
 	onScreenDisplay.internalResolution = 0;
 	onScreenDisplay.renderingResolution = 0;
 	onScreenDisplay.statistics = 0;
-	onScreenDisplay.pos = posBottomLeft;
+	onScreenDisplay.pos = posBottomRight;
 
 	for (u32 idx = 0; idx < HotKey::hkTotal; ++idx) {
 		hotkeys.enabledKeys[idx] = 0;
@@ -257,4 +257,3 @@ const char* Config::enabledHotkeyIniName(u32 _idx)
 	}
 	return nullptr;
 }
-

--- a/Source/RMG-Core/Settings.cpp
+++ b/Source/RMG-Core/Settings.cpp
@@ -1589,16 +1589,16 @@ static l_Setting get_setting(SettingsID settingId)
         setting = {SETTING_SECTION_GCA, "Map_Start", 5};
         break;
     case SettingsID::GCAInput_Map_Z:
-        setting = {SETTING_SECTION_GCA, "Map_Z", 4};
+        setting = {SETTING_SECTION_GCA, "Map_Z", 12};
         break;
     case SettingsID::GCAInput_Map_Z2:
-        setting = {SETTING_SECTION_GCA, "Map_Z2", -1};
+        setting = {SETTING_SECTION_GCA, "Map_Z2", 13};
         break;
     case SettingsID::GCAInput_Map_L:
-        setting = {SETTING_SECTION_GCA, "Map_L", 12};
+        setting = {SETTING_SECTION_GCA, "Map_L", 14};
         break;
     case SettingsID::GCAInput_Map_R:
-        setting = {SETTING_SECTION_GCA, "Map_R", 13};
+        setting = {SETTING_SECTION_GCA, "Map_R", 4};
         break;
     case SettingsID::GCAInput_Map_DpadUp:
         setting = {SETTING_SECTION_GCA, "Map_DpadUp", 8};
@@ -1613,16 +1613,16 @@ static l_Setting get_setting(SettingsID settingId)
         setting = {SETTING_SECTION_GCA, "Map_DpadRight", 11};
         break;
     case SettingsID::GCAInput_Map_CUp:
-        setting = {SETTING_SECTION_GCA, "Map_CUp", 14};
+        setting = {SETTING_SECTION_GCA, "Map_CUp", -1};
         break;
     case SettingsID::GCAInput_Map_CDown:
-        setting = {SETTING_SECTION_GCA, "Map_CDown", 15};
+        setting = {SETTING_SECTION_GCA, "Map_CDown", -1};
         break;
     case SettingsID::GCAInput_Map_CLeft:
-        setting = {SETTING_SECTION_GCA, "Map_CLeft", 16};
+        setting = {SETTING_SECTION_GCA, "Map_CLeft", 3};
         break;
     case SettingsID::GCAInput_Map_CRight:
-        setting = {SETTING_SECTION_GCA, "Map_CRight", 17};
+        setting = {SETTING_SECTION_GCA, "Map_CRight", 2};
         break;
 
     // Internal settings (runtime-only, not persisted)


### PR DESCRIPTION
<img width="580" height="762" alt="image" src="https://github.com/user-attachments/assets/321ddd97-66b6-4223-a120-0af6cb7f041b" />
<img width="870" height="1004" alt="image" src="https://github.com/user-attachments/assets/d18a716f-a3b4-436f-88c4-21ca3eb0929b" />


Updated default gamecube button mappings and turned FPS display on by default