### PR TITLE
Rollback lobby: UI revamp + spectate fast-forward broadcast

### DIFF
--- a/Source/3rdParty/mupen64plus-core/src/api/frontend.c
+++ b/Source/3rdParty/mupen64plus-core/src/api/frontend.c
@@ -411,6 +411,16 @@ EXPORT m64p_error CALL CoreDoCommand(m64p_command Command, int ParamInt, void *P
                 return M64ERR_INVALID_STATE;
             if (ParamPtr == NULL)
                 return M64ERR_INPUT_ASSERT;
+            /* checksum == ROLLBACK_SAVE_FULL_SENTINEL: spectate keyframe wants a FULL
+             * normal-format savestate (TLB LUT included, zeroed) for a cold spectator,
+             * not the stripped rollback variant. checksum is an output of the save, so
+             * overloading it as an input flag is free (no new command / ABI change). */
+            if (((m64p_rollback_state*)ParamPtr)->checksum == ROLLBACK_SAVE_FULL_SENTINEL)
+                return savestates_save_full_buffer(
+                    &((m64p_rollback_state*)ParamPtr)->buffer,
+                    &((m64p_rollback_state*)ParamPtr)->len,
+                    &((m64p_rollback_state*)ParamPtr)->checksum,
+                    ((m64p_rollback_state*)ParamPtr)->frame) ? M64ERR_SUCCESS : M64ERR_INTERNAL;
             return savestates_save_rollback_buffer(
                 &((m64p_rollback_state*)ParamPtr)->buffer,
                 &((m64p_rollback_state*)ParamPtr)->len,
@@ -421,6 +431,22 @@ EXPORT m64p_error CALL CoreDoCommand(m64p_command Command, int ParamInt, void *P
                 return M64ERR_INVALID_STATE;
             if (ParamPtr == NULL)
                 return M64ERR_INPUT_ASSERT;
+            /* checksum == ROLLBACK_LOAD_DEFER_SENTINEL: stage the load for the next safe
+             * interrupt boundary instead of loading now. The spectate keyframe path runs
+             * this from inside an SI DMA, where a synchronous load corrupts the restored
+             * state; deferring matches how normal savestate loads are timed. */
+            if (((m64p_rollback_state*)ParamPtr)->checksum == ROLLBACK_LOAD_DEFER_SENTINEL) {
+                /* Stash the buffer, then stage it as a normal load job. gen_interrupt's
+                 * proven `job==load -> savestates_load()` check (the same path single-player
+                 * loads use) drains it at a clean between-blocks boundary; savestates_load()
+                 * dispatches savestates_type_rollback_buffer to the stashed buffer. */
+                savestates_set_pending_rollback_load(
+                    ((m64p_rollback_state*)ParamPtr)->buffer,
+                    ((m64p_rollback_state*)ParamPtr)->len);
+                savestates_set_job(savestates_job_load, savestates_type_rollback_buffer, NULL);
+                DebugMessage(M64MSG_INFO, "RMGK-DEFER: deferred rollback load staged as load job");
+                return M64ERR_SUCCESS;
+            }
             return savestates_load_rollback_buffer(
                 ((m64p_rollback_state*)ParamPtr)->buffer,
                 ((m64p_rollback_state*)ParamPtr)->len) ? M64ERR_SUCCESS : M64ERR_INTERNAL;

--- a/Source/3rdParty/mupen64plus-core/src/device/r4300/interrupt.c
+++ b/Source/3rdParty/mupen64plus-core/src/device/r4300/interrupt.c
@@ -701,6 +701,16 @@ void gen_interrupt(struct r4300_core* r4300)
             return;
         }
 
+        /* Spectate keyframe deferred load: same safe point as a normal savestate load —
+         * restore the rollback buffer here (between blocks, no SI/DMA in flight) and
+         * return, so the CPU re-dispatches cleanly from the restored PC. */
+        if (savestates_has_pending_rollback_load())
+        {
+            DebugMessage(M64MSG_INFO, "RMGK-DEFER: deferred rollback load drained");
+            savestates_run_pending_rollback_load();
+            return;
+        }
+
         if (r4300->reset_hard_job)
         {
             call_interrupt_handler(&r4300->cp0, 11);

--- a/Source/3rdParty/mupen64plus-core/src/device/rcp/si/si_controller.c
+++ b/Source/3rdParty/mupen64plus-core/src/device/rcp/si/si_controller.c
@@ -31,6 +31,7 @@
 #include "device/rcp/mi/mi_controller.h"
 #include "device/rcp/ri/ri_controller.h"
 #include "device/rdram/rdram.h"
+#include "main/savestates.h"
 #include "osal/preproc.h"
 
 static int validate_dma(struct si_controller* si, uint32_t reg)
@@ -87,12 +88,31 @@ static void dma_si_write(struct si_controller* si)
 
 static void dma_si_read(struct si_controller* si)
 {
+    int rollback_loads_before;
+
     if (!validate_dma(si, SI_PIF_ADDR_RD64B_REG))
         return;
 
     si->dma_dir = SI_DMA_READ;
 
+    /* A spectate keyframe is loaded from inside the PIF sync callback, which fires at
+     * the end of update_pif_ram() — i.e. right here, mid-SI-DMA. If that happens, the
+     * machine has been replaced with a savestate captured at a clean VI boundary (no SI
+     * transaction pending), so running the rest of THIS (stale) SI read on top of it —
+     * setting DMA_BUSY and scheduling an SI interrupt — would inject a phantom SI_INT
+     * into the just-restored event queue and desync the replay. Detect the nested load
+     * via the rollback-load counter and abandon the stale completion; the loaded state
+     * is already self-consistent. (Normal rollback loads happen outside dma_si_read, so
+     * they never trip this.) */
+    rollback_loads_before = savestates_get_rollback_load_counter();
+
     update_pif_ram(si->pif);
+
+    if (savestates_get_rollback_load_counter() != rollback_loads_before)
+    {
+        si->dma_dir = SI_NO_DMA;
+        return;
+    }
 
     cp0_update_count(si->mi->r4300);
     si->regs[SI_STATUS_REG] |= SI_STATUS_DMA_BUSY;

--- a/Source/3rdParty/mupen64plus-core/src/main/savestates.c
+++ b/Source/3rdParty/mupen64plus-core/src/main/savestates.c
@@ -89,6 +89,12 @@ static char *fname = NULL;
 static unsigned int slot = 0;
 static int autoinc_save_slot = 0;
 
+/* Counts completed rollback-buffer loads. The SI controller compares this across an
+ * update_pif_ram() call to detect a spectate keyframe load that happened *inside* the
+ * PIF sync callback (mid-SI-DMA), so it can skip the stale SI completion that would
+ * otherwise inject a phantom SI interrupt into the just-restored state. */
+static int rollback_load_counter = 0;
+
 enum { ROLLBACK_SAVE_STATES_COUNT = 120 };
 enum { ROLLBACK_LOAD_FRAMES_AGO = 30 };
 
@@ -119,6 +125,11 @@ static int *rollback_save_buffer_checksum = NULL;
 static int rollback_save_buffer_frame = 0;
 static unsigned char *rollback_save_prealloc_data = NULL;
 static int rollback_save_prealloc_capacity = 0;
+/* When set, a rollback-buffer save produces a FULL normal-format state (TLB LUT included,
+ * buffer zeroed, omit flag cleared) instead of the stripped rollback variant. Set only for
+ * the spectate keyframe save via savestates_save_full_buffer; the host's per-frame rollback
+ * saves leave it 0, so their path is byte-for-byte unchanged. */
+static int rollback_save_full = 0;
 static int rollback_verbose_stats = 0;
 
 void savestates_set_rollback_verbose_stats(int enabled)
@@ -204,6 +215,42 @@ void savestates_inc_slot(void)
 savestates_job savestates_get_job(void)
 {
     return job;
+}
+
+int savestates_get_rollback_load_counter(void)
+{
+    return rollback_load_counter;
+}
+
+/* Spectate keyframe deferred load: the spectator stages a rollback-buffer load and it is
+ * performed at the next safe interrupt boundary (gen_interrupt), exactly like a normal
+ * savestate load, instead of synchronously mid-frame. Loading a full machine state mid-SI
+ * DMA / mid-dynarec-block lets the half-finished operation run on top of the restored
+ * state and desyncs the replay one frame later. The buffer must stay valid until drained
+ * (it does — it's the spectator's persistent keyframe buffer). */
+static unsigned char* pending_rollback_load_buffer = NULL;
+static int pending_rollback_load_len = 0;
+
+int savestates_has_pending_rollback_load(void)
+{
+    return pending_rollback_load_buffer != NULL;
+}
+
+void savestates_set_pending_rollback_load(unsigned char* buffer, int len)
+{
+    pending_rollback_load_buffer = buffer;
+    pending_rollback_load_len = len;
+}
+
+int savestates_run_pending_rollback_load(void)
+{
+    unsigned char* buffer = pending_rollback_load_buffer;
+    int len = pending_rollback_load_len;
+    pending_rollback_load_buffer = NULL;
+    pending_rollback_load_len = 0;
+    if (buffer != NULL && len > 0)
+        return savestates_load_rollback_buffer(buffer, len);
+    return 0;
 }
 
 void savestates_set_job(savestates_job j, savestates_type t, const char *fn)
@@ -723,7 +770,12 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
     if (memory_data != NULL)
     {
         rollback_tlb_start = SDL_GetPerformanceCounter();
-        if (memcmp(rollback_old_tlb_entries, dev->r4300.cp0.tlb.entries, sizeof(rollback_old_tlb_entries)) == 0)
+        /* The "entries unchanged -> keep existing LUT" shortcut is only valid for the OMITTED
+         * (stripped rollback) format, where there's no LUT in the buffer to install. A FULL
+         * buffer (omit flag clear) carries its own LUT — a cold spectator must always install
+         * it, so don't take the skip in that case. */
+        if (rollback_tlb_lut_omitted &&
+            memcmp(rollback_old_tlb_entries, dev->r4300.cp0.tlb.entries, sizeof(rollback_old_tlb_entries)) == 0)
         {
             rollback_tlb_lut_skipped = 1;
         }
@@ -1713,6 +1765,18 @@ int savestates_load(void)
     char *filepath = NULL;
     int ret = 0;
 
+    /* Spectate keyframe: a rollback buffer was staged via savestates_set_job(load,
+     * savestates_type_rollback_buffer). Load it from memory here — at the same safe
+     * interrupt boundary the normal file load uses — and skip all file handling. */
+    if (type == savestates_type_rollback_buffer)
+    {
+        ret = savestates_run_pending_rollback_load();
+        DebugMessage(M64MSG_INFO, "RMGK-DEFER: rollback-buffer job loaded (ret=%d)", ret);
+        StateChanged(M64CORE_STATE_LOADCOMPLETE, ret);
+        savestates_clear_job();
+        return ret;
+    }
+
     if (fname != NULL && strcmp(fname, "MEMORY") == 0)
     {
         type = savestates_type_m64p;
@@ -1882,7 +1946,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
 
     // Allocate memory for the save state data
     save->size = 16788288 + sizeof(queue) + 4 + 4096;
-    if (rollback_buffer_save)
+    if (rollback_buffer_save && !rollback_save_full)
         save->size -= rollback_tlb_lut_size;
     allocation_size = save->size;
     if (rollback_buffer_save)
@@ -1927,7 +1991,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
         return 0;
     }
 
-    if (!rollback_buffer_save)
+    if (!rollback_buffer_save || rollback_save_full)
         memset(save->data, 0, allocation_size);
 
     // Write the save state data to memory
@@ -2099,7 +2163,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
 
     if (rollback_buffer_save)
         rollback_save_tlb_start = SDL_GetPerformanceCounter();
-    if (!rollback_buffer_save)
+    if (!rollback_buffer_save || rollback_save_full)
     {
         PUTARRAY(dev->r4300.cp0.tlb.LUT_r, curr, uint32_t, 0x100000);
         PUTARRAY(dev->r4300.cp0.tlb.LUT_w, curr, uint32_t, 0x100000);
@@ -2321,7 +2385,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
         rollback_header[1] = rollback_state_header_size;
         rollback_header[2] = savestate_latest_version;
         rollback_header[3] = rollback_save_buffer_frame;
-        rollback_header[4] = rollback_state_flag_omit_tlb_lut;
+        rollback_header[4] = rollback_save_full ? 0 : rollback_state_flag_omit_tlb_lut;
         rollback_header[5] = 0;
 
         if (rollback_save_buffer_checksum != NULL)
@@ -2702,6 +2766,21 @@ int savestates_save_rollback_buffer(unsigned char **buffer, int *len, int *check
     return result;
 }
 
+/* Spectate keyframe: a FULL normal-format savestate into a caller buffer (same memory-buffer
+ * plumbing as savestates_save_rollback_buffer, but the rollback_save_full flag makes the save
+ * include the TLB LUT and zero the buffer, and clears the omit flag in the header). The host's
+ * per-frame rollback saves never set the flag, so their fast stripped path is unchanged. The
+ * resulting buffer carries the rollback header (so the existing buffer-load path reads it) but
+ * is otherwise a complete savestate a cold spectator can load. */
+int savestates_save_full_buffer(unsigned char **buffer, int *len, int *checksum, int frame)
+{
+    int result;
+    rollback_save_full = 1;
+    result = savestates_save_rollback_buffer(buffer, len, checksum, frame);
+    rollback_save_full = 0;
+    return result;
+}
+
 int savestates_load_rollback_buffer(unsigned char *buffer, int len)
 {
     int result;
@@ -2716,6 +2795,7 @@ int savestates_load_rollback_buffer(unsigned char *buffer, int len)
     if (result)
     {
         main_rollback_capture_load_probe();
+        ++rollback_load_counter;
     }
     rollback_load_buffer = NULL;
     rollback_load_buffer_size = 0;

--- a/Source/3rdParty/mupen64plus-core/src/main/savestates.h
+++ b/Source/3rdParty/mupen64plus-core/src/main/savestates.h
@@ -37,10 +37,25 @@ typedef enum _savestates_type
     savestates_type_unknown,
     savestates_type_m64p,
     savestates_type_pj64_zip,
-    savestates_type_pj64_unc
+    savestates_type_pj64_unc,
+    savestates_type_rollback_buffer /* spectate keyframe: load the stashed pending buffer */
 } savestates_type;
 
 savestates_job savestates_get_job(void);
+int savestates_get_rollback_load_counter(void);
+/* Spectate keyframe deferred rollback-buffer load (drained at a safe interrupt boundary).
+ * ROLLBACK_LOAD_DEFER_SENTINEL is passed in m64p_rollback_state.checksum to request it. */
+#define ROLLBACK_LOAD_DEFER_SENTINEL 0x44454645 /* 'DEFE' */
+int  savestates_has_pending_rollback_load(void);
+void savestates_set_pending_rollback_load(unsigned char* buffer, int len);
+int  savestates_run_pending_rollback_load(void);
+/* Spectate keyframe FULL save: same memory-buffer mechanism as a rollback save, but the
+ * buffer is a complete normal-format savestate (TLB LUT included, buffer zeroed) — for a
+ * cold spectator to load via the normal path, not a stripped rollback reload of the same
+ * machine. Requested by passing ROLLBACK_SAVE_FULL_SENTINEL in m64p_rollback_state.checksum
+ * (checksum is an output of the save, so it's free to overload as an input flag). */
+#define ROLLBACK_SAVE_FULL_SENTINEL 0x46554c4c /* 'FULL' */
+int  savestates_save_full_buffer(unsigned char **buffer, int *len, int *checksum, int frame);
 void savestates_set_job(savestates_job j, savestates_type t, const char *fn);
 void savestates_request_rollback_save(void);
 void savestates_init(void);

--- a/Source/RMG-Core/Emulation.cpp
+++ b/Source/RMG-Core/Emulation.cpp
@@ -23,10 +23,15 @@
 #include "File.hpp"
 #include "Rom.hpp"
 #include "rmgk_gekko.hpp"
+#include "n02_client.h"
 
 #include "m64p/Api.hpp"
 
 #include <cstdlib>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <sstream>
 #include <vector>
 
 // Windows/POSIX dynamic loading
@@ -255,6 +260,37 @@ static void FrameCallback(unsigned int frameIndex)
 #endif
 }
 
+// Spectate keyframe restore: a savestate the spectator must load before consuming any
+// recorded input, so its replay starts from the broadcaster's snapshot (frame F) rather
+// than boot. Staged from the UI thread (CoreStageSpectateKeyframe); loaded exactly once
+// on the emulation thread in the PIF sync below — the rollback load is synchronous, so it
+// must run on the emulation thread, not cross-thread from the UI.
+static std::mutex          s_SpectateKeyframeMutex;
+static std::vector<unsigned char> s_SpectateKeyframeBuf;
+static int                 s_SpectateKeyframeFrame = -1;
+static bool                s_SpectateKeyframeStaged = false;
+static bool                s_SpectateKeyframeLoaded = false;
+
+// Spectate keyframe divergence probe (diagnostic): after loading a keyframe, hash the
+// just-restored state (= the broadcaster's S(frame)) and the state at the start of each
+// of the next frames the spectator replays, dumping them to <prefix>_spectate.log so
+// they can be diffed against the broadcaster's per-frame host probe to find the first
+// divergent frame. All probe state below is touched only on the emulation thread.
+// -1 = inactive; 1..N = how many replayed frames still to hash.
+static int                 s_SpectateProbeSeq = -1;
+static int                 s_SpectateProbeFrameBase = -1;
+static std::vector<unsigned char> s_SpectateProbeScratch;
+// Diagnostic: hash of the spectator's state at the moment the deferred keyframe load was
+// staged (pre-jump). Compared at seq 0 to tell "load never drained" (resaved==prejump)
+// from "load landed" (resaved==kfbuf).
+static uint64_t            s_SpectatePreJumpHash = 0;
+// Companion to the state probe: logs the actual controller input the spectator APPLIES
+// each frame after the keyframe load, so it can be diffed against the broadcaster's
+// recorded krec input per frame. Tells us whether the boundary divergence is an input
+// misalignment (inputs differ / are shifted) or hidden state (inputs identical but the
+// state still forks). -1 = inactive; 0..N = frames applied since load.
+static int                 s_SpectateInputProbeCount = -1;
+
 // Kaillera PIF sync callback (called from mupen64plus-core after netplay sync)
 static void KailleraPifSyncCallback(struct pif* pif)
 {
@@ -274,6 +310,12 @@ static void KailleraPifSyncCallback(struct pif* pif)
         return; // Invalid player number
     }
 
+    // Playback/spectate has no local player: every player's input comes from the krec.
+    // In this mode we must NEVER read or inject this machine's physical controller —
+    // doing so was overriding the recorded input with the viewer's idle joystick and
+    // desyncing the replay. Live netplay (false) still submits the local controller.
+    const bool inPlayback = CoreIsKailleraPlaybackMode();
+
     // Check if this is a controller read command for channel 0 (local player)
     // We only want to sync on actual input reads, not status queries or other commands
     bool isControllerRead = (pif_channel_has_command(pif->channels[0]) &&
@@ -285,13 +327,136 @@ static void KailleraPifSyncCallback(struct pif* pif)
         // First controller read this frame - read local input and sync with Kaillera
         s_SyncedThisFrame = true;  // Mark as synced BEFORE calling Kaillera
 
-        // Read 4-byte controller response from local controller
-        // N64 controller format: [buttons_hi][buttons_lo][x_axis][y_axis]
-        uint8_t* rx = pif->channels[0].rx_buf;
-        uint32_t local_input = (rx[0] << 24) | (rx[1] << 16) | (rx[2] << 8) | rx[3];
+        // Spectate keyframe restore: the first controller read after a keyframe is
+        // staged, jump to the broadcaster's snapshot (frame F) before consuming any
+        // recorded input. The load must NOT happen synchronously here — this runs inside
+        // an SI DMA (dma_si_read -> update_pif_ram -> sync callback), and a full machine
+        // load mid-SI / mid-dynarec-block leaves the half-finished SI completion and the
+        // rest of the current block running on top of the restored state, desyncing at
+        // F+1. Instead defer it: the core performs the load at its next safe interrupt
+        // boundary (gen_interrupt), exactly like a normal savestate load, then the game
+        // re-dispatches cleanly from the restored PC and frame F's own read consumes
+        // krec[F]. (One controller poll per frame is assumed: gen_interrupt fires between
+        // this pre-load read and the next read, so the load is done by then.)
+        {
+            std::lock_guard<std::mutex> kfLock(s_SpectateKeyframeMutex);
+            // Wait until the krec tail has actually arrived (>=1 indexed input record)
+            // before loading. The server slices the tail to start at the keyframe frame F,
+            // so frameIndex[0] IS frame F; if we loaded before the tail arrived we'd have
+            // nothing to realign the reader to. Until then player_MPV idles at the live
+            // edge (returns 0, consumes nothing), so no krec is wasted by waiting.
+            if (s_SpectateKeyframeStaged && !s_SpectateKeyframeLoaded && !s_SpectateKeyframeBuf.empty() &&
+                n02::playbackGetTotalFrames() > 0) {
+                CoreRollbackState kfState{};
+                kfState.buffer = s_SpectateKeyframeBuf.data();
+                kfState.len    = static_cast<int>(s_SpectateKeyframeBuf.size());
+                kfState.frame  = s_SpectateKeyframeFrame;
+                const bool deferOk = CoreRollbackLoadGameStateDeferred(kfState);
+                s_SpectateKeyframeLoaded = true;
 
+                // Realign the krec reader to frame F. The ROM boot polls controllers and
+                // consumes krec records before this load lands, advancing pos past F; seek
+                // back to index 0 (= frame F) so the first post-load read consumes krec[F],
+                // not a later record. This is the actual fix for the post-keyframe desync:
+                // the load restored frame F's state correctly, but the inputs were shifted.
+                const bool seekOk = n02::playbackSeekToFrame(0);
+
+                // Arm the verification probe. seq 0 = the first post-load read (frame F),
+                // which re-saves the just-restored state and should match the broadcaster's
+                // frame-F hash; seq k = after k replayed frames.
+                s_SpectateProbeFrameBase = s_SpectateKeyframeFrame;
+                s_SpectateProbeScratch.assign(s_SpectateKeyframeBuf.size() + 65536, 0);
+                s_SpectateProbeSeq = 0;
+
+                // Capture the pre-jump state hash (the load is deferred, so the machine is
+                // still on its own timeline right now). At seq 0 we compare the re-saved
+                // hash to BOTH this and the keyframe buffer: resaved==prejump => the load
+                // never drained; resaved==kfbuf => it landed cleanly.
+                s_SpectatePreJumpHash = 0;
+                {
+                    CoreRollbackState pj{};
+                    if (CoreRollbackSaveGameStateInto(pj, s_SpectateProbeScratch.data(),
+                                                      static_cast<int>(s_SpectateProbeScratch.size()),
+                                                      s_SpectateKeyframeFrame)) {
+                        s_SpectatePreJumpHash = rmgk_gekko::hash_bytes(pj.buffer,
+                                                    static_cast<size_t>(pj.len));
+                    }
+                    std::ostringstream sc;
+                    sc << "spectate_stage frame=" << s_SpectateKeyframeFrame
+                       << " kflen=" << s_SpectateKeyframeBuf.size()
+                       << " prejump_hash=" << std::hex << s_SpectatePreJumpHash << std::dec
+                       << " tail_frames=" << n02::playbackGetTotalFrames()
+                       << " defer_ok=" << (deferOk ? 1 : 0)
+                       << " seek_ok=" << (seekOk ? 1 : 0);
+                    rmgk_gekko::write_spectate_probe(sc.str());
+                }
+                s_SpectateInputProbeCount = 0;
+
+                // Don't consume a krec record on this pre-load read; clear the per-frame
+                // sync flag so frame F's own read (after the deferred load lands) consumes
+                // krec[F].
+                s_SyncedThisFrame = false;
+                return;
+            }
+        }
+
+        // Divergence probe seq 1..N: each subsequent frame's first controller read runs
+        // at the start of that frame, i.e. AFTER the previous frame fully advanced — so
+        // re-saving here fingerprints the spectator's state at the start of replayed
+        // frame (base + seq), comparable to the broadcaster's host probe for that frame.
+        // A mismatch starting at base+1 means the very first replayed input is wrong
+        // (boundary alignment); a mismatch only after many clean frames means a slow
+        // reseed from state the savestate doesn't carry.
+        if (s_SpectateProbeSeq >= 0 && s_SpectateProbeSeq <= 30) {
+            const int probeFrame = s_SpectateProbeFrameBase + s_SpectateProbeSeq;
+            CoreRollbackState probe{};
+            if (CoreRollbackSaveGameStateInto(probe, s_SpectateProbeScratch.data(),
+                                              static_cast<int>(s_SpectateProbeScratch.size()), probeFrame)) {
+                const uint64_t h = rmgk_gekko::hash_bytes(probe.buffer, static_cast<size_t>(probe.len));
+                std::ostringstream stream;
+                stream << "spectate_probe side=spec frame=" << probeFrame
+                       << " hash=" << std::hex << h << std::dec
+                       << " len=" << probe.len;
+                rmgk_gekko::write_spectate_probe(stream.str());
+
+                // DECISIVE load-landed check: seq 0 is the first read after the deferred
+                // keyframe load should have drained at gen_interrupt. If the load landed,
+                // re-saving here reproduces the keyframe buffer byte-for-byte (Phase 1
+                // idempotency), so resaved_hash == kfbuf_hash. If they differ, the load
+                // never executed (the spectator is still on its own boot/replay timeline).
+                if (s_SpectateProbeSeq == 0) {
+                    uint64_t kfHash = 0; size_t kfLen = 0;
+                    {
+                        std::lock_guard<std::mutex> kfLock(s_SpectateKeyframeMutex);
+                        kfLen = s_SpectateKeyframeBuf.size();
+                        if (kfLen > 0)
+                            kfHash = rmgk_gekko::hash_bytes(s_SpectateKeyframeBuf.data(), kfLen);
+                    }
+                    const char* verdict = (kfLen > 0 && kfHash == h) ? "landed"
+                                        : (h == s_SpectatePreJumpHash)  ? "NOT_DRAINED"
+                                        : "other";
+                    std::ostringstream lc;
+                    lc << "spectate_loadcheck frame=" << probeFrame
+                       << " kfbuf_hash=" << std::hex << kfHash
+                       << " resaved_hash=" << h
+                       << " prejump_hash=" << s_SpectatePreJumpHash << std::dec
+                       << " kflen=" << kfLen << " resavedlen=" << probe.len
+                       << " verdict=" << verdict;
+                    rmgk_gekko::write_spectate_probe(lc.str());
+                }
+            }
+            s_SpectateProbeSeq++;
+        }
+
+        // Live netplay submits THIS client's local controller in slot 0 and gets back
+        // all players' synced inputs. In playback/spectate slot 0 must stay zero so the
+        // krec fully populates the buffer — reading the local controller here is what
+        // drove the spectator's P1 with the viewer's joystick.
         uint32_t sync_buffer[MAX_PLAYERS] = {0};
-        sync_buffer[0] = local_input;
+        if (!inPlayback) {
+            uint8_t* rx = pif->channels[0].rx_buf;
+            sync_buffer[0] = (rx[0] << 24) | (rx[1] << 16) | (rx[2] << 8) | rx[3];
+        }
 
         // Synchronize with Kaillera - this must be called exactly ONCE per emulator frame
         int ret = CoreModifyKailleraPlayValues(sync_buffer, sizeof(uint32_t));
@@ -314,17 +479,39 @@ static void KailleraPifSyncCallback(struct pif* pif)
         }
 
         if (ret == 0) {
-            // Frame delay period - n02 returns 0 while buffering initial frames
-            // Use cached input from previous sync (or zeros if none yet)
-            return;
-        }
+            // No fresh synced input this frame. Live netplay: frame-delay buffering —
+            // return and let the previous cached input stand. Playback/spectate: the
+            // next krec record hasn't arrived yet (live edge); do NOT return, because the
+            // viewer's physical controller is still sitting in PIF RAM and would drive
+            // this frame. Fall through so the PIF write re-applies the last cached krec
+            // input (or forced neutral) instead of the local controller.
+            if (!inPlayback) {
+                return;
+            }
+        } else {
+            int num_received = ret / sizeof(uint32_t);
 
-        int num_received = ret / sizeof(uint32_t);
+            // Cache synced results for subsequent polls this frame and for writing to PIF
+            s_CachedNumReceived = num_received;
+            for (int i = 0; i < MAX_PLAYERS; i++) {
+                s_CachedSyncBuffer[i] = sync_buffer[i];
+            }
 
-        // Cache synced results for subsequent polls this frame and for writing to PIF
-        s_CachedNumReceived = num_received;
-        for (int i = 0; i < MAX_PLAYERS; i++) {
-            s_CachedSyncBuffer[i] = sync_buffer[i];
+            // Spectate input probe: log the input the spectator actually applies this
+            // frame so it lines up with the broadcaster's recorded krec bytes.
+            if (s_SpectateInputProbeCount >= 0 && s_SpectateInputProbeCount <= 30 && num_received > 0) {
+                std::ostringstream istream;
+                istream << "spectate_input side=spec frame=" << (s_SpectateProbeFrameBase + s_SpectateInputProbeCount)
+                        << " mode=" << n02::getActiveMode()
+                        << " ipb=" << (inPlayback ? 1 : 0);
+                for (int p = 0; p < num_received && p < 2; p++) {
+                    char buf[16];
+                    snprintf(buf, sizeof(buf), " p%d=%08x", p, s_CachedSyncBuffer[p]);
+                    istream << buf;
+                }
+                rmgk_gekko::write_spectate_probe(istream.str());
+                s_SpectateInputProbeCount++;
+            }
         }
     }
 
@@ -363,6 +550,13 @@ static void KailleraPifSyncCallback(struct pif* pif)
                     rx[2] = (s_CachedSyncBuffer[i] >> 8) & 0xFF;
                     rx[3] = s_CachedSyncBuffer[i] & 0xFF;
                 }
+                else if (inPlayback && pif->channels[i].rx_buf != NULL) {
+                    // Playback with no synced krec input yet: force neutral so the
+                    // viewer's local controller (already written here by the input
+                    // plugin) can never drive the replay.
+                    uint8_t* rx = pif->channels[i].rx_buf;
+                    rx[0] = rx[1] = rx[2] = rx[3] = 0;
+                }
             }
             else if (cmd == JCMD_PAK_READ && pif->channels[i].rx_buf != NULL) {
                 // No controller pak present
@@ -375,6 +569,34 @@ static void KailleraPifSyncCallback(struct pif* pif)
         }
     }
 #endif // NETPLAY
+}
+
+CORE_EXPORT void CoreStageSpectateKeyframe(const unsigned char* data, int len, int frame)
+{
+    // UI thread: stage a savestate for the spectator's emulation to restore on its
+    // emulation thread before the first recorded input is consumed (see the PIF sync
+    // callback). Stage BEFORE the spectate emulation starts so the load wins the race.
+    std::lock_guard<std::mutex> lock(s_SpectateKeyframeMutex);
+    if (data != nullptr && len > 0)
+        s_SpectateKeyframeBuf.assign(data, data + len);
+    else
+        s_SpectateKeyframeBuf.clear();
+    s_SpectateKeyframeFrame  = frame;
+    s_SpectateKeyframeStaged = (data != nullptr && len > 0);
+    s_SpectateKeyframeLoaded = false;
+}
+
+CORE_EXPORT void CoreClearSpectateKeyframe(void)
+{
+    std::lock_guard<std::mutex> lock(s_SpectateKeyframeMutex);
+    s_SpectateKeyframeBuf.clear();
+    s_SpectateKeyframeFrame  = -1;
+    s_SpectateKeyframeStaged = false;
+    s_SpectateKeyframeLoaded = false;
+    // Disarm the divergence probe so a partial window can't fire into a later session.
+    s_SpectateProbeSeq        = -1;
+    s_SpectateProbeFrameBase  = -1;
+    s_SpectateInputProbeCount = -1;
 }
 
 //

--- a/Source/RMG-Core/Emulation.cpp
+++ b/Source/RMG-Core/Emulation.cpp
@@ -23,7 +23,9 @@
 #include "File.hpp"
 #include "Rom.hpp"
 #include "rmgk_gekko.hpp"
+#ifdef RMGK_HAVE_P2P_TRANSPORT
 #include "n02_client.h"
+#endif
 
 #include "m64p/Api.hpp"
 
@@ -345,6 +347,7 @@ static void KailleraPifSyncCallback(struct pif* pif)
             // so frameIndex[0] IS frame F; if we loaded before the tail arrived we'd have
             // nothing to realign the reader to. Until then player_MPV idles at the live
             // edge (returns 0, consumes nothing), so no krec is wasted by waiting.
+#ifdef RMGK_HAVE_P2P_TRANSPORT
             if (s_SpectateKeyframeStaged && !s_SpectateKeyframeLoaded && !s_SpectateKeyframeBuf.empty() &&
                 n02::playbackGetTotalFrames() > 0) {
                 CoreRollbackState kfState{};
@@ -398,6 +401,7 @@ static void KailleraPifSyncCallback(struct pif* pif)
                 s_SyncedThisFrame = false;
                 return;
             }
+#endif
         }
 
         // Divergence probe seq 1..N: each subsequent frame's first controller read runs
@@ -502,7 +506,9 @@ static void KailleraPifSyncCallback(struct pif* pif)
             if (s_SpectateInputProbeCount >= 0 && s_SpectateInputProbeCount <= 30 && num_received > 0) {
                 std::ostringstream istream;
                 istream << "spectate_input side=spec frame=" << (s_SpectateProbeFrameBase + s_SpectateInputProbeCount)
+#ifdef RMGK_HAVE_P2P_TRANSPORT
                         << " mode=" << n02::getActiveMode()
+#endif
                         << " ipb=" << (inPlayback ? 1 : 0);
                 for (int p = 0; p < num_received && p < 2; p++) {
                     char buf[16];

--- a/Source/RMG-Core/Emulation.cpp
+++ b/Source/RMG-Core/Emulation.cpp
@@ -837,6 +837,17 @@ CORE_EXPORT bool CoreStartEmulation(std::filesystem::path n64rom, std::filesyste
             {
                 error += m64p::Core.ErrorMessage(m64p_ret);
             }
+
+            // A plugin fatal error at startup is almost always the video plugin
+            // failing to initialize — most often an OpenGL version / driver
+            // problem (the raw message is opaque). Point the user at the cause.
+            if (error.find("plugin function returned a fatal error") != std::string::npos)
+            {
+                error += "  This usually means the graphics plugin couldn't start — "
+                         "often an outdated or unsupported graphics driver (GLideN64 needs "
+                         "OpenGL 3.3+). Update your GPU driver, or pick a different video "
+                         "plugin in Settings.";
+            }
         }
     }
 

--- a/Source/RMG-Core/Emulation.hpp
+++ b/Source/RMG-Core/Emulation.hpp
@@ -69,4 +69,11 @@ bool CoreIsSynchronizedNetplayActive(void);
 // used for synchronization in netplay/Kaillera
 int CoreGetCurrentFrameCount(void);
 
+// Spectate keyframe restore. Stage a savestate (raw rollback-state bytes) for the
+// spectator's emulation to load on its emulation thread before it consumes the first
+// recorded input, so its replay starts at the broadcaster's snapshot (frame) instead
+// of boot. Stage BEFORE the spectate emulation starts. Clear when not spectating.
+void CoreStageSpectateKeyframe(const unsigned char* data, int len, int frame);
+void CoreClearSpectateKeyframe(void);
+
 #endif // CORE_EMULATION_HPP

--- a/Source/RMG-Core/RollbackNetcode.cpp
+++ b/Source/RMG-Core/RollbackNetcode.cpp
@@ -50,6 +50,42 @@ CORE_EXPORT bool CoreRollbackSaveGameStateInto(CoreRollbackState& state, unsigne
     return true;
 }
 
+// Must match ROLLBACK_SAVE_FULL_SENTINEL in mupen64plus-core savestates.h. Passed in the
+// (save-output) checksum field to request a FULL normal-format savestate (TLB LUT included,
+// buffer zeroed) instead of the stripped rollback variant.
+static const int kRollbackSaveFullSentinel = 0x46554c4c; /* 'FULL' */
+
+CORE_EXPORT bool CoreRollbackSaveFullStateInto(CoreRollbackState& state, unsigned char* buffer, int capacity, int frame)
+{
+    std::string error;
+    m64p_error ret;
+    m64p_rollback_state coreState = {};
+
+    if (!m64p::Core.IsHooked())
+    {
+        return false;
+    }
+
+    coreState.frame = frame;
+    coreState.buffer = buffer;
+    coreState.len = capacity;
+    coreState.checksum = kRollbackSaveFullSentinel;
+    ret = m64p::Core.DoCommand(M64CMD_ROLLBACK_SAVE_STATE, 0, &coreState);
+    if (ret != M64ERR_SUCCESS)
+    {
+        error = "CoreRollbackSaveFullStateInto DoCommand(M64CMD_ROLLBACK_SAVE_STATE) Failed: ";
+        error += m64p::Core.ErrorMessage(ret);
+        CoreSetError(error);
+        return false;
+    }
+
+    state.buffer = coreState.buffer;
+    state.len = coreState.len;
+    state.checksum = coreState.checksum;
+    state.frame = frame;
+    return true;
+}
+
 CORE_EXPORT bool CoreRollbackLoadGameState(const CoreRollbackState& state)
 {
     std::string error;
@@ -69,6 +105,38 @@ CORE_EXPORT bool CoreRollbackLoadGameState(const CoreRollbackState& state)
     if (ret != M64ERR_SUCCESS)
     {
         error = "CoreRollbackLoadGameState DoCommand(M64CMD_ROLLBACK_LOAD_STATE) Failed: ";
+        error += m64p::Core.ErrorMessage(ret);
+        CoreSetError(error);
+        return false;
+    }
+
+    return true;
+}
+
+// Must match ROLLBACK_LOAD_DEFER_SENTINEL in mupen64plus-core savestates.h. Passed in the
+// (load-unused) checksum field to tell the core to defer the load to its next safe
+// interrupt boundary instead of loading synchronously.
+static const int kRollbackLoadDeferSentinel = 0x44454645; /* 'DEFE' */
+
+CORE_EXPORT bool CoreRollbackLoadGameStateDeferred(const CoreRollbackState& state)
+{
+    std::string error;
+    m64p_error ret;
+    m64p_rollback_state coreState = {};
+
+    if (!m64p::Core.IsHooked())
+    {
+        return false;
+    }
+
+    coreState.buffer = state.buffer;
+    coreState.len = state.len;
+    coreState.checksum = kRollbackLoadDeferSentinel;
+    coreState.frame = state.frame;
+    ret = m64p::Core.DoCommand(M64CMD_ROLLBACK_LOAD_STATE, 0, &coreState);
+    if (ret != M64ERR_SUCCESS)
+    {
+        error = "CoreRollbackLoadGameStateDeferred DoCommand(M64CMD_ROLLBACK_LOAD_STATE) Failed: ";
         error += m64p::Core.ErrorMessage(ret);
         CoreSetError(error);
         return false;

--- a/Source/RMG-Core/RollbackNetcode.hpp
+++ b/Source/RMG-Core/RollbackNetcode.hpp
@@ -139,7 +139,17 @@ using CoreRollbackInputCallback = int (*)(void* values, int size, int players);
 
 bool CoreRollbackSaveGameState(CoreRollbackState& state, int frame);
 bool CoreRollbackSaveGameStateInto(CoreRollbackState& state, unsigned char* buffer, int capacity, int frame);
+// Like CoreRollbackSaveGameStateInto but produces a FULL normal-format savestate (TLB LUT
+// included, buffer zeroed) instead of the stripped rollback variant. Use for the spectate
+// keyframe so a cold spectator can load a complete state via the normal path. Safe to call
+// at GekkoNet's frame-aligned save point — it's read-only on the device and calls no plugins.
+bool CoreRollbackSaveFullStateInto(CoreRollbackState& state, unsigned char* buffer, int capacity, int frame);
 bool CoreRollbackLoadGameState(const CoreRollbackState& state);
+// Like CoreRollbackLoadGameState but the core performs the load at its next safe interrupt
+// boundary instead of synchronously. Use this when calling from inside the emulation loop
+// (e.g. the PIF/SI callback), where an immediate full-state load would corrupt the
+// in-flight SI/dynarec operation. The state buffer must remain valid until the next frame.
+bool CoreRollbackLoadGameStateDeferred(const CoreRollbackState& state);
 void CoreRollbackFreeGameState(CoreRollbackState& state);
 bool CoreRollbackAdvanceFrame(void);
 bool CoreRollbackSampleInput(void* values, int size, int players);

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -32,6 +32,7 @@
 #include <atomic>
 #include <chrono>
 #include <ctime>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -198,6 +199,34 @@ long long g_GekkoLastLoadStateUs = 0;
 long long g_GekkoLastSaveStateUs = 0;
 long long g_GekkoLastRunFrameUs = 0;
 long long g_GekkoLastPendingSaveUs = 0;
+
+// --- Spectate keyframe capture-and-hold (broadcaster side) ---
+// The UI requests a keyframe; we snapshot the live frame's state, then HOLD it until
+// the recording confirms that frame (flushes it to the krec, past the rollback
+// horizon) with no rollback having touched frame <= it since the snapshot. Only then
+// is it a state a spectator can restore and replay the confirmed krec from without
+// desyncing. The snapshot is taken right after the live frame's input is latched into
+// PIF RAM, so its "next" input to apply is the following frame — hence the replay
+// frame the spectator starts at is the captured frame + this offset. We snapshot via
+// GekkoNet's own per-frame save (the safe VI-boundary point), whose state is "before
+// frame F's input" — the rollback load+replay convention — so the spectator replays
+// from frame F itself (offset 0). If testing reveals a 1-frame misalignment, nudge this.
+constexpr int kKeyframeReplayFrameOffset = 0;
+std::atomic<bool> g_GekkoKeyframeRequested{false};
+bool g_GekkoKeyframePending = false;
+int  g_GekkoKeyframePendingLiveFrame = -1; // the live frame F we snapshotted (confirm when flushed)
+std::vector<unsigned char> g_GekkoKeyframePendingBuf;
+std::mutex g_GekkoKeyframeReadyMutex;
+bool g_GekkoKeyframeReady = false;
+int  g_GekkoKeyframeReadyFrame = -1; // krec frame the spectator replays from (F + offset)
+std::vector<unsigned char> g_GekkoKeyframeReadyBuf;
+
+// Spectate keyframe divergence probe (diagnostic): once a keyframe is captured, log a
+// content hash of the broadcaster's confirmed state for the keyframe frame and the next
+// kSpectateProbeWindow frames, so they can be diffed against the spectator's replayed-
+// state hashes (see Emulation.cpp) to find the first divergent frame. -1 = inactive.
+constexpr int kSpectateProbeWindow = 30;
+int g_GekkoSpectateProbeStartFrame = -1;
 rmgk_gekko::InputProvider g_GekkoDebugInputProvider = nullptr;
 rmgk_gekko::FrameCallback g_GekkoDebugBeginFrame = nullptr;
 rmgk_gekko::FrameCallback g_GekkoDebugEndFrame = nullptr;
@@ -621,6 +650,56 @@ bool save_gekko_state(const PendingGekkoSave& save)
                << " checksum=" << static_cast<unsigned int>(state.checksum)
                << " elapsed_us=" << g_GekkoLastSaveStateUs;
         write_gekko_log(stream.str());
+    }
+
+    // Spectate keyframe: when the UI asked for one and we aren't already holding a snapshot,
+    // capture a FULL normal-format savestate of THIS frame (not GekkoNet's stripped rollback
+    // save in save.state). A cold spectator must load a complete state via the normal path;
+    // the rollback variant omits the TLB LUT and isn't zeroed (fine for a warm same-machine
+    // reload, wrong for a cold join). Taken here at the same frame-aligned VI boundary GekkoNet
+    // just saved at, so it stays aligned with the krec. The full save is read-only on the
+    // device and calls no plugins (verified in savestates_save_m64p), so it cannot disturb the
+    // live rollback. Core mallocs the buffer; we copy it out and free it. HOLD the snapshot —
+    // it's only committed once the recording flushes this frame to the krec without an
+    // intervening rollback, so the bytes match the confirmed krec a spectator replays.
+    if (g_GekkoKeyframeRequested.load(std::memory_order_relaxed) && !g_GekkoKeyframePending &&
+        save.frame >= 0 && state.len > 0 && save.state != nullptr)
+    {
+        CoreRollbackState fullState{};
+        if (CoreRollbackSaveFullStateInto(fullState, nullptr, 0, save.frame) &&
+            fullState.buffer != nullptr && fullState.len > 0)
+        {
+            g_GekkoKeyframePendingBuf.assign(fullState.buffer, fullState.buffer + fullState.len);
+            g_GekkoKeyframePendingLiveFrame = save.frame;
+            g_GekkoKeyframePending = true;
+            g_GekkoKeyframeRequested.store(false, std::memory_order_relaxed);
+            // Arm the divergence probe window for this keyframe's neighborhood.
+            g_GekkoSpectateProbeStartFrame = save.frame;
+            if (g_GekkoLogEnabled)
+            {
+                std::ostringstream stream;
+                stream << "keyframe snapshot frame=" << save.frame
+                       << " full_len=" << fullState.len << " rollback_len=" << state.len;
+                write_gekko_log(stream.str());
+            }
+        }
+        CoreRollbackFreeGameState(fullState);
+    }
+
+    // Spectate divergence probe (diagnostic): hash the broadcaster's confirmed state for
+    // the keyframe frame and the following frames so a spectator's replayed-state hashes
+    // can be diffed against them (see Emulation.cpp). Rollback can re-save a frame more
+    // than once; when reading the log, take the LAST hash logged per frame number.
+    if (g_GekkoSpectateProbeStartFrame >= 0 &&
+        save.frame >= g_GekkoSpectateProbeStartFrame &&
+        save.frame <= g_GekkoSpectateProbeStartFrame + kSpectateProbeWindow)
+    {
+        const uint64_t h = rmgk_gekko::hash_bytes(save.state, static_cast<size_t>(state.len));
+        std::ostringstream stream;
+        stream << "spectate_probe side=host frame=" << save.frame
+               << " hash=" << std::hex << h << std::dec
+               << " len=" << state.len;
+        rmgk_gekko::write_spectate_probe(stream.str());
     }
 
     return true;
@@ -1224,6 +1303,15 @@ int rollback_execute_begin_frame(void* userData)
             case GekkoLoadEvent:
                 summaryLoadCount++;
                 write_gekko_log("load_state begin");
+                // A rollback to frame <= a held keyframe means that frame may be
+                // re-simulated differently than we snapshotted — discard the pending
+                // keyframe so we never commit a state that diverges from the krec.
+                if (g_GekkoKeyframePending &&
+                    event->data.load.frame <= g_GekkoKeyframePendingLiveFrame)
+                {
+                    g_GekkoKeyframePending = false;
+                    write_gekko_log("keyframe discarded reason=rollback");
+                }
                 if (!load_gekko_state(event))
                 {
                     return 0;
@@ -2010,6 +2098,18 @@ CORE_EXPORT void rmgk_gekko::close_session()
     g_GekkoMaxObservedFrame = -1;
     g_GekkoExecuting.store(false, std::memory_order_relaxed);
     g_GekkoPendingSaves.clear();
+    // Reset spectate keyframe capture state for the next session.
+    g_GekkoKeyframeRequested.store(false, std::memory_order_relaxed);
+    g_GekkoKeyframePending = false;
+    g_GekkoKeyframePendingLiveFrame = -1;
+    g_GekkoKeyframePendingBuf.clear();
+    g_GekkoSpectateProbeStartFrame = -1;
+    {
+        std::lock_guard<std::mutex> lock(g_GekkoKeyframeReadyMutex);
+        g_GekkoKeyframeReady = false;
+        g_GekkoKeyframeReadyFrame = -1;
+        g_GekkoKeyframeReadyBuf.clear();
+    }
     g_GekkoDebugInputProvider = nullptr;
     g_GekkoDebugBeginFrame = nullptr;
     g_GekkoDebugEndFrame = nullptr;
@@ -2152,6 +2252,65 @@ CORE_EXPORT bool rmgk_gekko::synchronize_input(void* values, int size, int playe
                     break;
                 }
                 n02::recordingWriteInputs(it->second.data(), static_cast<int>(it->second.size()));
+                // Spectate input probe: log the confirmed krec input per frame (the exact
+                // bytes a spectator must replay) so it can be diffed against the
+                // spectator's applied input — revealing whether the boundary divergence is
+                // an input misalignment or hidden state.
+                if (g_GekkoSpectateProbeStartFrame >= 0 &&
+                    it->first >= g_GekkoSpectateProbeStartFrame &&
+                    it->first <= g_GekkoSpectateProbeStartFrame + kSpectateProbeWindow &&
+                    g_GekkoInputSize >= 4)
+                {
+                    // Label by krec RECORD INDEX (not the GekkoNet frame) so it shares the
+                    // spectator's coordinate system — the spectator counts records from 0.
+                    // The record for this frame was just written above, so its 0-based index
+                    // is recordingFrameCount() - 1.
+                    const int hostRecordIdx = n02::recordingFrameCount() - 1;
+                    std::ostringstream istream;
+                    istream << "spectate_input side=host frame=" << hostRecordIdx
+                            << " gekko=" << it->first;
+                    const std::vector<unsigned char>& in = it->second;
+                    const int players = static_cast<int>(in.size()) / g_GekkoInputSize;
+                    for (int p = 0; p < players && p < 2; p++)
+                    {
+                        const size_t off = static_cast<size_t>(p) * g_GekkoInputSize;
+                        char buf[32];
+                        snprintf(buf, sizeof(buf), " p%d=%02x%02x%02x%02x", p,
+                                 in[off], in[off + 1], in[off + 2], in[off + 3]);
+                        istream << buf;
+                    }
+                    rmgk_gekko::write_spectate_probe(istream.str());
+                }
+                // Confirm a held keyframe once its frame has flushed to the krec: it's
+                // now past the rollback horizon and survived any rollback (else the
+                // Load handler would have discarded it), so the snapshot matches the
+                // confirmed krec. Hand it to the UI thread to compress + upload.
+                if (g_GekkoKeyframePending && it->first == g_GekkoKeyframePendingLiveFrame)
+                {
+                    {
+                        std::lock_guard<std::mutex> lock(g_GekkoKeyframeReadyMutex);
+                        g_GekkoKeyframeReadyBuf = g_GekkoKeyframePendingBuf;
+                        // The spectator restores at the krec RECORD INDEX, not the GekkoNet
+                        // frame: the server (krecFrameOffset) and the spectator's frameIndex
+                        // both count 0x12 records from 0, but recording starts ~N frames into
+                        // the match (handshake/rollback-horizon warmup), so record_index =
+                        // gekko_frame - N. recordingWriteInputs just wrote THIS frame's record
+                        // (line above), so its 0-based index is recordingFrameCount() - 1.
+                        // Sending the gekko frame instead shifted the spectator's inputs by N.
+                        g_GekkoKeyframeReadyFrame =
+                            n02::recordingFrameCount() - 1 + kKeyframeReplayFrameOffset;
+                        g_GekkoKeyframeReady = true;
+                    }
+                    g_GekkoKeyframePending = false;
+                    if (g_GekkoLogEnabled)
+                    {
+                        std::ostringstream stream;
+                        stream << "keyframe confirmed live_frame=" << g_GekkoKeyframePendingLiveFrame
+                               << " replay_frame=" << g_GekkoKeyframeReadyFrame
+                               << " len=" << g_GekkoKeyframeReadyBuf.size();
+                        write_gekko_log(stream.str());
+                    }
+                }
                 g_GekkoFrameInputBuffer.erase(it);
             }
         }
@@ -2163,6 +2322,53 @@ CORE_EXPORT bool rmgk_gekko::synchronize_input(void* values, int size, int playe
     (void)size;
     (void)players;
     return true;
+}
+
+CORE_EXPORT void rmgk_gekko::request_keyframe()
+{
+    // Just arm the request; the emulation thread snapshots at its next save and
+    // commits once confirmed (see save_gekko_state + the recording flush).
+    g_GekkoKeyframeRequested.store(true, std::memory_order_relaxed);
+}
+
+CORE_EXPORT bool rmgk_gekko::take_keyframe(std::vector<unsigned char>& out, int& frame)
+{
+    std::lock_guard<std::mutex> lock(g_GekkoKeyframeReadyMutex);
+    if (!g_GekkoKeyframeReady)
+    {
+        return false;
+    }
+    out = std::move(g_GekkoKeyframeReadyBuf);
+    g_GekkoKeyframeReadyBuf.clear();
+    frame = g_GekkoKeyframeReadyFrame;
+    g_GekkoKeyframeReady = false;
+    return true;
+}
+
+CORE_EXPORT uint64_t rmgk_gekko::hash_bytes(const unsigned char* data, size_t len)
+{
+    uint64_t h = 1469598103934665603ull; // FNV-1a 64-bit offset basis
+    if (data != nullptr)
+    {
+        for (size_t i = 0; i < len; i++)
+        {
+            h ^= static_cast<uint64_t>(data[i]);
+            h *= 1099511628211ull; // FNV-1a 64-bit prime
+        }
+    }
+    return h;
+}
+
+CORE_EXPORT void rmgk_gekko::write_spectate_probe(const std::string& message)
+{
+    std::lock_guard<std::mutex> lock(g_GekkoLogMutex);
+    get_gekko_log_path(); // side effect: ensures g_GekkoLogPrefix / g_GekkoLogDirectory are set
+    const std::string filename = g_GekkoLogPrefix + "_spectate.log";
+    const std::filesystem::path path = g_GekkoLogDirectory.empty()
+        ? std::filesystem::path(filename)
+        : g_GekkoLogDirectory / filename;
+    std::ofstream file(path, std::ios::out | std::ios::app);
+    file << message << "\n";
 }
 
 CORE_EXPORT void rmgk_gekko::set_debug_hooks(InputProvider inputProvider, FrameCallback beginFrame, FrameCallback endFrame, void* userData)

--- a/Source/RMG-Core/rmgk_gekko.hpp
+++ b/Source/RMG-Core/rmgk_gekko.hpp
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 // Describes one remote peer in a lobby-driven session. Each non-local
 // slot needs its own endpoint — GekkoNet's gekko_add_actor takes a
@@ -63,6 +64,30 @@ class rmgk_gekko
     static void set_debug_frame_output(int flags);
     static bool debug_run_frame_with_inputs(const uint32_t* inputs, int players, int flags);
     static bool toggle_client_input_replay();
+
+    // --- Spectate keyframe capture (broadcaster side) ---
+    // Ask the engine to capture a savestate "keyframe" for the broadcast/spectate
+    // feature. Thread-safe; the snapshot is taken on the emulation thread for the
+    // current live frame, then HELD until the recording confirms that frame (flushes
+    // it to the krec, past the rollback horizon) with no rollback having touched it
+    // since — so the savestate is guaranteed to match the confirmed krec a spectator
+    // will replay from. A no-op if there's no active session.
+    static void request_keyframe();
+    // Thread-safe (call from the UI thread): if a confirmed keyframe is ready, move
+    // its raw savestate bytes into out, set frame to its krec frame index, and return
+    // true (clearing the ready slot). Returns false if none is ready.
+    static bool take_keyframe(std::vector<unsigned char>& out, int& frame);
+
+    // --- Spectate keyframe divergence probe (diagnostic) ---
+    // FNV-1a 64-bit content hash over raw bytes — a real fingerprint of a rollback
+    // state buffer. The core's own rollback "checksum" field is a stub (always 0), so
+    // we hash the bytes ourselves. Shared so the broadcaster and spectator hash
+    // identically; comparing the two pinpoints where a spectate replay diverges.
+    static uint64_t hash_bytes(const unsigned char* data, size_t len);
+    // Append one line to <prefix>_spectate.log (a sibling of the GekkoNet log),
+    // UNCONDITIONALLY (independent of the verbose-log toggle, since the spectator is
+    // never in a GekkoNet session). Thread-safe.
+    static void write_spectate_probe(const std::string& message);
 };
 
 #endif // RMGK_GEKKO_HPP

--- a/Source/RMG/OnScreenDisplay.cpp
+++ b/Source/RMG/OnScreenDisplay.cpp
@@ -71,6 +71,9 @@ static bool        l_KailleraPortLabelsEnabled = false;
 static int         l_KailleraPortLabelPlayerCount = 0;
 static std::array<std::string, 4> l_KailleraPortLabelPlayerNames;
 static constexpr std::array<float, 4> l_KailleraPortLabelCenterOffset720p = { 19.0f, 0.0f, -19.0f, -70.0f };
+// Big centered banner (e.g. "Stream is buffering...") drawn over everything while
+// a spectator fast-forwards toward a broadcast's live edge. Empty = hidden.
+static std::string l_CenterMessage;
 
 static float OnScreenDisplayEaseOutCubic(float t)
 {
@@ -284,6 +287,46 @@ static void OnScreenDisplayRenderKailleraPortLabels(void)
     ImGui::PopStyleColor(2);
 }
 
+// A large message box centered on screen, drawn over everything else. Used for
+// the spectate "Stream is buffering..." banner during fast-forward catch-up.
+static void OnScreenDisplayRenderCenterMessage(void)
+{
+    if (l_CenterMessage.empty())
+    {
+        return;
+    }
+
+    ImGuiIO& io = ImGui::GetIO();
+    // Size relative to the 4:3 content height, matching the port-label math so it
+    // scales with the window. Larger multiplier than port labels — this is a hero
+    // banner, not a per-port tag.
+    float contentHeight = io.DisplaySize.y;
+    if (io.DisplaySize.x <= io.DisplaySize.y * (4.0f / 3.0f))
+        contentHeight = io.DisplaySize.x * (3.0f / 4.0f);
+    const float baseScale = std::max(1.0f, contentHeight / 240.0f);
+    const float fontScale = (baseScale * 9.0f) / (l_BaseFontSize * std::max(l_MessageScale, 0.1f));
+    const ImVec2 padding(16.0f * baseScale, 11.0f * baseScale);
+
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.66f));
+    ImGui::PushStyleColor(ImGuiCol_Text,     ImVec4(l_TextRed, l_TextGreen, l_TextBlue, 1.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, padding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f * baseScale);
+
+    ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f),
+                            ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::Begin("Stream Buffering Banner", nullptr,
+        ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration |
+        ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoNav |
+        ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoFocusOnAppearing);
+    ImGui::SetWindowFontScale(fontScale);
+    ImGui::Text("%s", l_CenterMessage.c_str());
+    ImGui::SetWindowFontScale(1.0f);
+    ImGui::End();
+
+    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor(2);
+}
+
 //
 // Exported Functions
 //
@@ -325,6 +368,7 @@ void OnScreenDisplayShutdown(void)
     l_KailleraChatEnabled = true;
     l_KailleraPortLabelPlayerCount = 0;
     l_KailleraPortLabelPlayerNames = {};
+    l_CenterMessage.clear();
     l_Initialized     = false;
     l_RenderingPaused = false;
 }
@@ -549,6 +593,11 @@ void OnScreenDisplayClearKailleraPortLabels(void)
     l_KailleraPortLabelPlayerNames = {};
 }
 
+void OnScreenDisplaySetCenterMessage(const std::string& message)
+{
+    l_CenterMessage = message;
+}
+
 void OnScreenDisplayRender(void)
 {
     if (!l_Initialized || l_RenderingPaused)
@@ -602,7 +651,8 @@ void OnScreenDisplayRender(void)
     }
 
     const bool hasPortLabels = l_KailleraPortLabelsEnabled && l_KailleraPortLabelPlayerCount > 0;
-    const bool hasMessages = l_Enabled && (hasVisibleQueueMessage || l_InputPromptActive || hasPortLabels);
+    const bool hasCenterMessage = !l_CenterMessage.empty();
+    const bool hasMessages = l_Enabled && (hasVisibleQueueMessage || l_InputPromptActive || hasPortLabels || hasCenterMessage);
 
     if (!hasMessages)
     {
@@ -745,6 +795,7 @@ void OnScreenDisplayRender(void)
     ImGui::PopStyleColor(2);
 
     OnScreenDisplayRenderKailleraPortLabels();
+    OnScreenDisplayRenderCenterMessage();
 
     ImGui::Render();
 

--- a/Source/RMG/OnScreenDisplay.hpp
+++ b/Source/RMG/OnScreenDisplay.hpp
@@ -50,6 +50,10 @@ void OnScreenDisplaySetKailleraPortLabels(int playerCount, const std::array<std:
 // clears live Kaillera port labels
 void OnScreenDisplayClearKailleraPortLabels(void);
 
+// Sets a large message box centered on screen, drawn over everything (e.g. the
+// spectate "Stream is buffering..." banner). Pass an empty string to hide it.
+void OnScreenDisplaySetCenterMessage(const std::string& message);
+
 // renders the OSD
 void OnScreenDisplayRender(void);
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
@@ -12,7 +12,6 @@
 #include <QHBoxLayout>
 #include <QFormLayout>
 #include <QLineEdit>
-#include <QComboBox>
 #include <QSpinBox>
 #include <QCheckBox>
 #include <QPushButton>
@@ -20,19 +19,22 @@
 #include <QDialogButtonBox>
 #include <QSettings>
 #include <QFileInfo>
-#include <QVariantMap>
 
 using namespace UserInterface::Dialog;
 
 CreateRoomDialog::CreateRoomDialog(const QString& defaultUsername,
-                                   const QMap<QString, CoreRomSettings>& roms,
+                                   const QString& gameName, const QString& gameMd5,
                                    QWidget* parent)
     : QDialog(parent)
 {
     setWindowTitle("Create Room");
     setModal(true);
+    // The game comes from the lobby's shared picker, not a picker of our own.
+    m_romName = gameName;
+    m_romMd5  = gameMd5;
     buildUi(defaultUsername);
-    populateRoms(roms);
+    if (m_gameLabel)
+        m_gameLabel->setText(gameName.isEmpty() ? QStringLiteral("—") : gameName);
     loadDefaults();
     validateInput();
 }
@@ -51,10 +53,9 @@ void CreateRoomDialog::buildUi(const QString& defaultUsername)
         m_nameEdit->setPlaceholderText("My Room");
     form->addRow("Room name:", m_nameEdit);
 
-    m_romCombo = new QComboBox(this);
-    m_romCombo->setEditable(false);
-    m_romCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    form->addRow("Game:", m_romCombo);
+    m_gameLabel = new QLabel(this);
+    m_gameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    form->addRow("Game:", m_gameLabel);
 
     m_maxPlayersSpin = new QSpinBox(this);
     m_maxPlayersSpin->setRange(2, 4);
@@ -99,44 +100,8 @@ void CreateRoomDialog::buildUi(const QString& defaultUsername)
 
     // Validation hooks
     connect(m_nameEdit,      &QLineEdit::textChanged, this, &CreateRoomDialog::validateInput);
-    connect(m_romCombo,      QOverload<int>::of(&QComboBox::currentIndexChanged), this, &CreateRoomDialog::validateInput);
     connect(m_passwordCheck, &QCheckBox::toggled,     this, &CreateRoomDialog::onPasswordToggled);
     connect(m_passwordEdit,  &QLineEdit::textChanged, this, &CreateRoomDialog::validateInput);
-}
-
-void CreateRoomDialog::populateRoms(const QMap<QString, CoreRomSettings>& roms)
-{
-    m_romCombo->clear();
-    if (roms.isEmpty())
-    {
-        m_romCombo->addItem("No ROMs in your library — add some first");
-        m_romCombo->setEnabled(false);
-        return;
-    }
-
-    // Sort by display name for predictable ordering.
-    QList<QString> filePaths = roms.keys();
-    QMap<QString, QString> sortedByName; // name → file
-    for (const auto& file : filePaths)
-    {
-        const auto& settings = roms.value(file);
-        const QString display = displayGameName(QString::fromStdString(settings.GoodName), file);
-        // Append file path as suffix to keep duplicate display names unique.
-        sortedByName.insert(display + "\x01" + file, file);
-    }
-
-    for (auto it = sortedByName.constBegin(); it != sortedByName.constEnd(); ++it)
-    {
-        const QString file = it.value();
-        const auto& settings = roms.value(file);
-        const QString display = displayGameName(QString::fromStdString(settings.GoodName), file);
-
-        QVariantMap data;
-        data["name"] = display;
-        data["md5"]  = QString::fromStdString(settings.MD5);
-        data["file"] = file;
-        m_romCombo->addItem(display, data);
-    }
 }
 
 QString CreateRoomDialog::displayGameName(const QString& goodName, const QString& filePath)
@@ -167,7 +132,7 @@ void CreateRoomDialog::onPasswordToggled(bool enabled)
 void CreateRoomDialog::validateInput()
 {
     const QString name = m_nameEdit->text().trimmed();
-    const bool   hasRom = m_romCombo->isEnabled() && !m_romCombo->currentData().isNull();
+    const bool   hasRom = !m_romMd5.isEmpty();
     const bool passwordRequired = m_passwordCheck->isChecked();
     const QString pwd  = m_passwordEdit->text();
 
@@ -188,9 +153,7 @@ void CreateRoomDialog::onCreateClicked()
     // Capture form values. Delay/prediction stay at their loadDefaults()
     // values (or the struct defaults 2/7) — host adjusts in-room.
     m_name = m_nameEdit->text().trimmed();
-    const QVariantMap romData = m_romCombo->currentData().toMap();
-    m_romName    = romData.value("name").toString();
-    m_romMd5     = romData.value("md5").toString();
+    // m_romName / m_romMd5 were set from the lobby picker in the constructor.
     m_romRegion  = ""; // baked into the ROM; resolved later via md5 lookup
     m_maxPlayers = m_maxPlayersSpin->value();
     m_password   = m_passwordCheck->isChecked() ? m_passwordEdit->text() : QString();
@@ -213,7 +176,6 @@ void CreateRoomDialog::showCreateFailure(const QString& reason)
 void CreateRoomDialog::setFormEnabled(bool enabled)
 {
     m_nameEdit->setEnabled(enabled);
-    m_romCombo->setEnabled(enabled);
     m_maxPlayersSpin->setEnabled(enabled);
     m_passwordCheck->setEnabled(enabled);
     m_passwordEdit->setEnabled(enabled && m_passwordCheck->isChecked());
@@ -224,13 +186,6 @@ void CreateRoomDialog::loadDefaults()
 {
     QSettings s;
     s.beginGroup("Lobby/CreateRoom");
-    if (s.contains("Rom"))
-    {
-        const QString preferred = s.value("Rom").toString();
-        const int idx = m_romCombo->findText(preferred);
-        if (idx >= 0)
-            m_romCombo->setCurrentIndex(idx);
-    }
     if (s.contains("MaxPlayers")) m_maxPlayersSpin->setValue(s.value("MaxPlayers").toInt());
     // Seed the initial delay/prediction from the last in-room values the
     // host configured. The in-room view writes to the same keys.
@@ -243,7 +198,7 @@ void CreateRoomDialog::saveDefaults()
 {
     QSettings s;
     s.beginGroup("Lobby/CreateRoom");
-    s.setValue("Rom",        m_romName);
+    // The game selection is persisted by the lobby's shared picker, not here.
     s.setValue("MaxPlayers", m_maxPlayers);
     // Delay/prediction persistence moves to the in-room view; CreateRoom
     // only consumes those defaults, doesn't write them.

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
@@ -184,7 +184,7 @@ void CreateRoomDialog::setFormEnabled(bool enabled)
 
 void CreateRoomDialog::loadDefaults()
 {
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     if (s.contains("MaxPlayers")) m_maxPlayersSpin->setValue(s.value("MaxPlayers").toInt());
     // Seed the initial delay/prediction from the last in-room values the
@@ -196,7 +196,7 @@ void CreateRoomDialog::loadDefaults()
 
 void CreateRoomDialog::saveDefaults()
 {
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     // The game selection is persisted by the lobby's shared picker, not here.
     s.setValue("MaxPlayers", m_maxPlayers);

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
@@ -11,12 +11,8 @@
 
 #include <QDialog>
 #include <QString>
-#include <QMap>
-
-#include <RMG-Core/RomSettings.hpp>
 
 class QLineEdit;
-class QComboBox;
 class QSpinBox;
 class QCheckBox;
 class QPushButton;
@@ -34,8 +30,10 @@ class CreateRoomDialog : public QDialog
     Q_OBJECT
 
 public:
+    // The game is chosen in the lobby's shared picker and passed in here; this
+    // dialog shows it read-only and reports it back via romName()/romMd5().
     CreateRoomDialog(const QString& defaultUsername,
-                     const QMap<QString, CoreRomSettings>& roms,
+                     const QString& gameName, const QString& gameMd5,
                      QWidget* parent = nullptr);
     ~CreateRoomDialog() override = default;
 
@@ -70,14 +68,13 @@ private slots:
 
 private:
     void buildUi(const QString& defaultUsername);
-    void populateRoms(const QMap<QString, CoreRomSettings>& roms);
     void loadDefaults();
     void saveDefaults();
     void setFormEnabled(bool enabled);
 
     // UI — delay/prediction spinners live in the in-room view now, not here.
     QLineEdit*   m_nameEdit       = nullptr;
-    QComboBox*   m_romCombo       = nullptr;
+    QLabel*      m_gameLabel      = nullptr;   // read-only game from the lobby picker
     QSpinBox*    m_maxPlayersSpin = nullptr;
     QCheckBox*   m_passwordCheck  = nullptr;
     QLineEdit*   m_passwordEdit   = nullptr;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -392,6 +392,7 @@ void LobbyClient::handleEnvelope(const QJsonObject& env)
     else if (type == "QUICK_MATCH_STATUS")   handleQuickMatchStatus(data);
     else if (type == "SPECTATE_BEGIN")       handleSpectateBegin(data);
     else if (type == "SPECTATE_DATA")        handleSpectateData(data);
+    else if (type == "SPECTATE_KEYFRAME")    handleSpectateKeyframe(data);
     else if (type == "SPECTATE_END")         handleSpectateEnd(data);
     else if (type == "SPECTATE_FAIL")        handleSpectateFail(data);
     else qDebug() << "lobby: unknown message type" << type;
@@ -642,6 +643,47 @@ void LobbyClient::handleSpectateData(const QJsonObject& data)
     const int liveFrame = data.value("frame").toInt();
     if (!raw.isEmpty())
         emit spectateData(matchId, raw, liveFrame);
+}
+
+void LobbyClient::handleSpectateKeyframe(const QJsonObject& data)
+{
+    const quint64 matchId = static_cast<quint64>(data.value("matchId").toDouble());
+    const int frame      = data.value("frame").toInt();
+    const int chunkIndex = data.value("chunkIndex").toInt();
+    const int chunkCount = data.value("chunkCount").toInt();
+    const QByteArray raw = QByteArray::fromBase64(data.value("data").toString().toLatin1());
+    if (chunkCount <= 0 || chunkIndex < 0 || chunkIndex >= chunkCount)
+        return;
+
+    // (Re)start reassembly when a new keyframe appears. Chunks arrive in order over
+    // the WS, but track per-index seen flags so a stray/duplicate can't corrupt it.
+    if (m_kfRecvFrame != frame || m_kfRecvCount != chunkCount || m_kfRecvChunkSeen.size() != chunkCount)
+    {
+        m_kfRecvFrame = frame;
+        m_kfRecvCount = chunkCount;
+        m_kfRecvGot = 0;
+        m_kfRecvBuf.clear();
+        m_kfRecvChunkSeen = QList<bool>();
+        for (int i = 0; i < chunkCount; i++)
+            m_kfRecvChunkSeen.append(false);
+    }
+    if (!m_kfRecvChunkSeen[chunkIndex])
+    {
+        m_kfRecvChunkSeen[chunkIndex] = true;
+        m_kfRecvBuf.append(raw); // in-order append (server sends chunks sequentially)
+        m_kfRecvGot++;
+    }
+    if (m_kfRecvGot < m_kfRecvCount)
+        return;
+
+    const QByteArray full = m_kfRecvBuf;
+    const int doneFrame = m_kfRecvFrame;
+    m_kfRecvFrame = -1;
+    m_kfRecvCount = 0;
+    m_kfRecvGot = 0;
+    m_kfRecvBuf.clear();
+    m_kfRecvChunkSeen = QList<bool>();
+    emit spectateKeyframe(matchId, doneFrame, full);
 }
 
 void LobbyClient::handleSpectateEnd(const QJsonObject& data)
@@ -1227,6 +1269,29 @@ void LobbyClient::sendBroadcastData(quint64 matchId, const QByteArray& chunk, in
     d["data"]    = QString::fromLatin1(chunk.toBase64());
     d["frame"]   = liveFrame; // broadcaster's live krec frame after this chunk
     sendEnvelope("BROADCAST_DATA", d);
+}
+
+void LobbyClient::sendBroadcastKeyframe(quint64 matchId, const QByteArray& savestate, int frame)
+{
+    if (savestate.isEmpty())
+        return;
+    // Split into chunks so each BROADCAST_KEYFRAME message stays under the server's
+    // 1 MiB read limit (savestate is multi-MB even compressed). ~512 KiB raw per
+    // chunk → ~683 KiB base64, comfortably under the limit.
+    const int chunkBytes = 512 * 1024;
+    const int total = static_cast<int>((savestate.size() + chunkBytes - 1) / chunkBytes);
+    for (int i = 0; i < total; i++)
+    {
+        const int start = i * chunkBytes;
+        const int len = qMin(chunkBytes, static_cast<int>(savestate.size()) - start);
+        QJsonObject d;
+        d["matchId"]    = QJsonValue(qint64(matchId));
+        d["frame"]      = frame;
+        d["chunkIndex"] = i;
+        d["chunkCount"] = total;
+        d["data"]       = QString::fromLatin1(savestate.mid(start, len).toBase64());
+        sendEnvelope("BROADCAST_KEYFRAME", d);
+    }
 }
 
 void LobbyClient::sendBroadcastEnd(quint64 matchId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -792,6 +792,12 @@ bool LobbyClient::syncPrematchManifest(const QList<LobbyMatchPeer>& peers, int l
         return false;
     }
 
+    // Pre-match sync spins a nested event loop on the UI thread. Without a wall-
+    // clock cap, a peer that never answers (UDP blocked, crashed after
+    // MATCH_BEGIN, missing ROM) would hang the whole client forever — the bug
+    // that left users force-killing the window. Bail out gracefully after this.
+    const qint64 kPrematchSyncTimeoutMs = 10'000;
+
     LobbyMatchPeer local{};
     LobbyMatchPeer host{};
     bool foundLocal = false;
@@ -847,8 +853,14 @@ bool LobbyClient::syncPrematchManifest(const QList<LobbyMatchPeer>& peers, int l
                 << "cheats" << static_cast<qulonglong>(cheatCount)
                 << "peers" << pendingAcks.size();
 
+        const qint64 hostSyncDeadlineMs = QDateTime::currentMSecsSinceEpoch() + kPrematchSyncTimeoutMs;
         while (!pendingAcks.isEmpty())
         {
+            if (QDateTime::currentMSecsSinceEpoch() > hostSyncDeadlineMs)
+            {
+                error = QStringLiteral("Pre-match sync timed out — a player didn't respond (missing ROM or blocked connection).");
+                return false;
+            }
             QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
             for (const auto& peer : peers)
             {
@@ -910,8 +922,14 @@ bool LobbyClient::syncPrematchManifest(const QList<LobbyMatchPeer>& peers, int l
             << "hostEndpoint" << hostEndpoint.first.toString()
             << hostEndpoint.second;
 
+    const qint64 clientSyncDeadlineMs = QDateTime::currentMSecsSinceEpoch() + kPrematchSyncTimeoutMs;
     for (;;)
     {
+        if (QDateTime::currentMSecsSinceEpoch() > clientSyncDeadlineMs)
+        {
+            error = QStringLiteral("Pre-match sync timed out — never heard from the host.");
+            return false;
+        }
         QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
         if (!m_udp->waitForReadyRead(50))
             continue;
@@ -1150,6 +1168,17 @@ void LobbyClient::kickFromRoom(quint64 userId)
     QJsonObject d;
     d["userId"] = QJsonValue(qint64(userId));
     sendEnvelope("ROOM_KICK", d);
+}
+
+void LobbyClient::swapSeats(int slotA, int slotB)
+{
+    QJsonObject d;
+    d["slotA"] = slotA;
+    d["slotB"] = slotB;
+    // Host-only; the server validates (host, state == "waiting", valid slots),
+    // swaps the two seats and rebroadcasts ROOM_STATE so every seated client
+    // re-renders with the new P1-P4 order.
+    sendEnvelope("ROOM_SWAP_SLOTS", d);
 }
 
 void LobbyClient::requestPingProbe(quint64 targetUserId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -124,6 +124,10 @@ public:
     void startRoom();
     void kickFromRoom(quint64 userId);
 
+    // Host-only: swap two seats (P1-P4) to re-order players before the match.
+    // Server validates (host, waiting, valid slots) and rebroadcasts ROOM_STATE.
+    void swapSeats(int slotA, int slotB);
+
     // Host-only: change the room's rollback delay / prediction / pacing. The
     // *Auto flags tell the server whether delay/prediction are host-Auto-driven
     // so non-hosts can mirror the host's label (pacing has no Auto). Server must

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -156,6 +156,9 @@ public:
     // Broadcast (one player streams the live match's .krec up to the server).
     void sendBroadcastBegin(quint64 matchId);
     void sendBroadcastData(quint64 matchId, const QByteArray& chunk, int liveFrame); // raw krec bytes (base64'd) + broadcaster's live frame
+    // Upload a savestate keyframe (already compressed) for frame F. Split into chunks
+    // so each message stays under the server's per-message read limit.
+    void sendBroadcastKeyframe(quint64 matchId, const QByteArray& savestate, int frame);
     void sendBroadcastEnd(quint64 matchId);
 
     // Spectate (pull a broadcast match's krec stream back down).
@@ -207,6 +210,9 @@ signals:
     // Spectate stream (server → spectator). data carries decoded krec bytes.
     void spectateBegan(quint64 matchId);
     void spectateData(quint64 matchId, const QByteArray& data, int liveFrame);
+    // A reassembled savestate keyframe (still compressed) the spectator should restore
+    // at frame, before replaying the krec tail that follows in spectateData.
+    void spectateKeyframe(quint64 matchId, int frame, const QByteArray& savestate);
     void spectateEnded(quint64 matchId, const QString& reason);
     void spectateFailed(quint64 matchId, const QString& reason);
 
@@ -246,6 +252,7 @@ private:
     void handleQuickMatchStatus(const QJsonObject& data);
     void handleSpectateBegin(const QJsonObject& data);
     void handleSpectateData(const QJsonObject& data);
+    void handleSpectateKeyframe(const QJsonObject& data);
     void handleSpectateEnd(const QJsonObject& data);
     void handleSpectateFail(const QJsonObject& data);
 
@@ -263,6 +270,13 @@ private:
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_udpKeepaliveTimer = nullptr;
     bool m_inPrematchSync = false;
+
+    // Incoming spectate keyframe reassembly (chunked SPECTATE_KEYFRAME messages).
+    int        m_kfRecvFrame = -1;
+    int        m_kfRecvCount = 0;
+    int        m_kfRecvGot = 0;
+    QByteArray m_kfRecvBuf;
+    QList<bool> m_kfRecvChunkSeen;
 
     // Pending HELLO context
     QString m_pendingUsername;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyConnectDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyConnectDialog.cpp
@@ -102,13 +102,13 @@ void LobbyConnectDialog::onConnect()
 
 void LobbyConnectDialog::loadSettings()
 {
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     m_usernameEdit->setText(s.value("Lobby/Username").toString());
 }
 
 void LobbyConnectDialog::saveSettings()
 {
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     s.setValue("Lobby/Username", m_username);
 }
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -3440,12 +3440,13 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     // GekkoNet attempts to bind it. 100ms is plenty on Windows for an UDP
     // socket teardown to complete; without this delay the bind races.
     const QString gameName  = m_currentRoomGame;
+    const QString romFile   = localRomFile; // resolved above by MD5 — robust for off-database ROMs
     const int localPortInt  = int(localPort);
     const int slot          = local.slot;
     const int delay         = m_currentRoomDelay;
     const int prediction    = m_currentRoomPrediction;
-    QTimer::singleShot(100, this, [this, gameName, remotePeers, localPortInt, slot, delay, prediction]() {
-        emit matchReady(gameName, remotePeers, localPortInt, slot, delay, prediction);
+    QTimer::singleShot(100, this, [this, gameName, romFile, remotePeers, localPortInt, slot, delay, prediction]() {
+        emit matchReady(gameName, romFile, remotePeers, localPortInt, slot, delay, prediction);
     });
 }
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -243,6 +243,19 @@ namespace
         return c.fail;
     }
 
+    // Friendly label for an authoritative *room* state. Distinct from
+    // stateGlyph(), which maps per-user presence states ("playing", "in_room",
+    // …); the room state machine uses a different vocabulary ("waiting",
+    // "starting", "in_game", "finished") that stateGlyph would pass through raw.
+    QString roomStateLabel(const QString& state)
+    {
+        if (state == "waiting")  return "Waiting";
+        if (state == "starting") return "Starting";
+        if (state == "in_game")  return "In Game";
+        if (state == "finished") return "Finished";
+        return state;
+    }
+
     // Color for a presence/room state string (the values stateGlyph maps).
     QString stateHex(const QString& state, bool dark)
     {
@@ -2508,7 +2521,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     m_roomSubtitle->setText(QString("Hosted by %1  ·  %2 players max")
                                 .arg(hostName).arg(maxPlayers));
 
-    applyRoomStateBadge(stateGlyph(state), stateHex(state, isDarkTheme()));
+    applyRoomStateBadge(roomStateLabel(state), stateHex(state, isDarkTheme()));
 
     const QJsonArray players = roomState.value("players").toArray();
     QStringList metaParts;
@@ -2731,6 +2744,13 @@ void RollbackLobbyDialog::notifyEmulationStarted()
     if (!m_awaitingEmulationStart) return;
     m_awaitingEmulationStart = false;
     m_emulationActive = true;
+
+    // Emulation is live now, so retire the "Connecting…" transient that
+    // onMatchBegin painted over the badge. The room is in_game on the server;
+    // mirror that authoritative state (don't assume — read m_currentRoomState).
+    applyRoomStateBadge(roomStateLabel(m_currentRoomState),
+                        stateHex(m_currentRoomState, isDarkTheme()));
+
     if (m_currentMatchId == 0) return;
 
     {

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -48,6 +48,7 @@
 #include <QTreeWidget>
 #include <QHeaderView>
 #include <QTabWidget>
+#include <QTabBar>
 #include <QTextEdit>
 #include <QLineEdit>
 #include <QJsonArray>
@@ -62,6 +63,7 @@
 #include <QDateTime>
 #include <QShowEvent>
 #include <QCloseEvent>
+#include <QMouseEvent>
 #include <QTimer>
 #include <QFont>
 #include <QUrl>
@@ -103,6 +105,40 @@ void setAutoComboLabel(QComboBox* combo, int resolved)
     const int idx = combo->findData(0);
     if (idx >= 0) combo->setItemText(idx, QStringLiteral("Auto (%1 f)").arg(resolved));
 }
+
+// Tab bar where every tab is half the column wide: one tab → 50% (the right
+// half stays empty), two tabs → 50% each = 100%. So the "Lobby" tab keeps the
+// same width whether or not a "Room" tab is present. Never narrower than the
+// tab's own content, so labels never clip on a very narrow column.
+class HalfWidthTabBar : public QTabBar
+{
+public:
+    using QTabBar::QTabBar;
+protected:
+    QSize tabSizeHint(int index) const override
+    {
+        QSize hint = QTabBar::tabSizeHint(index);
+        const int avail = parentWidget() ? parentWidget()->width() : width();
+        if (avail > 0)
+            hint.setWidth(qMax(hint.width(), avail / 2));
+        return hint;
+    }
+};
+
+// QTabWidget that installs the HalfWidthTabBar. setTabBar()/tabBar() are
+// protected on QTabWidget, so the custom bar has to be wired up from inside a
+// subclass rather than after construction.
+class ChatTabWidget : public QTabWidget
+{
+public:
+    explicit ChatTabWidget(QWidget* parent = nullptr) : QTabWidget(parent)
+    {
+        auto* bar = new HalfWidthTabBar(this);
+        bar->setExpanding(false);   // a lone tab must stay 50%, not stretch
+        bar->setDrawBase(false);    // no full-width base line under the tabs
+        setTabBar(bar);
+    }
+};
 } // namespace
 
 // ──────────────────────────────────────────────────────────────────────
@@ -166,6 +202,108 @@ namespace
             case LobbyClient::ConnectionState::Failed:         return c.fail;
             default:                                           return c.idle;
         }
+    }
+
+    // ── Per-player / per-state / per-ping accents ──────────────────────
+    // Distinct seat colors so P1-P4 read apart at a glance (P1 blue,
+    // P2 red, P3 green, P4 amber — a Smash/Mario-Kart-style set). Light
+    // and dark variants keep contrast on both themes; brightness mirrors
+    // the way statusColors() picks Material 500 on dark / 800 on light.
+    QString playerAccentHex(int slot, bool dark)
+    {
+        switch (slot)
+        {
+            case 1: return dark ? "#4aa3ff" : "#0078D7"; // blue
+            case 2: return dark ? "#ff6b66" : "#d83a34"; // red
+            case 3: return dark ? "#4caf50" : "#2e9e3f"; // green
+            case 4: return dark ? "#ffca45" : "#b5790a"; // amber
+            default: return dark ? "#bdbdbd" : "#9e9e9e";
+        }
+    }
+
+    // Soft accent-tinted fill for the seat card. rgba so it sits gently over
+    // palette(base) on either theme — heavier on dark where a faint wash
+    // would vanish.
+    QString playerCardBg(int slot, bool dark)
+    {
+        struct RGB { int r, g, b; };
+        RGB c;
+        switch (slot)
+        {
+            case 1: c = dark ? RGB{74, 163, 255} : RGB{0, 120, 215};  break;
+            case 2: c = dark ? RGB{255, 107, 102} : RGB{216, 58, 52}; break;
+            case 3: c = dark ? RGB{76, 175, 80} : RGB{46, 158, 63};   break;
+            case 4: c = dark ? RGB{255, 202, 69} : RGB{181, 121, 10}; break;
+            default: c = RGB{128, 128, 128}; break;
+        }
+        return QString("rgba(%1, %2, %3, %4)")
+            .arg(c.r).arg(c.g).arg(c.b)
+            .arg(dark ? "0.14" : "0.08");
+    }
+
+    // Same accent at a stronger alpha for the card's hairline border.
+    QString playerBorderRgba(int slot, bool dark)
+    {
+        struct RGB { int r, g, b; };
+        RGB c;
+        switch (slot)
+        {
+            case 1: c = dark ? RGB{74, 163, 255} : RGB{0, 120, 215};  break;
+            case 2: c = dark ? RGB{255, 107, 102} : RGB{216, 58, 52}; break;
+            case 3: c = dark ? RGB{76, 175, 80} : RGB{46, 158, 63};   break;
+            case 4: c = dark ? RGB{255, 202, 69} : RGB{181, 121, 10}; break;
+            default: c = RGB{128, 128, 128}; break;
+        }
+        return QString("rgba(%1, %2, %3, 0.55)").arg(c.r).arg(c.g).arg(c.b);
+    }
+
+    // Ping quality tiers: green good, amber playable, red rough, grey unknown.
+    // (statusColors() already resolves the active theme.)
+    QString pingHex(int ms)
+    {
+        const auto c = statusColors();
+        if (ms < 0)   return c.idle; // no measurement yet
+        if (ms <= 60) return c.ok;
+        if (ms <= 120) return c.wait;
+        return c.fail;
+    }
+
+    // Color for a presence/room state string (the values stateGlyph maps).
+    QString stateHex(const QString& state, bool dark)
+    {
+        const auto c = statusColors();
+        if (state == "idle" || state == "waiting")          return c.ok;
+        if (state == "hosting" || state == "in_room")       return dark ? "#4aa3ff" : "#0078D7";
+        if (state == "searching" || state == "starting" ||
+            state == "connecting")                          return c.wait;
+        if (state == "playing" || state == "in_game")       return dark ? "#b78cff" : "#7a44c9"; // purple
+        if (state == "spectating")                          return dark ? "#4aa3ff" : "#0078D7";
+        if (state == "browsing")                            return c.idle;
+        return c.idle;
+    }
+
+    // Right-aligned seat meta as rich text: an accent-colored HOST badge and a
+    // ping-tier-colored "N ms". Shared by renderSeatFilled and the live ping
+    // refresh in onPingMeasured so the two never drift. pingMs < 0 hides ping.
+    QString seatMetaHtml(int slot, bool isHost, int pingMs, bool dark)
+    {
+        QStringList parts;
+        if (isHost)
+            parts << QString("<span style='color:%1; font-weight:700;'>HOST</span>")
+                         .arg(playerAccentHex(slot, dark));
+        if (pingMs >= 0)
+            parts << QString("<span style='color:%1; font-weight:600;'>%2 ms</span>")
+                         .arg(pingHex(pingMs)).arg(pingMs);
+        return parts.join(QStringLiteral("&nbsp;·&nbsp;"));
+    }
+
+    // A translucent fill derived from a solid hex — used for the soft pill /
+    // badge backgrounds so an accent reads gently over palette(window/base).
+    QString tintRgba(const QString& hex, double alpha)
+    {
+        const QColor c(hex);
+        return QString("rgba(%1, %2, %3, %4)")
+            .arg(c.red()).arg(c.green()).arg(c.blue()).arg(alpha);
     }
 
     // Apply a +N point delta to the widget's font. Used to bump section
@@ -419,15 +557,26 @@ QWidget* RollbackLobbyDialog::buildMarquee()
 
     h->addSpacing(SPACING_DEFAULT);
 
-    m_statusLed = new QLabel(this);
+    // Connection status: a colored LED dot + status-colored label. No filled
+    // pill background — just the dot and text follow the connection state
+    // (set in updateStatusIndicator).
+    m_statusPill = new QFrame(this);
+    m_statusPill->setObjectName("StatusPill");
+    auto* pillLay = new QHBoxLayout(m_statusPill);
+    pillLay->setContentsMargins(0, 0, 0, 0);
+    pillLay->setSpacing(SPACING_TIGHT + 2);
+
+    m_statusLed = new QLabel(m_statusPill);
     m_statusLed->setFixedSize(STATUS_DOT_PX, STATUS_DOT_PX);
     m_statusLed->setStyleSheet(
         QString("background-color: %1; border-radius: %2px;")
             .arg(statusColors().idle).arg(STATUS_DOT_PX / 2));
-    h->addWidget(m_statusLed);
+    pillLay->addWidget(m_statusLed);
 
-    m_statusText = new QLabel("Offline", this);
-    h->addWidget(m_statusText);
+    m_statusText = new QLabel("Offline", m_statusPill);
+    m_statusText->setStyleSheet(QString("color: %1; font-weight: 600;").arg(statusColors().idle));
+    pillLay->addWidget(m_statusText);
+    h->addWidget(m_statusPill);
 
     h->addSpacing(SPACING_DEFAULT * 2);
 
@@ -604,18 +753,22 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     topRow->addStretch(1);
 
     m_roomStateLabel = new QLabel("Waiting", this);
-    bumpFont(m_roomStateLabel, 0, /*bold=*/true);
     topRow->addWidget(m_roomStateLabel);
+    applyRoomStateBadge("Waiting", stateHex("waiting", isDarkTheme()));
     lay->addLayout(topRow);
 
-    // ROM title (large)
+    // ROM title (large). Word-wrap so a long ROM name doesn't pin a wide
+    // minimum width on the whole left column (it's shared via the stacked
+    // widget with the browse view).
     m_roomTitle = new QLabel("—", this);
     bumpFont(m_roomTitle, 4, /*bold=*/true);
+    m_roomTitle->setWordWrap(true);
     lay->addWidget(m_roomTitle);
 
     // Subtitle (host / max players) — default WindowText since this is
     // important info; the bold title above gives the hierarchy.
     m_roomSubtitle = new QLabel("—", this);
+    m_roomSubtitle->setWordWrap(true);
     lay->addWidget(m_roomSubtitle);
 
     // Meta line (Seats / Region) — plain rich text. Delay and prediction
@@ -661,6 +814,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     auto* delayLbl = new QLabel("Frame delay:", this);
     m_delayCombo = new QComboBox(this);
+    m_delayCombo->setObjectName("LobbyCombo");
     fillFrameCombo(m_delayCombo, "Auto");
     m_delayCombo->setToolTip(delayTip);
     // Stash the explainer so onRoomStateChanged can restore it after a
@@ -673,6 +827,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     auto* predLbl = new QLabel("Prediction:", this);
     m_predictionCombo = new QComboBox(this);
+    m_predictionCombo->setObjectName("LobbyCombo");
     fillFrameCombo(m_predictionCombo, "Default");
     m_predictionCombo->setToolTip(predictionTip);
     m_predictionCombo->setProperty("originalTip", predictionTip);
@@ -691,6 +846,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         "Host-only. All players will use the same model.");
     auto* pacingLbl = new QLabel("Pacing:", this);
     m_pacingCombo = new QComboBox(this);
+    m_pacingCombo->setObjectName("LobbyCombo");
     m_pacingCombo->addItem("Aggressive", 0);
     m_pacingCombo->addItem("Smooth", 1);
     m_pacingCombo->setToolTip(pacingTip);
@@ -699,11 +855,19 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     settingsRow->addWidget(m_pacingCombo);
 
     settingsRow->addStretch(1);
+    lay->addLayout(settingsRow);
 
-    // Per-player local recording toggle. Sits on the (otherwise host-only)
-    // settings row but stays enabled for everyone — each player decides whether
-    // to save their own .krec. Initialized from the cap-aware default and kept
-    // in the shared n02 recording flag, exactly like the p2p / kaillera lobbies.
+    // Recording toggles live on their own row beneath the combos. Keeping them
+    // off the combo row keeps that row's minimum width small, so the left
+    // column can be dragged narrower (more room for chat / players).
+    auto* toggleRow = new QHBoxLayout;
+    toggleRow->setContentsMargins(0, 0, 0, 0);
+    toggleRow->setSpacing(SPACING_DEFAULT);
+
+    // Per-player local recording toggle. Stays enabled for everyone — each
+    // player decides whether to save their own .krec. Initialized from the
+    // cap-aware default and kept in the shared n02 recording flag, exactly like
+    // the p2p / kaillera lobbies.
     m_recordCheck = new QCheckBox("Record game", this);
     m_recordCheck->setToolTip(
         "Record this match to a .krec file on your PC.\n"
@@ -714,7 +878,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     connect(m_recordCheck, &QCheckBox::toggled, this, [](bool checked) {
         n02_kaillera_recording_enabled = checked;
     });
-    settingsRow->addWidget(m_recordCheck);
+    toggleRow->addWidget(m_recordCheck);
 
     // Broadcast: stream this match's krec to the server so others can spectate.
     // Broadcasting implies recording (the stream is the krec), so ticking it
@@ -728,9 +892,10 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         if (checked && m_recordCheck)
             m_recordCheck->setChecked(true); // broadcasting needs the krec written
     });
-    settingsRow->addWidget(m_broadcastCheck);
+    toggleRow->addWidget(m_broadcastCheck);
+    toggleRow->addStretch(1);
 
-    lay->addLayout(settingsRow);
+    lay->addLayout(toggleRow);
 
     // Both combos share the same change handler. Skip emits while we're
     // applying values from a ROOM_STATE refresh — otherwise we'd ping-pong
@@ -758,7 +923,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     auto* seatsBox = new QWidget(this);
     auto* seatsLay = new QVBoxLayout(seatsBox);
     seatsLay->setContentsMargins(0, SPACING_TIGHT, 0, 0);
-    seatsLay->setSpacing(0);
+    seatsLay->setSpacing(SPACING_TIGHT);
     for (int i = 0; i < 4; ++i)
     {
         buildSeatRow(m_seats[i], i + 1, seatsBox);
@@ -814,25 +979,28 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
 void RollbackLobbyDialog::buildSeatRow(SeatRow& s, int slotIdx, QWidget* parent)
 {
-    s.row = new QWidget(parent);
+    s.slot = slotIdx;
+    // A QFrame (not bare QWidget) so the per-player card background / border
+    // set via setStyleSheet in the render helpers paints reliably.
+    auto* card = new QFrame(parent);
+    card->setObjectName("SeatCard");
+    s.row = card;
     auto* lay = new QHBoxLayout(s.row);
-    lay->setContentsMargins(SPACING_DEFAULT, SPACING_TIGHT, SPACING_DEFAULT, SPACING_TIGHT);
+    lay->setContentsMargins(MARGIN_GROUP, SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT);
     lay->setSpacing(SPACING_DEFAULT);
 
-    // Filled/empty dot — single glyph, color follows palette so it picks
-    // up the theme like everything else.
+    // Filled/empty dot — single glyph, tinted with the player's accent when
+    // filled (set in renderSeatFilled), muted grey when empty.
     s.dotLabel = new QLabel(QStringLiteral("○"), s.row);
     s.dotLabel->setFixedWidth(14);
     lay->addWidget(s.dotLabel);
 
-    // Slot tag — bold, fixed width so names line up across rows.
+    // Slot tag — a colored "P1" chip; shape + color applied per-player in the
+    // render helpers. Fixed min size so names line up across rows.
     s.slotLabel = new QLabel(QString("P%1").arg(slotIdx), s.row);
-    s.slotLabel->setFixedWidth(28);
-    {
-        QFont f = s.slotLabel->font();
-        f.setBold(true);
-        s.slotLabel->setFont(f);
-    }
+    s.slotLabel->setObjectName("SeatChip");
+    s.slotLabel->setAlignment(Qt::AlignCenter);
+    s.slotLabel->setMinimumWidth(30);
     lay->addWidget(s.slotLabel);
 
     s.nameLabel = new QLabel(QStringLiteral("Waiting…"), s.row);
@@ -840,9 +1008,10 @@ void RollbackLobbyDialog::buildSeatRow(SeatRow& s, int slotIdx, QWidget* parent)
 
     lay->addStretch(1);
 
-    // Right-aligned meta (host · ping). PlaceholderText is theme-aware
-    // muted body text — readable on Fusion Dark and not screaming on light.
+    // Right-aligned meta (HOST badge · ping). Rich text so the badge and the
+    // ping value can carry their own colors.
     s.metaLabel = new QLabel(QString(), s.row);
+    s.metaLabel->setTextFormat(Qt::RichText);
     s.metaLabel->setForegroundRole(QPalette::PlaceholderText);
     lay->addWidget(s.metaLabel);
 
@@ -872,17 +1041,38 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
 {
     s.isHost = false;
     s.userId = 0;
+
+    // Muted, dashed card — clearly "open seat" without competing with the
+    // filled, color-tinted player cards.
+    if (s.row)
+        s.row->setStyleSheet(
+            "QFrame#SeatCard {"
+            "  background-color: transparent;"
+            "  border: 1px dashed palette(mid);"
+            "  border-radius: 8px;"
+            "}");
     if (s.dotLabel)
     {
         s.dotLabel->setText(QStringLiteral("○"));
-        s.dotLabel->setForegroundRole(QPalette::PlaceholderText);
+        s.dotLabel->setStyleSheet(QString("color: %1;").arg(statusColors().idle));
     }
     if (s.slotLabel)
-        s.slotLabel->setForegroundRole(QPalette::PlaceholderText);
+        s.slotLabel->setStyleSheet(
+            QString("QLabel#SeatChip {"
+                    "  background-color: rgba(128,128,128,0.18);"
+                    "  color: %1;"
+                    "  border-radius: 7px;"
+                    "  padding: 1px 7px;"
+                    "  font-weight: 700;"
+                    "}").arg(statusColors().idle));
     if (s.nameLabel)
     {
         s.nameLabel->setText(QStringLiteral("Waiting…"));
+        s.nameLabel->setStyleSheet(QString());
         s.nameLabel->setForegroundRole(QPalette::PlaceholderText);
+        QFont f = s.nameLabel->font();
+        f.setBold(false);
+        s.nameLabel->setFont(f);
     }
     if (s.metaLabel) s.metaLabel->setText(QString());
     if (s.kickButton) s.kickButton->setVisible(false);
@@ -893,29 +1083,54 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
 {
     s.isHost = isHost;
     if (s.kickButton) s.kickButton->setVisible(canKick);
+
+    const bool dark = isDarkTheme();
+    const QString accent = playerAccentHex(s.slot, dark);
+
+    // Player-colored, gently tinted card. Self stands out with a more vivid
+    // (fully-opaque) accent border in the same color — kept at 1px because a
+    // 2px rounded border renders with uneven/notchy corners.
+    if (s.row)
+        s.row->setStyleSheet(QString(
+            "QFrame#SeatCard {"
+            "  background-color: %1;"
+            "  border: 1px solid %2;"
+            "  border-radius: 8px;"
+            "}")
+            .arg(playerCardBg(s.slot, dark),
+                 isSelf ? accent : playerBorderRgba(s.slot, dark)));
+
     if (s.dotLabel)
     {
         s.dotLabel->setText(QStringLiteral("●"));
-        s.dotLabel->setForegroundRole(QPalette::WindowText);
+        s.dotLabel->setStyleSheet(QString("color: %1;").arg(accent));
     }
     if (s.slotLabel)
-        s.slotLabel->setForegroundRole(QPalette::WindowText);
+        s.slotLabel->setStyleSheet(QString(
+            "QLabel#SeatChip {"
+            "  background-color: %1;"
+            "  color: white;"
+            "  border-radius: 7px;"
+            "  padding: 1px 7px;"
+            "  font-weight: 700;"
+            "}").arg(accent));
     if (s.nameLabel)
     {
         QString name = username;
         if (isSelf) name += QStringLiteral("  (you)");
         s.nameLabel->setText(name);
+        s.nameLabel->setStyleSheet(QString());
         s.nameLabel->setForegroundRole(QPalette::WindowText);
+        QFont f = s.nameLabel->font();
+        f.setBold(isSelf);
+        s.nameLabel->setFont(f);
     }
     if (s.metaLabel)
     {
-        // Compose host + ping. Self never shows a ping (pingMs == -1 also
-        // means "no measurement yet" for peers we haven't probed). Ping shows
-        // up after the first PROBE_REPLY arrives, refreshes on each tick.
-        QStringList parts;
-        if (isHost)              parts << QStringLiteral("host");
-        if (!isSelf && pingMs >= 0) parts << QStringLiteral("%1 ms").arg(pingMs);
-        s.metaLabel->setText(parts.join(QStringLiteral(" · ")));
+        // HOST badge + ping. Self never shows a ping (pingMs == -1 also means
+        // "no measurement yet" for peers we haven't probed). Ping shows up
+        // after the first PROBE_REPLY arrives, refreshed on each tick.
+        s.metaLabel->setText(seatMetaHtml(s.slot, isHost, isSelf ? -1 : pingMs, dark));
     }
 }
 
@@ -923,33 +1138,43 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
 
 QWidget* RollbackLobbyDialog::buildChatColumn()
 {
-    // No "Chat" wrapper — the tab labels ("Lobby" / "Room") already convey
-    // the column's identity and the splitter handle separates it visually.
+    // The tab labels ("Lobby" / "Room") already convey the column's identity;
+    // a borderless rounded card frame matches the players list and the P2P
+    // hosting screen. documentMode keeps the tabs flat so they don't double-
+    // border against the card edge.
     auto* col = new QWidget(this);
     auto* lay = new QVBoxLayout(col);
     lay->setContentsMargins(MARGIN_OUTER, MARGIN_OUTER, MARGIN_OUTER, MARGIN_OUTER);
     lay->setSpacing(SPACING_DEFAULT);
 
-    m_chatTabs = new QTabWidget(this);
-    // documentMode=true gives Chrome-style "floating" tabs that visually
-    // detach from the content below; documentMode=false (the default) lets
-    // the active tab sit flush in the pane border instead. Combine with
-    // QTextEdit::NoFrame inside so we don't double-border the chat area.
+    auto* card = new QFrame(col);
+    card->setObjectName("LobbyCard");
+    auto* cardLay = new QVBoxLayout(card);
+    cardLay->setContentsMargins(SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT);
+    cardLay->setSpacing(SPACING_DEFAULT);
 
-    m_chatViewLobby = new QTextEdit(this);
+    // ChatTabWidget installs the HalfWidthTabBar internally (setTabBar is
+    // protected). Each tab is half the column wide: one tab → 50%, two → 100%.
+    m_chatTabs = new ChatTabWidget(card);
+    m_chatTabs->setObjectName("ChatTabs");
+    m_chatTabs->setDocumentMode(true);
+
+    m_chatViewLobby = new QTextEdit(card);
     m_chatViewLobby->setReadOnly(true);
     m_chatViewLobby->setLineWrapMode(QTextEdit::WidgetWidth);
     m_chatViewLobby->setFrameShape(QFrame::NoFrame);
     m_chatTabs->addTab(m_chatViewLobby, "Lobby");
 
-    lay->addWidget(m_chatTabs, 1);
+    cardLay->addWidget(m_chatTabs, 1);
 
-    m_chatInput = new QLineEdit(this);
+    m_chatInput = new QLineEdit(card);
     m_chatInput->setPlaceholderText("Type a message and press Enter…");
     m_chatInput->setEnabled(false);
     m_chatInput->setMinimumHeight(BUTTON_MIN_HEIGHT);
     connect(m_chatInput, &QLineEdit::returnPressed, this, &RollbackLobbyDialog::onChatSendClicked);
-    lay->addWidget(m_chatInput);
+    cardLay->addWidget(m_chatInput);
+
+    lay->addWidget(card, 1);
 
     return col;
 }
@@ -958,15 +1183,20 @@ QWidget* RollbackLobbyDialog::buildChatColumn()
 
 QWidget* RollbackLobbyDialog::buildPlayersColumn()
 {
-    // No "Players" wrapper — the tree's column header ("Player / State /
-    // Ping") already labels the content and the splitter handle isolates
-    // the column visually.
+    // The tree's column header ("Player / State / Ping") already labels the
+    // content; a borderless rounded card frame gives it the polished, P2P-
+    // style container without a heavy titled group box.
     auto* col = new QWidget(this);
     auto* lay = new QVBoxLayout(col);
     lay->setContentsMargins(MARGIN_OUTER, MARGIN_OUTER, MARGIN_OUTER, MARGIN_OUTER);
     lay->setSpacing(SPACING_DEFAULT);
 
-    m_playersTree = new QTreeWidget(this);
+    auto* card = new QFrame(col);
+    card->setObjectName("LobbyCard");
+    auto* cardLay = new QVBoxLayout(card);
+    cardLay->setContentsMargins(SPACING_TIGHT, SPACING_TIGHT, SPACING_TIGHT, SPACING_TIGHT);
+
+    m_playersTree = new QTreeWidget(card);
     m_playersTree->setObjectName("PlayersTree");
     m_playersTree->setHeaderLabels({ "Player", "State", "Est. Ping" });
     m_playersTree->setRootIsDecorated(false);
@@ -978,7 +1208,11 @@ QWidget* RollbackLobbyDialog::buildPlayersColumn()
     m_playersTree->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     m_playersTree->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
     m_playersTree->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
-    lay->addWidget(m_playersTree);
+    // Click in the empty area below the rows to clear the selection (handled in
+    // eventFilter — there's no built-in property for this).
+    m_playersTree->viewport()->installEventFilter(this);
+    cardLay->addWidget(m_playersTree);
+    lay->addWidget(card);
 
     return col;
 }
@@ -1001,11 +1235,96 @@ void RollbackLobbyDialog::applyStylesheet()
         : QStringLiteral("rgba(0, 120, 215, 0.10)");
     const QString bannerBorder = QStringLiteral("rgba(0, 120, 215, 0.45)");
 
+    // Brand accent (P1 blue) for the header text, and a faint accent wash for
+    // the marquee strip so it reads as a header band rather than blank window.
+    const QString brandAccent = playerAccentHex(1, dark);
+    const QString marqueeBg   = tintRgba(brandAccent, dark ? 0.16 : 0.07);
+
+    // Themed chevron for the styled combos (same asset the P2P dialog uses), so
+    // the drop-down arrow doesn't fall back to Qt's default that clashes with
+    // the rounded border.
+    const QString comboArrow = QString(":/icons/%1/svg/arrow-down-s-line.svg")
+        .arg(dark ? "white" : "black");
+
     const QString qss = QString(
-        // Marquee — thin divider, no fancy gradient.
+        // Marquee — faint accent header band with a hairline divider.
         "QFrame#LobbyMarquee {"
-        "  background-color: palette(window);"
+        "  background-color: %5;"
         "  border-bottom: 1px solid %1;"
+        "}"
+        "QLabel#LobbyBrand { color: %4; }"
+
+        // Rounded content cards (players list, chat) — the P2P-style container
+        // without a heavy titled group box.
+        "QFrame#LobbyCard {"
+        "  border: 1px solid %1;"
+        "  border-radius: 10px;"
+        "  background-color: palette(base);"
+        "}"
+
+        // Active Rooms / Ongoing Matches — styled as tables: square 1px outline,
+        // a distinct header row, and light column / row separators.
+        "QTreeWidget#RoomsTree, QTreeWidget#MatchesTree {"
+        "  border: 1px solid %1;"
+        "  background-color: palette(base);"
+        "}"
+        "QTreeWidget#RoomsTree::item, QTreeWidget#MatchesTree::item {"
+        "  padding: 3px 4px;"
+        "  border-bottom: 1px solid rgba(127, 127, 127, 0.12);"
+        "}"
+        "QTreeWidget#RoomsTree QHeaderView::section,"
+        " QTreeWidget#MatchesTree QHeaderView::section {"
+        "  background-color: rgba(127, 127, 127, 0.12);"
+        "  color: palette(text);"
+        "  border: none;"
+        "  border-right: 1px solid %1;"
+        "  border-bottom: 1px solid %1;"
+        "  padding: 4px 6px;"
+        "  font-weight: 600;"
+        "}"
+        "QTreeWidget#RoomsTree QHeaderView::section:last,"
+        " QTreeWidget#MatchesTree QHeaderView::section:last {"
+        "  border-right: none;"
+        "}"
+
+        // Chat tabs — flat underline style (no surrounding bar / boxed tabs).
+        // Each tab is half the column wide via HalfWidthTabBar.
+        "QTabWidget#ChatTabs::pane {"
+        "  border: none;"
+        "  background: transparent;"
+        "}"
+        "QTabWidget#ChatTabs QTabBar {"
+        "  background: transparent;"
+        "  qproperty-drawBase: 0;"
+        "}"
+        // Both tabs read as tabs (subtle neutral fill); the active one is
+        // accented with a blue fill, text and underline. Only the *outer*
+        // corners round — the two tabs share a flat seam in the middle (first
+        // tab rounds top-left, last rounds top-right, a lone tab rounds both).
+        "QTabWidget#ChatTabs QTabBar::tab {"
+        "  background: rgba(127, 127, 127, 0.12);"
+        "  border: none;"
+        "  border-bottom: 2px solid transparent;"
+        "  border-top-left-radius: 0px;"
+        "  border-top-right-radius: 0px;"
+        "  padding: 5px 10px;"
+        "  margin: 0px;"
+        "  color: palette(text);"
+        "}"
+        "QTabWidget#ChatTabs QTabBar::tab:first { border-top-left-radius: 6px; }"
+        "QTabWidget#ChatTabs QTabBar::tab:last { border-top-right-radius: 6px; }"
+        "QTabWidget#ChatTabs QTabBar::tab:only-one {"
+        "  border-top-left-radius: 6px;"
+        "  border-top-right-radius: 6px;"
+        "}"
+        "QTabWidget#ChatTabs QTabBar::tab:hover {"
+        "  background: rgba(127, 127, 127, 0.20);"
+        "}"
+        "QTabWidget#ChatTabs QTabBar::tab:selected {"
+        "  color: %4;"
+        "  background: %5;"
+        "  border-bottom: 2px solid %4;"
+        "  font-weight: 600;"
         "}"
 
         // Section headers — bold uppercase label with a hairline divider
@@ -1034,7 +1353,7 @@ void RollbackLobbyDialog::applyStylesheet()
         "QPushButton#QuickMatchBtn, QPushButton#StartGameBtn,"
         " QPushButton#BannerReturnBtn {"
         "  border: 1px solid #0066b4;"
-        "  border-radius: 4px;"
+        "  border-radius: 7px;"
         "  padding: 4px 16px;"
         "  font-weight: 700;"
         "  color: white;"
@@ -1053,7 +1372,75 @@ void RollbackLobbyDialog::applyStylesheet()
         "  color: palette(mid);"
         "  border-color: %1;"
         "}"
-    ).arg(border, bannerBg, bannerBorder);
+
+        // Secondary action buttons — Create Room / Drop / Leave read as a set,
+        // matching the P2P hosting screen's secondary buttons.
+        "QPushButton#CreateRoomBtn, QPushButton#DropBtn, QPushButton#LeaveBtn {"
+        "  border: 1px solid %1;"
+        "  border-radius: 7px;"
+        "  padding: 4px 14px;"
+        "  font-weight: 600;"
+        "  background-color: palette(button);"
+        "}"
+        "QPushButton#CreateRoomBtn:hover, QPushButton#DropBtn:hover,"
+        " QPushButton#LeaveBtn:hover {"
+        "  border-color: palette(dark);"
+        "  background-color: palette(light);"
+        "}"
+        "QPushButton#CreateRoomBtn:pressed, QPushButton#DropBtn:pressed,"
+        " QPushButton#LeaveBtn:pressed {"
+        "  background-color: palette(midlight);"
+        "}"
+        "QPushButton#CreateRoomBtn:disabled, QPushButton#DropBtn:disabled {"
+        "  color: palette(mid);"
+        "}"
+
+        // Session-setting combos — rounded, themed border (P2P style).
+        "QComboBox#LobbyCombo, QComboBox#BrowseRomCombo {"
+        "  border: 1px solid %1;"
+        "  border-radius: 7px;"
+        "  background-color: palette(base);"
+        "  padding: 3px 8px;"
+        "  min-height: 22px;"
+        "}"
+        "QComboBox#LobbyCombo:focus, QComboBox#BrowseRomCombo:focus {"
+        "  border-color: palette(highlight);"
+        "}"
+        "QComboBox#LobbyCombo:disabled { color: palette(mid); }"
+        "QComboBox#LobbyCombo::drop-down, QComboBox#BrowseRomCombo::drop-down {"
+        "  subcontrol-origin: padding;"
+        "  subcontrol-position: top right;"
+        "  width: 20px;"
+        "  border: none;"
+        "  border-left: 1px solid %1;"
+        "  border-top-right-radius: 7px;"
+        "  border-bottom-right-radius: 7px;"
+        "  background-color: transparent;"
+        "  margin: 1px;"
+        "}"
+        "QComboBox#LobbyCombo::down-arrow, QComboBox#BrowseRomCombo::down-arrow {"
+        "  image: url(%6);"
+        "  width: 12px;"
+        "  height: 12px;"
+        "}"
+
+        // Seat kick button — red accent, transparent until hovered (P2P style).
+        "QPushButton#SeatKickButton {"
+        "  border: 1px solid transparent;"
+        "  border-radius: 6px;"
+        "  padding: 0px;"
+        "  color: #c03a3a;"
+        "  background-color: transparent;"
+        "  font-weight: 800;"
+        "}"
+        "QPushButton#SeatKickButton:hover {"
+        "  border-color: #d77a7a;"
+        "  background-color: rgba(208, 72, 72, 0.12);"
+        "}"
+        "QPushButton#SeatKickButton:pressed {"
+        "  background-color: rgba(208, 72, 72, 0.20);"
+        "}"
+    ).arg(border, bannerBg, bannerBorder, brandAccent, marqueeBg, comboArrow);
 
     setStyleSheet(qss);
 }
@@ -1144,6 +1531,20 @@ void RollbackLobbyDialog::closeEvent(QCloseEvent* event)
     if (m_client)
         m_client->disconnectFromServer();
     QDialog::closeEvent(event);
+}
+
+bool RollbackLobbyDialog::eventFilter(QObject* watched, QEvent* event)
+{
+    // A click in the players-list viewport that doesn't land on a row clears
+    // the selection, so a highlighted name can be dismissed by clicking off it.
+    if (m_playersTree && watched == m_playersTree->viewport() &&
+        event->type() == QEvent::MouseButtonPress)
+    {
+        auto* me = static_cast<QMouseEvent*>(event);
+        if (!m_playersTree->itemAt(me->position().toPoint()))
+            m_playersTree->clearSelection();
+    }
+    return QDialog::eventFilter(watched, event);
 }
 
 QString RollbackLobbyDialog::prefillUsername() const
@@ -1325,13 +1726,32 @@ void RollbackLobbyDialog::onConnectError(const QString& msg)
 
 void RollbackLobbyDialog::updateStatusIndicator(LobbyClient::ConnectionState s)
 {
+    const QString sc = statusColor(s);
     if (m_statusLed)
     {
         m_statusLed->setStyleSheet(
             QString("background-color: %1; border-radius: %2px;")
-                .arg(statusColor(s)).arg(STATUS_DOT_PX / 2));
+                .arg(sc).arg(STATUS_DOT_PX / 2));
     }
-    if (m_statusText) m_statusText->setText(humanState(s));
+    if (m_statusText)
+    {
+        m_statusText->setText(humanState(s));
+        m_statusText->setStyleSheet(QString("color: %1; font-weight: 600;").arg(sc));
+    }
+}
+
+void RollbackLobbyDialog::applyRoomStateBadge(const QString& text, const QString& colorHex)
+{
+    if (!m_roomStateLabel) return;
+    m_roomStateLabel->setText(text);
+    m_roomStateLabel->setStyleSheet(QString(
+        "QLabel {"
+        "  color: %1;"
+        "  background-color: %2;"
+        "  border-radius: 9px;"
+        "  padding: 2px 10px;"
+        "  font-weight: 700;"
+        "}").arg(colorHex, tintRgba(colorHex, isDarkTheme() ? 0.22 : 0.14)));
 }
 
 void RollbackLobbyDialog::updateInRoomBanner()
@@ -1369,11 +1789,9 @@ void RollbackLobbyDialog::updateServerMeta()
     }
     const int players = m_client->users().size();
     const int rooms = m_client->rooms().size();
-    QUrl u(m_serverUrl);
-    QString host = u.isValid() && !u.host().isEmpty() ? u.host() : m_serverUrl;
-    if (u.port() > 0) host = QString("%1:%2").arg(host).arg(u.port());
-    m_serverMeta->setText(QString("%1  ·  %2 player%3  ·  %4 room%5")
-                              .arg(host)
+    // Server host/IP intentionally omitted from the header — just show the
+    // live population.
+    m_serverMeta->setText(QString("%1 player%2  ·  %3 room%4")
                               .arg(players).arg(players == 1 ? "" : "s")
                               .arg(rooms).arg(rooms == 1 ? "" : "s"));
 }
@@ -1428,15 +1846,18 @@ void RollbackLobbyDialog::onUserUpdated(quint64 userId)
 
 void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyClient::LobbyUser& u)
 {
+    const bool dark = isDarkTheme();
     item->setText(0, u.username);
-    // Self gets bold; everyone else uses default palette text.
+    // Self gets bold and an accent tint; everyone else uses default palette text.
     if (u.id == m_client->selfUserId())
     {
         QFont f = item->font(0);
         f.setBold(true);
         item->setFont(0, f);
+        item->setForeground(0, QColor(playerAccentHex(1, dark)));
     }
     item->setText(1, stateGlyph(u.state));
+    item->setForeground(1, QColor(stateHex(u.state, dark)));
 
     // While searching, hovering the state shows which ROM they're queued for.
     if (u.state == "searching" && !u.searchingRom.isEmpty())
@@ -1454,12 +1875,15 @@ void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyCli
     if (u.id == m_client->selfUserId())
     {
         item->setText(2, dash);
+        item->setForeground(2, QColor(statusColors().idle));
     }
     else
     {
         const int rtt = UserInterface::Dialog::LobbyRegions::estimatedRttMs(
             m_client->selfRegion(), u.region);
         item->setText(2, rtt > 0 ? QString("~%1 ms").arg(rtt) : dash);
+        // Tint by the same ping tiers as the seat cards (grey when unknown).
+        item->setForeground(2, QColor(pingHex(rtt > 0 ? rtt : -1)));
     }
 
     const QString regionLabel = UserInterface::Dialog::LobbyRegions::labelFor(u.region);
@@ -1574,6 +1998,7 @@ void RollbackLobbyDialog::refreshRoomRow(QTreeWidgetItem* item, const LobbyClien
     if (r.hasPassword) nameCell = QStringLiteral("🔒  ") + nameCell;
     if (mine)          nameCell = QStringLiteral("★  ") + nameCell;
 
+    const bool dark = isDarkTheme();
     item->setText(0, nameCell);
     item->setText(1, r.hostName);
     item->setText(2, r.romName);
@@ -1581,10 +2006,19 @@ void RollbackLobbyDialog::refreshRoomRow(QTreeWidgetItem* item, const LobbyClien
     item->setText(4, stateGlyph(r.state));
     item->setData(0, Qt::UserRole, QVariant::fromValue(r.id));
 
-    // Bold the user's own room; everything else native.
+    // Seats: green when there's room to join, red when full.
+    const bool full = (r.maxPlayers > 0 && r.players >= r.maxPlayers);
+    const auto sc = statusColors();
+    item->setForeground(3, QColor(full ? sc.fail : sc.ok));
+    // State: same color language as presence / seats.
+    item->setForeground(4, QColor(stateHex(r.state, dark)));
+
+    // Bold the user's own room and tint its name with the P1 accent.
     QFont f = item->font(0);
     f.setBold(mine);
     item->setFont(0, f);
+    if (mine)
+        item->setForeground(0, QColor(playerAccentHex(1, dark)));
 }
 
 void RollbackLobbyDialog::onCreateRoomClicked()
@@ -1885,7 +2319,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     m_roomSubtitle->setText(QString("Hosted by %1  ·  %2 players max")
                                 .arg(hostName).arg(maxPlayers));
 
-    m_roomStateLabel->setText(stateGlyph(state));
+    applyRoomStateBadge(stateGlyph(state), stateHex(state, isDarkTheme()));
 
     const QJsonArray players = roomState.value("players").toArray();
     QStringList metaParts;
@@ -2165,10 +2599,7 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
     {
         if (s.userId != userId || !s.metaLabel)
             continue;
-        QStringList parts;
-        if (s.isHost) parts << QStringLiteral("host");
-        parts << QStringLiteral("%1 ms").arg(rttMs);
-        s.metaLabel->setText(parts.join(QStringLiteral(" · ")));
+        s.metaLabel->setText(seatMetaHtml(s.slot, s.isHost, rttMs, isDarkTheme()));
         break;
     }
 
@@ -2566,7 +2997,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     // the awaiting flag was set and left Drop disabled.
     if (m_startBtn) m_startBtn->setEnabled(false);
     if (m_dropBtn)  m_dropBtn->setEnabled(true);
-    if (m_roomStateLabel) m_roomStateLabel->setText("Connecting…");
+    applyRoomStateBadge("Connecting…", stateHex("connecting", isDarkTheme()));
 
     CoreAddCallbackMessage(CoreDebugMessageType::Info,
         QString("Rollback lobby MATCH_BEGIN: match=%1 peers=%2 self=%3 roomGame='%4' delay=%5 prediction=%6 anchorPort=%7")
@@ -2704,7 +3135,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
         appendChatSystemLine(CHANNEL_ROOM, message);
         CoreAddCallbackMessage(CoreDebugMessageType::Error, message.toUtf8().constData());
         m_awaitingEmulationStart = false;
-        if (m_roomStateLabel) m_roomStateLabel->setText("Pre-match sync failed");
+        applyRoomStateBadge("Pre-match sync failed", QString(statusColors().fail));
         return;
     }
 
@@ -2718,7 +3149,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
         appendChatSystemLine(CHANNEL_ROOM, message);
         CoreAddCallbackMessage(CoreDebugMessageType::Error, message.toUtf8().constData());
         m_awaitingEmulationStart = false;
-        if (m_roomStateLabel) m_roomStateLabel->setText("Pre-match sync failed");
+        applyRoomStateBadge("Pre-match sync failed", QString(statusColors().fail));
         return;
     }
     appendChatSystemLine(CHANNEL_ROOM, "Pre-match sync complete.");

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -355,6 +355,7 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
     connect(m_client, &LobbyClient::pingProbeMeasured,    this, &RollbackLobbyDialog::onPingMeasured);
     connect(m_client, &LobbyClient::spectateBegan,        this, &RollbackLobbyDialog::onSpectateBegan);
     connect(m_client, &LobbyClient::spectateData,         this, &RollbackLobbyDialog::onSpectateData);
+    connect(m_client, &LobbyClient::spectateKeyframe,     this, &RollbackLobbyDialog::onSpectateKeyframe);
     connect(m_client, &LobbyClient::spectateEnded,        this, &RollbackLobbyDialog::onSpectateEnded);
     connect(m_client, &LobbyClient::spectateFailed,       this, &RollbackLobbyDialog::onSpectateFailed);
 
@@ -3107,6 +3108,7 @@ void RollbackLobbyDialog::startBroadcast(quint64 matchId)
     if (m_broadcasting) return;
     m_broadcasting = true;
     m_broadcastMatchId = matchId;
+    m_lastKeyframeRequestMs = 0; // request the first keyframe on the next drain tick
     {
         QMutexLocker lock(&m_broadcastMutex);
         m_broadcastBuf.clear();
@@ -3149,16 +3151,48 @@ void RollbackLobbyDialog::onBroadcastDrainTick()
     QByteArray chunk;
     {
         QMutexLocker lock(&m_broadcastMutex);
-        if (m_broadcastBuf.isEmpty()) return;
         chunk = m_broadcastBuf;   // COW share
         m_broadcastBuf.clear();   // detaches m_broadcastBuf, leaving chunk intact
     }
-    if (m_broadcastMatchId != 0)
+    if (m_broadcastMatchId == 0)
+        return;
+
+    if (!chunk.isEmpty())
     {
         // Stamp the broadcaster's live krec frame so spectators know the live
         // edge and can fast-forward to it. The drained chunk carries records up
         // to ~this frame, so it's the right "after this chunk" live position.
         m_client->sendBroadcastData(m_broadcastMatchId, chunk, n02::recordingFrameCount());
+    }
+
+    // Periodic savestate keyframe: ask the engine for one at a fixed interval (it
+    // snapshots + holds it until confirmed against rollback), then poll for the
+    // result and upload it so late spectators can jump near the live edge instead
+    // of replaying from frame 0. Runs even when no krec chunk drained this tick.
+    //
+    // EXPERIMENT (2026-06-29): keyframes disabled to measure pure replay-from-frame-0.
+    // With no keyframe uploaded, the server falls back to streaming the full spool from
+    // frame 0 (broadcast.go spectateStart), so the spectator replays the whole match
+    // (deterministic — boot-replay RNG is correct) and fast-forwards. Tests whether
+    // video-on catch-up is fast enough to make keyframes unnecessary. Flip to re-enable.
+    constexpr bool kSpectateKeyframesEnabled = false;
+    if (kSpectateKeyframesEnabled)
+    {
+        const qint64 kKeyframeIntervalMs = 60000; // ~once a minute (knob)
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (m_lastKeyframeRequestMs == 0 || nowMs - m_lastKeyframeRequestMs >= kKeyframeIntervalMs)
+        {
+            rmgk_gekko::request_keyframe();
+            m_lastKeyframeRequestMs = nowMs;
+        }
+        std::vector<unsigned char> kf;
+        int kfFrame = -1;
+        if (rmgk_gekko::take_keyframe(kf, kfFrame) && !kf.empty() && kfFrame >= 0)
+        {
+            m_client->sendBroadcastKeyframe(m_broadcastMatchId,
+                QByteArray(reinterpret_cast<const char*>(kf.data()), static_cast<int>(kf.size())),
+                kfFrame);
+        }
     }
 }
 
@@ -3168,6 +3202,7 @@ void RollbackLobbyDialog::beginSpectate(quint64 matchId, const QString& gameName
 {
     if (m_spectatingMatchId != 0) return; // already spectating
     m_spectatingMatchId = matchId;
+    m_spectateStreamArmed = false; // wait for this subscribe's SPECTATE_BEGIN before accepting data
     m_client->startSpectate(matchId);
     emit spectateLaunch(matchId, gameName);
     appendChatSystemLine(CHANNEL_LOBBY, "Connecting to live replay…");
@@ -3178,18 +3213,30 @@ void RollbackLobbyDialog::stopSpectating()
     if (m_spectatingMatchId == 0) return;
     m_client->stopSpectate(m_spectatingMatchId);
     m_spectatingMatchId = 0;
+    m_spectateStreamArmed = false;
 }
 
 void RollbackLobbyDialog::onSpectateBegan(quint64 matchId)
 {
     if (matchId != m_spectatingMatchId) return;
+    // The session boundary: everything on the wire before this is leftover from a
+    // prior watch of this same match. Arm the stream now; keyframe + tail follow.
+    m_spectateStreamArmed = true;
     appendChatSystemLine(CHANNEL_LOBBY, "Watching — buffering the match…");
 }
 
 void RollbackLobbyDialog::onSpectateData(quint64 matchId, const QByteArray& bytes, int liveFrame)
 {
     if (matchId != m_spectatingMatchId) return;
+    if (!m_spectateStreamArmed) return; // stale chunk from a previous watch — drop it
     emit spectateStreamData(bytes, liveFrame);
+}
+
+void RollbackLobbyDialog::onSpectateKeyframe(quint64 matchId, int frame, const QByteArray& savestate)
+{
+    if (matchId != m_spectatingMatchId) return;
+    if (!m_spectateStreamArmed) return; // stale keyframe from a previous watch — drop it
+    emit spectateStreamKeyframe(frame, savestate);
 }
 
 void RollbackLobbyDialog::onSpectateEnded(quint64 matchId, const QString& reason)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -679,7 +679,7 @@ QWidget* RollbackLobbyDialog::buildBrowseView()
                 if (idx < 0 || !m_browseRomCombo->isEnabled()) return;
                 const QString name = m_browseRomCombo->itemText(idx);
                 if (name.isEmpty()) return;
-                QSettings s;
+                QSettings s("RMG-K", "n02");
                 s.beginGroup("Lobby/CreateRoom");
                 s.setValue("Rom", name);
                 s.endGroup();
@@ -1574,7 +1574,7 @@ void RollbackLobbyDialog::populateBrowseRoms()
     }
 
     // Restore the last-used selection (shared with Create Room via QSettings).
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     const QString preferred = s.value("Rom").toString();
     s.endGroup();
@@ -1755,7 +1755,7 @@ QString RollbackLobbyDialog::prefillUsername() const
 {
     // Prefer a previously saved lobby name, then the Kaillera username, then the
     // OS username. Conform whatever we pick to the lobby's allowed charset/length.
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     QString name = s.value("Lobby/Username").toString().trimmed();
 
     if (name.isEmpty())
@@ -1841,7 +1841,7 @@ void RollbackLobbyDialog::onConnectClicked()
     if (m_userLabel) m_userLabel->setText(QString("User: %1").arg(m_username));
 
     // Remember it so the field pre-fills next time.
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     s.setValue("Lobby/Username", m_username);
 
     if (m_connectButton) m_connectButton->setEnabled(false);
@@ -2908,7 +2908,7 @@ void RollbackLobbyDialog::applyHostRoomSettings(bool force)
     // Persist the concrete resolved values (never the Auto sentinel 0) so
     // CreateRoomDialog seeds a valid delay/prediction for the next room. Pacing
     // also rides the engine setting so a freshly created room defaults to it.
-    QSettings s;
+    QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     s.setValue("Delay",      effDelay);
     s.setValue("Prediction", effPred);

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -47,8 +47,6 @@
 #include <QStackedWidget>
 #include <QTreeWidget>
 #include <QHeaderView>
-#include <QTabWidget>
-#include <QTabBar>
 #include <QTextEdit>
 #include <QLineEdit>
 #include <QJsonArray>
@@ -56,6 +54,7 @@
 #include <QLabel>
 #include <QFrame>
 #include <QComboBox>
+#include <QCompleter>
 #include <QCheckBox>
 #include <QSettings>
 #include <QMessageBox>
@@ -64,6 +63,12 @@
 #include <QShowEvent>
 #include <QCloseEvent>
 #include <QMouseEvent>
+#include <QDrag>
+#include <QMimeData>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QPixmap>
 #include <QTimer>
 #include <QFont>
 #include <QUrl>
@@ -106,39 +111,6 @@ void setAutoComboLabel(QComboBox* combo, int resolved)
     if (idx >= 0) combo->setItemText(idx, QStringLiteral("Auto (%1 f)").arg(resolved));
 }
 
-// Tab bar where every tab is half the column wide: one tab → 50% (the right
-// half stays empty), two tabs → 50% each = 100%. So the "Lobby" tab keeps the
-// same width whether or not a "Room" tab is present. Never narrower than the
-// tab's own content, so labels never clip on a very narrow column.
-class HalfWidthTabBar : public QTabBar
-{
-public:
-    using QTabBar::QTabBar;
-protected:
-    QSize tabSizeHint(int index) const override
-    {
-        QSize hint = QTabBar::tabSizeHint(index);
-        const int avail = parentWidget() ? parentWidget()->width() : width();
-        if (avail > 0)
-            hint.setWidth(qMax(hint.width(), avail / 2));
-        return hint;
-    }
-};
-
-// QTabWidget that installs the HalfWidthTabBar. setTabBar()/tabBar() are
-// protected on QTabWidget, so the custom bar has to be wired up from inside a
-// subclass rather than after construction.
-class ChatTabWidget : public QTabWidget
-{
-public:
-    explicit ChatTabWidget(QWidget* parent = nullptr) : QTabWidget(parent)
-    {
-        auto* bar = new HalfWidthTabBar(this);
-        bar->setExpanding(false);   // a lone tab must stay 50%, not stretch
-        bar->setDrawBase(false);    // no full-width base line under the tabs
-        setTabBar(bar);
-    }
-};
 } // namespace
 
 // ──────────────────────────────────────────────────────────────────────
@@ -150,6 +122,9 @@ namespace
 {
     const char* const CHANNEL_LOBBY = "lobby";
     const char* const CHANNEL_ROOM  = "room";
+
+    // MIME type carrying the dragged seat's slot during a host reorder drag.
+    const char* const kSeatMime = "application/x-rmgk-seat-slot";
 
     constexpr int MARGIN_OUTER       = 8;   // dialog/column outside padding
     constexpr int MARGIN_GROUP       = 10;  // banner / accent-frame content inset
@@ -376,11 +351,13 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
     m_broadcastDrainTimer->setInterval(80);
     connect(m_broadcastDrainTimer, &QTimer::timeout, this, &RollbackLobbyDialog::onBroadcastDrainTick);
 
-    // 5 s cadence is a balance: fast enough that the displayed ping tracks
-    // real conditions, slow enough that we're not flooding peers' anchor
-    // sockets. Stays stopped until a room is entered.
+    // 3 s cadence is a balance: fast enough that the displayed ping tracks real
+    // conditions, slow enough that we're not flooding peers' anchor sockets. The
+    // *first* ping for a peer no longer waits on this tick — onRoomStateChanged
+    // fires an immediate probe the moment a peer is seated. Stays stopped until a
+    // room is entered.
     m_pingProbeTimer = new QTimer(this);
-    m_pingProbeTimer->setInterval(5'000);
+    m_pingProbeTimer->setInterval(3'000);
     connect(m_pingProbeTimer, &QTimer::timeout, this, &RollbackLobbyDialog::onPingProbeTick);
 }
 
@@ -670,6 +647,30 @@ QWidget* RollbackLobbyDialog::buildBrowseView()
     m_browseRomCombo = new QComboBox(this);
     m_browseRomCombo->setObjectName("BrowseRomCombo");
     m_browseRomCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    // Searchable: type to filter (substring, case-insensitive) or scroll the
+    // full list. NoInsert keeps typed text from being added as a bogus entry.
+    m_browseRomCombo->setEditable(true);
+    m_browseRomCombo->setInsertPolicy(QComboBox::NoInsert);
+    if (auto* comp = m_browseRomCombo->completer())
+    {
+        comp->setCompletionMode(QCompleter::PopupCompletion);
+        comp->setFilterMode(Qt::MatchContains);
+        comp->setCaseSensitivity(Qt::CaseInsensitive);
+    }
+    // Remember the last game picked here — Create Room and Quick Match both key
+    // off this combo, so persisting on selection (not just on Create) means the
+    // choice survives across sessions however the user proceeds. populateBrowseRoms
+    // blocks signals while restoring, so this never fires for the restore itself.
+    connect(m_browseRomCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [this](int idx) {
+                if (idx < 0 || !m_browseRomCombo->isEnabled()) return;
+                const QString name = m_browseRomCombo->itemText(idx);
+                if (name.isEmpty()) return;
+                QSettings s;
+                s.beginGroup("Lobby/CreateRoom");
+                s.setValue("Rom", name);
+                s.endGroup();
+            });
     gameRow->addWidget(gameLbl, 0);
     gameRow->addWidget(m_browseRomCombo, 1);
     lay->addLayout(gameRow);
@@ -921,6 +922,9 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     lay->addWidget(seatsHeader);
 
     auto* seatsBox = new QWidget(this);
+    m_seatsBox = seatsBox;
+    seatsBox->setAcceptDrops(true);      // host reorder: drop a seat onto another
+    seatsBox->installEventFilter(this);  // handles DragEnter/Move/Drop
     auto* seatsLay = new QVBoxLayout(seatsBox);
     seatsLay->setContentsMargins(0, SPACING_TIGHT, 0, 0);
     seatsLay->setSpacing(SPACING_TIGHT);
@@ -932,7 +936,33 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     }
     lay->addWidget(seatsBox);
 
-    lay->addStretch(1);
+    // ── Room chat — sits directly below the seats, with its own input. The
+    //    lobby chat stays in the dedicated middle column. ──
+    auto* roomChatHeader = new QLabel("ROOM CHAT", this);
+    roomChatHeader->setProperty("class", "SectionHeader");
+    roomChatHeader->setContentsMargins(0, SPACING_DEFAULT, 0, 0);
+    lay->addWidget(roomChatHeader);
+
+    auto* roomChatCard = new QFrame(this);
+    roomChatCard->setObjectName("LobbyCard");
+    auto* roomChatLay = new QVBoxLayout(roomChatCard);
+    roomChatLay->setContentsMargins(SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT);
+    roomChatLay->setSpacing(SPACING_DEFAULT);
+
+    m_chatViewRoom = new QTextEdit(roomChatCard);
+    m_chatViewRoom->setReadOnly(true);
+    m_chatViewRoom->setLineWrapMode(QTextEdit::WidgetWidth);
+    m_chatViewRoom->setFrameShape(QFrame::NoFrame);
+    roomChatLay->addWidget(m_chatViewRoom, 1);
+
+    m_roomChatInput = new QLineEdit(roomChatCard);
+    m_roomChatInput->setPlaceholderText("Message the room…");
+    m_roomChatInput->setEnabled(false);
+    m_roomChatInput->setMinimumHeight(BUTTON_MIN_HEIGHT);
+    connect(m_roomChatInput, &QLineEdit::returnPressed, this, &RollbackLobbyDialog::onRoomChatSendClicked);
+    roomChatLay->addWidget(m_roomChatInput);
+
+    lay->addWidget(roomChatCard, 1);   // expands to fill between seats and actions
 
     // ── Action bar ──
     auto* actionRow = new QHBoxLayout;
@@ -950,7 +980,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     m_dropBtn = new QPushButton("Drop Game", this);
     m_dropBtn->setObjectName("DropBtn");
     m_dropBtn->setEnabled(false);
-    m_dropBtn->setMinimumHeight(BUTTON_MIN_HEIGHT);
+    m_dropBtn->setMinimumHeight(HERO_BUTTON_HEIGHT);
     m_dropBtn->setAutoDefault(false);
     m_dropBtn->setDefault(false);
     m_dropBtn->setCursor(Qt::PointingHandCursor);
@@ -959,7 +989,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     m_leaveBtn = new QPushButton("Leave Room", this);
     m_leaveBtn->setObjectName("LeaveBtn");
-    m_leaveBtn->setMinimumHeight(BUTTON_MIN_HEIGHT);
+    m_leaveBtn->setMinimumHeight(HERO_BUTTON_HEIGHT);
     m_leaveBtn->setAutoDefault(false);
     m_leaveBtn->setDefault(false);
     m_leaveBtn->setCursor(Qt::PointingHandCursor);
@@ -988,6 +1018,20 @@ void RollbackLobbyDialog::buildSeatRow(SeatRow& s, int slotIdx, QWidget* parent)
     auto* lay = new QHBoxLayout(s.row);
     lay->setContentsMargins(MARGIN_GROUP, SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT);
     lay->setSpacing(SPACING_DEFAULT);
+
+    // Drag grip — only shown to the host while the room is waiting (toggled in
+    // onRoomStateChanged). Dragging it onto another seat swaps the two players.
+    // A hidden widget reclaims its layout space, so non-host seats stay flush.
+    s.dragHandle = new QLabel(QStringLiteral("⋮⋮"), s.row);
+    s.dragHandle->setObjectName("SeatDragHandle");
+    s.dragHandle->setFixedWidth(14);
+    s.dragHandle->setAlignment(Qt::AlignCenter);
+    s.dragHandle->setForegroundRole(QPalette::PlaceholderText); // subtle grip
+    s.dragHandle->setCursor(Qt::OpenHandCursor);
+    s.dragHandle->setToolTip(QStringLiteral("Drag onto another seat to swap players"));
+    s.dragHandle->setVisible(false);
+    s.dragHandle->installEventFilter(this);
+    lay->addWidget(s.dragHandle);
 
     // Filled/empty dot — single glyph, tinted with the player's accent when
     // filled (set in renderSeatFilled), muted grey when empty.
@@ -1138,14 +1182,17 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
 
 QWidget* RollbackLobbyDialog::buildChatColumn()
 {
-    // The tab labels ("Lobby" / "Room") already convey the column's identity;
-    // a borderless rounded card frame matches the players list and the P2P
-    // hosting screen. documentMode keeps the tabs flat so they don't double-
-    // border against the card edge.
+    // Lobby chat only — room chat lives below the seats in the in-room view.
+    // A bold header labels the column (it used to be a tab) and the chat sits
+    // in the same rounded card as the players list.
     auto* col = new QWidget(this);
     auto* lay = new QVBoxLayout(col);
     lay->setContentsMargins(MARGIN_OUTER, MARGIN_OUTER, MARGIN_OUTER, MARGIN_OUTER);
     lay->setSpacing(SPACING_DEFAULT);
+
+    auto* header = new QLabel("LOBBY CHAT", this);
+    header->setProperty("class", "SectionHeader");
+    lay->addWidget(header);
 
     auto* card = new QFrame(col);
     card->setObjectName("LobbyCard");
@@ -1153,22 +1200,14 @@ QWidget* RollbackLobbyDialog::buildChatColumn()
     cardLay->setContentsMargins(SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT, SPACING_DEFAULT);
     cardLay->setSpacing(SPACING_DEFAULT);
 
-    // ChatTabWidget installs the HalfWidthTabBar internally (setTabBar is
-    // protected). Each tab is half the column wide: one tab → 50%, two → 100%.
-    m_chatTabs = new ChatTabWidget(card);
-    m_chatTabs->setObjectName("ChatTabs");
-    m_chatTabs->setDocumentMode(true);
-
     m_chatViewLobby = new QTextEdit(card);
     m_chatViewLobby->setReadOnly(true);
     m_chatViewLobby->setLineWrapMode(QTextEdit::WidgetWidth);
     m_chatViewLobby->setFrameShape(QFrame::NoFrame);
-    m_chatTabs->addTab(m_chatViewLobby, "Lobby");
-
-    cardLay->addWidget(m_chatTabs, 1);
+    cardLay->addWidget(m_chatViewLobby, 1);
 
     m_chatInput = new QLineEdit(card);
-    m_chatInput->setPlaceholderText("Type a message and press Enter…");
+    m_chatInput->setPlaceholderText("Message the lobby…");
     m_chatInput->setEnabled(false);
     m_chatInput->setMinimumHeight(BUTTON_MIN_HEIGHT);
     connect(m_chatInput, &QLineEdit::returnPressed, this, &RollbackLobbyDialog::onChatSendClicked);
@@ -1229,6 +1268,20 @@ void RollbackLobbyDialog::applyStylesheet()
     const QString border = dark ? QStringLiteral("rgba(255,255,255,0.18)")
                                 : QStringLiteral("palette(mid)");
 
+    // Disabled controls need a *readable* grey on dark themes — palette(mid) is
+    // near-invisible against the dark base (you can't see a non-host's combos or
+    // the "No ROMs" picker). Light mode keeps palette(mid), which already reads.
+    const QString disabledText = dark ? QStringLiteral("rgba(255,255,255,0.45)")
+                                      : QStringLiteral("palette(mid)");
+
+    // Selected-row highlight for the lobby tables. Styling ::item makes Qt fall
+    // back to a near-white selection that's unreadable on dark themes, so set an
+    // explicit blue wash + readable text for each theme.
+    const QString selBg   = dark ? QStringLiteral("rgba(0,120,215,0.55)")
+                                 : QStringLiteral("rgba(0,120,215,0.22)");
+    const QString selText = dark ? QStringLiteral("#ffffff")
+                                 : QStringLiteral("palette(text)");
+
     // Banner accent — soft blue tint that reads on both light and dark themes.
     const QString bannerBg = dark
         ? QStringLiteral("rgba(0, 120, 215, 0.18)")
@@ -1246,7 +1299,13 @@ void RollbackLobbyDialog::applyStylesheet()
     const QString comboArrow = QString(":/icons/%1/svg/arrow-down-s-line.svg")
         .arg(dark ? "white" : "black");
 
-    const QString qss = QString(
+    // Drop Game is destructive (it ends the match), so it gets a caution-red
+    // secondary treatment — same size as the others, set apart by color, not
+    // size. Leave Room stays neutral; Start Game is the filled-blue primary.
+    const QString cautionRed  = dark ? QStringLiteral("#ef6b68") : QStringLiteral("#c0392b");
+    const QString cautionSoft = tintRgba(cautionRed, dark ? 0.18 : 0.10);
+
+    QString qss = QString(
         // Marquee — faint accent header band with a hairline divider.
         "QFrame#LobbyMarquee {"
         "  background-color: %5;"
@@ -1285,46 +1344,6 @@ void RollbackLobbyDialog::applyStylesheet()
         "QTreeWidget#RoomsTree QHeaderView::section:last,"
         " QTreeWidget#MatchesTree QHeaderView::section:last {"
         "  border-right: none;"
-        "}"
-
-        // Chat tabs — flat underline style (no surrounding bar / boxed tabs).
-        // Each tab is half the column wide via HalfWidthTabBar.
-        "QTabWidget#ChatTabs::pane {"
-        "  border: none;"
-        "  background: transparent;"
-        "}"
-        "QTabWidget#ChatTabs QTabBar {"
-        "  background: transparent;"
-        "  qproperty-drawBase: 0;"
-        "}"
-        // Both tabs read as tabs (subtle neutral fill); the active one is
-        // accented with a blue fill, text and underline. Only the *outer*
-        // corners round — the two tabs share a flat seam in the middle (first
-        // tab rounds top-left, last rounds top-right, a lone tab rounds both).
-        "QTabWidget#ChatTabs QTabBar::tab {"
-        "  background: rgba(127, 127, 127, 0.12);"
-        "  border: none;"
-        "  border-bottom: 2px solid transparent;"
-        "  border-top-left-radius: 0px;"
-        "  border-top-right-radius: 0px;"
-        "  padding: 5px 10px;"
-        "  margin: 0px;"
-        "  color: palette(text);"
-        "}"
-        "QTabWidget#ChatTabs QTabBar::tab:first { border-top-left-radius: 6px; }"
-        "QTabWidget#ChatTabs QTabBar::tab:last { border-top-right-radius: 6px; }"
-        "QTabWidget#ChatTabs QTabBar::tab:only-one {"
-        "  border-top-left-radius: 6px;"
-        "  border-top-right-radius: 6px;"
-        "}"
-        "QTabWidget#ChatTabs QTabBar::tab:hover {"
-        "  background: rgba(127, 127, 127, 0.20);"
-        "}"
-        "QTabWidget#ChatTabs QTabBar::tab:selected {"
-        "  color: %4;"
-        "  background: %5;"
-        "  border-bottom: 2px solid %4;"
-        "  font-weight: 600;"
         "}"
 
         // Section headers — bold uppercase label with a hairline divider
@@ -1395,6 +1414,24 @@ void RollbackLobbyDialog::applyStylesheet()
         "  color: palette(mid);"
         "}"
 
+        // Drop Game — caution variant of the secondary style (destructive).
+        "QPushButton#DropBtn {"
+        "  color: %7;"
+        "  border-color: %7;"
+        "}"
+        "QPushButton#DropBtn:hover {"
+        "  color: %7;"
+        "  border-color: %7;"
+        "  background-color: %8;"
+        "}"
+        "QPushButton#DropBtn:pressed {"
+        "  background-color: %8;"
+        "}"
+        "QPushButton#DropBtn:disabled {"
+        "  color: palette(mid);"
+        "  border-color: %1;"
+        "}"
+
         // Session-setting combos — rounded, themed border (P2P style).
         "QComboBox#LobbyCombo, QComboBox#BrowseRomCombo {"
         "  border: 1px solid %1;"
@@ -1403,10 +1440,26 @@ void RollbackLobbyDialog::applyStylesheet()
         "  padding: 3px 8px;"
         "  min-height: 22px;"
         "}"
+        // The browse combo is editable (searchable); strip the embedded line
+        // edit's own frame/background so it sits flush inside the combo border.
+        "QComboBox#BrowseRomCombo QLineEdit {"
+        "  border: none;"
+        "  background: transparent;"
+        "  padding: 0px;"
+        "  color: palette(text);"
+        "  selection-background-color: palette(highlight);"
+        "}"
         "QComboBox#LobbyCombo:focus, QComboBox#BrowseRomCombo:focus {"
         "  border-color: palette(highlight);"
         "}"
-        "QComboBox#LobbyCombo:disabled { color: palette(mid); }"
+        "QComboBox#LobbyCombo:disabled, QComboBox#BrowseRomCombo:disabled {"
+        "  color: %9;"
+        "}"
+        // Editable browse combo: the embedded line edit's own color rule would
+        // otherwise win, so dim it explicitly when disabled too.
+        "QComboBox#BrowseRomCombo QLineEdit:disabled {"
+        "  color: %9;"
+        "}"
         "QComboBox#LobbyCombo::drop-down, QComboBox#BrowseRomCombo::drop-down {"
         "  subcontrol-origin: padding;"
         "  subcontrol-position: top right;"
@@ -1440,7 +1493,20 @@ void RollbackLobbyDialog::applyStylesheet()
         "QPushButton#SeatKickButton:pressed {"
         "  background-color: rgba(208, 72, 72, 0.20);"
         "}"
-    ).arg(border, bannerBg, bannerBorder, brandAccent, marqueeBg, comboArrow);
+    ).arg(border, bannerBg, bannerBorder, brandAccent, marqueeBg, comboArrow,
+          cautionRed, cautionSoft, disabledText);
+
+    // Appended separately: the block above already uses the 9-arg arg() limit.
+    // A bare :selected covers both focused and unfocused selection, so the row
+    // stays readable after focus moves (e.g. right after a double-click to join).
+    qss += QString(
+        "QTreeWidget#RoomsTree::item:selected,"
+        " QTreeWidget#MatchesTree::item:selected,"
+        " QTreeWidget#PlayersTree::item:selected {"
+        "  background-color: %1;"
+        "  color: %2;"
+        "}"
+    ).arg(selBg, selText);
 
     setStyleSheet(qss);
 }
@@ -1508,6 +1574,22 @@ void RollbackLobbyDialog::populateBrowseRoms()
     m_browseRomCombo->blockSignals(false);
 }
 
+QVariantMap RollbackLobbyDialog::selectedBrowseRom() const
+{
+    if (!m_browseRomCombo || !m_browseRomCombo->isEnabled())
+        return {};
+    QVariantMap data = m_browseRomCombo->currentData().toMap();
+    // Editable combo: if the user typed an exact name but didn't commit it (no
+    // index change), currentData() is stale — fall back to matching the text.
+    if (data.value("md5").toString().isEmpty())
+    {
+        const int idx = m_browseRomCombo->findText(m_browseRomCombo->currentText());
+        if (idx >= 0)
+            data = m_browseRomCombo->itemData(idx).toMap();
+    }
+    return data;
+}
+
 // ──────────────────────────────────────────────────────────────────────
 //  Show / close
 // ──────────────────────────────────────────────────────────────────────
@@ -1543,8 +1625,117 @@ bool RollbackLobbyDialog::eventFilter(QObject* watched, QEvent* event)
         auto* me = static_cast<QMouseEvent*>(event);
         if (!m_playersTree->itemAt(me->position().toPoint()))
             m_playersTree->clearSelection();
+        return QDialog::eventFilter(watched, event);
     }
+
+    // ── Seat reorder: start a drag from a seat's grip handle ──
+    if (m_canReorderSeats)
+    {
+        for (auto& s : m_seats)
+        {
+            if (!s.dragHandle || watched != s.dragHandle)
+                continue;
+            if (event->type() == QEvent::MouseButtonPress)
+            {
+                auto* me = static_cast<QMouseEvent*>(event);
+                if (me->button() == Qt::LeftButton && s.userId != 0)
+                {
+                    m_seatDragStartPos = me->globalPosition().toPoint();
+                    m_seatDragSlot     = s.slot;
+                }
+                return true;
+            }
+            if (event->type() == QEvent::MouseButtonRelease)
+            {
+                m_seatDragSlot = 0;
+                return true;
+            }
+            if (event->type() == QEvent::MouseMove)
+            {
+                auto* me = static_cast<QMouseEvent*>(event);
+                if ((me->buttons() & Qt::LeftButton) && m_seatDragSlot != 0 &&
+                    (me->globalPosition().toPoint() - m_seatDragStartPos).manhattanLength()
+                        >= QApplication::startDragDistance())
+                {
+                    const int slot = m_seatDragSlot;
+                    m_seatDragSlot = 0;
+                    startSeatDrag(slot, s.row);
+                }
+                return true;
+            }
+        }
+    }
+
+    // ── Seat reorder: accept the drop and ask the server to swap ──
+    if (m_seatsBox && watched == m_seatsBox)
+    {
+        if (event->type() == QEvent::DragEnter || event->type() == QEvent::DragMove)
+        {
+            auto* de = static_cast<QDragMoveEvent*>(event);
+            if (de->mimeData() && de->mimeData()->hasFormat(kSeatMime))
+            {
+                de->acceptProposedAction();
+                return true;
+            }
+        }
+        else if (event->type() == QEvent::Drop)
+        {
+            auto* de = static_cast<QDropEvent*>(event);
+            if (de->mimeData() && de->mimeData()->hasFormat(kSeatMime))
+            {
+                const int from = de->mimeData()->data(kSeatMime).toInt();
+                const int to   = seatSlotAtPos(de->position().toPoint());
+                if (m_client && m_canReorderSeats && from >= 1 && to >= 1 && from != to)
+                    m_client->swapSeats(from, to);
+                de->acceptProposedAction();
+                return true;
+            }
+        }
+    }
+
     return QDialog::eventFilter(watched, event);
+}
+
+void RollbackLobbyDialog::startSeatDrag(int slot, QWidget* card)
+{
+    if (slot < 1 || !card)
+        return;
+    auto* drag = new QDrag(this);
+    auto* mime = new QMimeData();
+    mime->setData(kSeatMime, QByteArray::number(slot));
+    drag->setMimeData(mime);
+    // Carry a snapshot of the seat card under the cursor for feedback.
+    const QPixmap pm = card->grab();
+    if (!pm.isNull())
+    {
+        drag->setPixmap(pm);
+        drag->setHotSpot(QPoint(pm.width() / 8, pm.height() / 2));
+    }
+    drag->exec(Qt::MoveAction);
+}
+
+int RollbackLobbyDialog::seatSlotAtPos(const QPoint& pos) const
+{
+    // pos is in m_seatsBox coordinates (the drop target). Seat cards are its
+    // direct children, so their geometry() is in the same space.
+    for (const auto& s : m_seats)
+    {
+        if (s.row && s.row->isVisible() && s.row->geometry().contains(pos))
+            return s.slot;
+    }
+    return 0;
+}
+
+QString RollbackLobbyDialog::localRomPathForMd5(const QString& md5) const
+{
+    if (md5.isEmpty())
+        return QString();
+    for (auto it = m_roms.constBegin(); it != m_roms.constEnd(); ++it)
+    {
+        if (QString::fromStdString(it.value().MD5).compare(md5, Qt::CaseInsensitive) == 0)
+            return it.key();
+    }
+    return QString();
 }
 
 QString RollbackLobbyDialog::prefillUsername() const
@@ -1683,14 +1874,8 @@ void RollbackLobbyDialog::onClientStateChanged(LobbyClient::ConnectionState s)
         m_quickMatchActive = false;
         if (m_quickMatchBtn) m_quickMatchBtn->setText("⚡  Quick Match");
 
-        if (m_chatViewRoom)
-        {
-            const int idx = m_chatTabs->indexOf(m_chatViewRoom);
-            if (idx >= 0) m_chatTabs->removeTab(idx);
-            m_chatViewRoom->deleteLater();
-            m_chatViewRoom = nullptr;
-        }
-        m_chatTabs->setCurrentWidget(m_chatViewLobby);
+        if (m_chatViewRoom) m_chatViewRoom->clear();
+        if (m_roomChatInput) m_roomChatInput->setEnabled(false);
         switchToRoomsView();
     }
     updateServerMeta();
@@ -2037,18 +2222,19 @@ void RollbackLobbyDialog::onCreateRoomClicked()
         m_createRoomDialog->activateWindow();
         return;
     }
-    // Open Create Room on the game chosen in the browse picker. CreateRoomDialog
-    // seeds its ROM from this key (findText on identical display names).
-    if (m_browseRomCombo && m_browseRomCombo->isEnabled() &&
-        !m_browseRomCombo->currentText().isEmpty())
+    // The room's game is whatever is selected in the lobby's shared picker — the
+    // same source Quick Match uses. Require a real pick before opening the form.
+    const QVariantMap romData = selectedBrowseRom();
+    const QString romName = romData.value("name").toString();
+    const QString romMd5  = romData.value("md5").toString();
+    if (romMd5.isEmpty())
     {
-        QSettings s;
-        s.beginGroup("Lobby/CreateRoom");
-        s.setValue("Rom", m_browseRomCombo->currentText());
-        s.endGroup();
+        QMessageBox::information(this, "Select a game",
+            "Pick a game from the dropdown before creating a room.");
+        return;
     }
 
-    m_createRoomDialog = new CreateRoomDialog(m_username, m_roms, this);
+    m_createRoomDialog = new CreateRoomDialog(m_username, romName, romMd5, this);
     connect(m_createRoomDialog, &CreateRoomDialog::createRequested,
             this, &RollbackLobbyDialog::onRoomCreateRequested);
     connect(m_createRoomDialog, &QDialog::finished, this, [this](int) {
@@ -2133,20 +2319,11 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
     m_knownSeatedUsers.clear();
     m_roomSeatsSeen = false;
 
-    if (!m_chatViewRoom)
-    {
-        m_chatViewRoom = new QTextEdit(this);
-        m_chatViewRoom->setReadOnly(true);
-        m_chatViewRoom->setLineWrapMode(QTextEdit::WidgetWidth);
-        m_chatViewRoom->setFrameShape(QFrame::NoFrame);
-        m_chatTabs->addTab(m_chatViewRoom, "Room");
-    }
-    else
-    {
-        // Fresh room, fresh chat — never carry the previous room's messages in.
-        m_chatViewRoom->clear();
-    }
-    m_chatTabs->setCurrentWidget(m_chatViewRoom);
+    // Fresh room, fresh chat — never carry the previous room's messages in.
+    // The room chat widget lives in the in-room view (below the seats) and
+    // persists; just clear it and enable its input.
+    if (m_chatViewRoom) m_chatViewRoom->clear();
+    if (m_roomChatInput) m_roomChatInput->setEnabled(true);
     switchToInRoomView();
 
     if (m_createRoomBtn) m_createRoomBtn->setEnabled(false);
@@ -2155,20 +2332,19 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
     updateInRoomBanner();
 
     if (!greetingChatLine.isEmpty())
-        appendChatLine(CHANNEL_LOBBY, greetingChatLine);
+        appendChatLine(CHANNEL_ROOM, greetingChatLine);
 
     // Start measuring actual round-trip to seated peers. Seat assignments
-    // populate via the follow-up ROOM_STATE message; the first tick fires
-    // 5 s after entry which gives that state plenty of time to arrive.
+    // populate via the follow-up ROOM_STATE message, which fires its own
+    // immediate probe per newly-seated peer; this timer just refreshes them.
     if (m_pingProbeTimer && !m_pingProbeTimer->isActive())
         m_pingProbeTimer->start();
 
-    // The regular cadence is 5 s, but a Quick Match auto-starts after a short
-    // warmup — too soon for that first tick. Kick one early probe (~1.2 s, once
-    // ROOM_STATE has populated the seats) so ping shows promptly and the host's
-    // Auto delay resolves before the match begins. Harmless in an empty room:
-    // onPingProbeTick skips self / unseated slots.
-    QTimer::singleShot(1200, this, &RollbackLobbyDialog::onPingProbeTick);
+    // Backstop in case ROOM_STATE seats arrive in a shape that didn't trigger a
+    // per-peer probe — kick one sweep shortly after entry so ping shows promptly
+    // and the host's Auto delay resolves before the match begins. Harmless in an
+    // empty room: onPingProbeTick skips self / unseated slots.
+    QTimer::singleShot(600, this, &RollbackLobbyDialog::onPingProbeTick);
 }
 
 void RollbackLobbyDialog::onRoomDoubleClicked(QTreeWidgetItem* item, int /*column*/)
@@ -2200,6 +2376,19 @@ void RollbackLobbyDialog::onRoomDoubleClicked(QTreeWidgetItem* item, int /*colum
             QMessageBox::information(this, "Match in progress",
                 "That room is already playing — try another or wait for it to finish.");
         }
+        return;
+    }
+
+    // Don't join a room whose ROM we don't have. Otherwise we'd commit, make the
+    // other players wait, then fail pre-match sync — which used to hang the whole
+    // client. Matched by MD5, the same check onMatchBegin uses, so passing here
+    // guarantees the ROM resolves at match start too.
+    if (!summary.romMd5.isEmpty() && localRomPathForMd5(summary.romMd5).isEmpty())
+    {
+        QMessageBox::warning(this, "ROM not found",
+            QString("You don't have the ROM for \"%1\" (%2).\n\n"
+                    "Add it to your ROM directory and refresh the list, then try again.")
+                .arg(summary.name, summary.romName));
         return;
     }
 
@@ -2432,6 +2621,16 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         }
     }
 
+    // Seat reorder is host-only and pre-match. Show the drag grip on occupied,
+    // visible seats so the host can drag one onto another to swap them.
+    m_canReorderSeats = iAmHost && (state == "waiting");
+    for (int i = 0; i < 4; ++i)
+    {
+        if (m_seats[i].dragHandle)
+            m_seats[i].dragHandle->setVisible(
+                m_canReorderSeats && i < maxPlayers && m_seats[i].userId != 0);
+    }
+
     // Flash + chime when a *new* player takes a seat. Compare this ROOM_STATE's
     // seated set against the last one; any id that's newly present (and isn't us)
     // is a join. The first ROOM_STATE after entering a room just seeds the set —
@@ -2443,32 +2642,64 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
             const quint64 uid = static_cast<quint64>(v.toObject().value("userId").toDouble());
             if (uid != 0) currentSeated.insert(uid);
         }
-        if (m_roomSeatsSeen)
+        const quint64 selfId = m_client->selfUserId();
+        bool sawNewPeer = false;
+        for (const quint64 uid : currentSeated)
         {
-            const quint64 selfId = m_client->selfUserId();
-            for (const quint64 uid : currentSeated)
-            {
-                if (uid != selfId && !m_knownSeatedUsers.contains(uid))
-                {
-                    notifyPlayerJoined();
-                    break; // one alert covers a batch of simultaneous joins
-                }
-            }
+            if (uid == selfId || m_knownSeatedUsers.contains(uid))
+                continue;
+            // Probe a newly-seated peer immediately so their ping appears within
+            // an RTT instead of waiting on the next probe tick — and so the host's
+            // Auto delay resolves from real ping before the match begins.
+            if (m_client) m_client->requestPingProbe(uid);
+            sawNewPeer = true;
         }
+        // Chime only once we've settled in: the first ROOM_STATE's occupants were
+        // already here, so they don't count as joins.
+        if (m_roomSeatsSeen && sawNewPeer)
+            notifyPlayerJoined();
         m_knownSeatedUsers = currentSeated;
         m_roomSeatsSeen = true;
     }
 
-    // Host can start whenever there are at least 2 seated players — no ready
-    // gate. Disabled mid-match (state != waiting) so the host can't start a
-    // second match on top of a live one.
-    const int seated = players.size();
-    const bool canStart = (state == "waiting") && seated >= 2;
-    m_startBtn->setEnabled(iAmHost && canStart);
+    // Start button gating (host-only): waiting, 2+ seated, ping from everyone.
+    refreshStartButton();
+}
+
+void RollbackLobbyDialog::refreshStartButton()
+{
+    if (!m_startBtn)
+        return;
+
+    const quint64 selfId = m_client ? m_client->selfUserId() : 0;
+    const bool iAmHost = (m_client && m_currentRoomHostId == selfId);
+    const bool waiting = (m_currentRoomState == "waiting");
+
+    int seated = 0;
+    int peersAwaitingPing = 0;
+    for (const auto& s : m_seats)
+    {
+        if (s.userId == 0)
+            continue;
+        ++seated;
+        // We never ping ourselves; every *other* seated player needs a measured
+        // ping before the host may start, so the match opens on real latency
+        // (and the Auto frame-delay has resolved from it).
+        if (s.userId != selfId && m_client && m_client->measuredPingMs(s.userId) < 0)
+            ++peersAwaitingPing;
+    }
+
+    const bool enoughPlayers = seated >= 2;
+    const bool pingsReady    = (peersAwaitingPing == 0);
+    const bool canStart      = iAmHost && waiting && enoughPlayers && pingsReady;
+
+    m_startBtn->setEnabled(canStart);
     m_startBtn->setToolTip(
-        !iAmHost ? "Only the host can start the game."
-                 : (canStart ? "" : (seated < 2 ? "Need at least 2 players to start."
-                                                : "Already in a match.")));
+        !iAmHost         ? QStringLiteral("Only the host can start the game.")
+        : !waiting       ? QStringLiteral("Already in a match.")
+        : !enoughPlayers ? QStringLiteral("Need at least 2 players to start.")
+        : !pingsReady    ? QStringLiteral("Measuring ping to all players…")
+                         : QString());
 }
 
 void RollbackLobbyDialog::onDropGameClicked()
@@ -2607,6 +2838,9 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
     // only acts when we're the host of a waiting room with Auto selected.
     if (m_delayAuto)
         applyHostRoomSettings(false);
+
+    // A peer's first ping may be what unblocks the host's Start button.
+    refreshStartButton();
 }
 
 int RollbackLobbyDialog::worstSeatPingMs() const
@@ -2687,14 +2921,8 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
 
     if (m_client) m_client->reopenUdpAnchor();
 
-    if (m_chatViewRoom)
-    {
-        const int idx = m_chatTabs->indexOf(m_chatViewRoom);
-        if (idx >= 0) m_chatTabs->removeTab(idx);
-        m_chatViewRoom->deleteLater();
-        m_chatViewRoom = nullptr;
-    }
-    m_chatTabs->setCurrentWidget(m_chatViewLobby);
+    if (m_chatViewRoom) m_chatViewRoom->clear();
+    if (m_roomChatInput) m_roomChatInput->setEnabled(false);
 
     switchToRoomsView();
     if (m_startBtn) m_startBtn->setEnabled(false);
@@ -2725,13 +2953,17 @@ void RollbackLobbyDialog::onChatSendClicked()
 {
     const QString text = m_chatInput->text().trimmed();
     if (text.isEmpty()) return;
-
-    QString channel = CHANNEL_LOBBY;
-    if (m_chatViewRoom && m_chatTabs->currentWidget() == m_chatViewRoom)
-        channel = CHANNEL_ROOM;
-
-    m_client->sendChat(channel, text);
+    m_client->sendChat(CHANNEL_LOBBY, text);
     m_chatInput->clear();
+}
+
+void RollbackLobbyDialog::onRoomChatSendClicked()
+{
+    if (!m_roomChatInput) return;
+    const QString text = m_roomChatInput->text().trimmed();
+    if (text.isEmpty()) return;
+    m_client->sendChat(CHANNEL_ROOM, text);
+    m_roomChatInput->clear();
 }
 
 void RollbackLobbyDialog::onChatMessageReceived(const LobbyClient::ChatMessage& msg)
@@ -2811,7 +3043,7 @@ void RollbackLobbyDialog::onQuickMatchClicked()
             return;
         }
 
-        const QVariantMap romData = m_browseRomCombo ? m_browseRomCombo->currentData().toMap() : QVariantMap();
+        const QVariantMap romData = selectedBrowseRom();
         const QString romName = romData.value("name").toString();
         const QString romMd5  = romData.value("md5").toString();
         if (romMd5.isEmpty())
@@ -2959,6 +3191,34 @@ void RollbackLobbyDialog::onSpectateFailed(quint64 matchId, const QString& reaso
     emit spectateStreamClosed(reason);
 }
 
+void RollbackLobbyDialog::abortMatchStart(const QString& reason)
+{
+    if (!reason.isEmpty())
+    {
+        appendChatSystemLine(CHANNEL_ROOM, reason);
+        CoreAddCallbackMessage(CoreDebugMessageType::Error, reason.toUtf8().constData());
+    }
+    applyRoomStateBadge("Pre-match start failed", QString(statusColors().fail));
+
+    const quint64 matchId = m_currentMatchId;
+    m_awaitingEmulationStart = false;
+    m_currentMatchId = 0;
+
+    // Cancel any launch the MainWindow may already be spinning up, and tell the
+    // server the match is over so the room flips back to "waiting" for everyone
+    // (a follow-up ROOM_STATE re-enables Start and clears the badge).
+    emit closeMatchRequested();
+    if (matchId != 0 && m_client)
+        m_client->reportMatchFinished(matchId);
+
+    if (m_dropBtn) m_dropBtn->setEnabled(false);
+
+    // No-op while the anchor is still open (these failures all happen before
+    // releaseUdpAnchor); guards the rare path where it was already torn down so
+    // ping probing keeps working without a relaunch.
+    if (m_client) m_client->reopenUdpAnchor();
+}
+
 void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient::LobbyMatchPeer>& peers)
 {
     const QString line = QString("Match #%1 starting with %2 player(s)").arg(matchId).arg(peers.size());
@@ -3034,7 +3294,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     }
     if (!foundLocal)
     {
-        appendChatSystemLine(CHANNEL_ROOM, "MATCH_BEGIN missing local peer - aborting");
+        abortMatchStart("Match start failed: missing local peer.");
         return;
     }
 
@@ -3109,7 +3369,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
 
     if (remotePeers.isEmpty())
     {
-        appendChatSystemLine(CHANNEL_ROOM, "MATCH_BEGIN missing remote peer - aborting");
+        abortMatchStart("Match start failed: missing remote peer.");
         return;
     }
 
@@ -3119,23 +3379,10 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     // mapping so GekkoNet's first frame doesn't have to eat the handshake.
     m_client->punchPeerEndpoints(peers);
 
-    QString localRomFile;
-    for (auto it = m_roms.constBegin(); it != m_roms.constEnd(); ++it)
-    {
-        if (QString::fromStdString(it.value().MD5).compare(m_currentRoomMd5, Qt::CaseInsensitive) == 0)
-        {
-            localRomFile = it.key();
-            break;
-        }
-    }
-
+    const QString localRomFile = localRomPathForMd5(m_currentRoomMd5);
     if (localRomFile.isEmpty())
     {
-        const QString message = QString("Pre-match sync failed: local ROM not found for %1").arg(m_currentRoomGame);
-        appendChatSystemLine(CHANNEL_ROOM, message);
-        CoreAddCallbackMessage(CoreDebugMessageType::Error, message.toUtf8().constData());
-        m_awaitingEmulationStart = false;
-        applyRoomStateBadge("Pre-match sync failed", QString(statusColors().fail));
+        abortMatchStart(QString("Match start failed: you don't have the ROM for %1.").arg(m_currentRoomGame));
         return;
     }
 
@@ -3143,13 +3390,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     QString prematchError;
     if (!m_client->syncPrematchManifest(peers, local.slot, localRomFile, prematchError))
     {
-        const QString message = prematchError.isEmpty()
-            ? QStringLiteral("Pre-match sync failed.")
-            : prematchError;
-        appendChatSystemLine(CHANNEL_ROOM, message);
-        CoreAddCallbackMessage(CoreDebugMessageType::Error, message.toUtf8().constData());
-        m_awaitingEmulationStart = false;
-        applyRoomStateBadge("Pre-match sync failed", QString(statusColors().fail));
+        abortMatchStart(prematchError.isEmpty() ? QStringLiteral("Pre-match sync failed.") : prematchError);
         return;
     }
     appendChatSystemLine(CHANNEL_ROOM, "Pre-match sync complete.");

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -96,6 +96,9 @@ signals:
 protected:
     void showEvent(QShowEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
+    // Clears the players-list selection when the user clicks empty space in it,
+    // so a highlighted name can be dismissed by clicking off it.
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private slots:
     void onConnectClicked();
@@ -184,6 +187,9 @@ private:
     void    switchToInRoomView();
     void    enterRoom(quint64 roomId, const QString& greetingChatLine);
     void    updateStatusIndicator(LobbyClient::ConnectionState s);
+    // Render the in-room state label as a colored pill (Waiting / Connecting /
+    // In Game / failure). colorHex drives both the text and the soft fill.
+    void    applyRoomStateBadge(const QString& text, const QString& colorHex);
     void    updateServerMeta();
     void    updateInRoomBanner();   // refresh "you're in: X" banner in browse view
 
@@ -217,6 +223,7 @@ private:
         QPushButton* kickButton = nullptr; // ✕ — host-only, removes the seated player
         bool     isHost    = false;
         quint64  userId    = 0;           // seated user, 0 when empty
+        int      slot      = 0;           // 1-4, drives the per-player accent color
     };
     void buildSeatRow(SeatRow& row, int slotIdx, QWidget* parent);
     void renderSeatEmpty(SeatRow& row);
@@ -234,6 +241,7 @@ private:
     // ── Marquee bar ──
     QFrame*  m_marquee     = nullptr;
     QLabel*  m_brandLabel  = nullptr;
+    QFrame*  m_statusPill  = nullptr;   // rounded pill holding the LED + text
     QLabel*  m_statusLed   = nullptr;
     QLabel*  m_statusText  = nullptr;
     QLabel*  m_serverMeta  = nullptr;

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -75,8 +75,10 @@ public:
 signals:
     // Fired when the server has issued MATCH_BEGIN. Each entry in remotePeers
     // is pre-formatted as "<slot>,<ip>,<port>" — matches the LOBBY| address
-    // peer-entry format consumed by CoreStartEmulation.
-    void matchReady(QString gameName, QStringList remotePeers,
+    // peer-entry format consumed by CoreStartEmulation. romFile is the local
+    // ROM path resolved by MD5 (not by name) so ROMs absent from the database
+    // — where name matching fails — still launch; gameName is for display only.
+    void matchReady(QString gameName, QString romFile, QStringList remotePeers,
                     int localPort, int localPlayer,
                     int frameDelay, int predictionWindow);
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -94,6 +94,9 @@ signals:
     // broadcast match, feed it krec bytes as they arrive, and tear it down.
     void spectateLaunch(quint64 matchId, QString gameName);
     void spectateStreamData(QByteArray bytes, int liveFrame);
+    // A savestate keyframe (raw bytes) the spectator should restore at frame before
+    // replaying the krec tail, so catch-up is bounded regardless of match length.
+    void spectateStreamKeyframe(int frame, QByteArray savestate);
     void spectateStreamClosed(QString reason);
 
 protected:
@@ -141,6 +144,7 @@ private slots:
     // Spectator: server stream callbacks.
     void onSpectateBegan(quint64 matchId);
     void onSpectateData(quint64 matchId, const QByteArray& bytes, int liveFrame);
+    void onSpectateKeyframe(quint64 matchId, int frame, const QByteArray& savestate);
     void onSpectateEnded(quint64 matchId, const QString& reason);
     void onSpectateFailed(quint64 matchId, const QString& reason);
 
@@ -332,10 +336,20 @@ private:
     QByteArray m_broadcastBuf;
     bool       m_broadcasting   = false;
     quint64    m_broadcastMatchId = 0;
+    // Wall-clock of the last savestate-keyframe request (0 = request one now). The
+    // drain tick requests a keyframe at a fixed interval and polls for the result.
+    qint64     m_lastKeyframeRequestMs = 0;
 
     // Non-zero while this client is spectating a broadcast match (the match id
     // we asked the server to stream). Cleared when the spectate session ends.
     quint64    m_spectatingMatchId = 0;
+    // Session boundary guard. The persistent lobby socket can still deliver krec
+    // chunks from a PREVIOUS watch of the same match after we re-subscribe (same
+    // matchId, so they'd otherwise pass the filter and corrupt the new replay).
+    // The server always sends SPECTATE_BEGIN first on a fresh subscribe, after all
+    // the stale data on the wire — so we drop every keyframe/data message until we
+    // see the BEGIN for the current subscribe. Reset false in beginSpectate.
+    bool       m_spectateStreamArmed = false;
 
     // Seat rows (always 4 — slots beyond maxPlayers are hidden)
     SeatRow    m_seats[4];

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -18,6 +18,8 @@
 #include <QStringList>
 #include <QByteArray>
 #include <QMutex>
+#include <QPoint>
+#include <QVariant>
 
 #include <RMG-Core/RomSettings.hpp>
 
@@ -29,7 +31,6 @@ class QTextEdit;
 class QLineEdit;
 class QPushButton;
 class QSplitter;
-class QTabWidget;
 class QStackedWidget;
 class QComboBox;
 class QCheckBox;
@@ -142,6 +143,7 @@ private slots:
     void onSpectateFailed(quint64 matchId, const QString& reason);
 
     void onChatSendClicked();
+    void onRoomChatSendClicked();
     void onChatMessageReceived(const LobbyClient::ChatMessage& msg);
     void onMatchBegin(quint64 matchId, const QList<LobbyClient::LobbyMatchPeer>& peers);
 
@@ -164,6 +166,12 @@ private:
 
     // Repopulate the browse-view ROM picker from m_roms (RMG-K library).
     void     populateBrowseRoms();
+
+    // Resolve the game selected in the (editable) browse picker to its item data
+    // {name, md5, file}. Falls back to matching the typed text to an item, so a
+    // typed-but-not-committed entry still resolves. Shared by Quick Match and
+    // Create Room. Empty map when nothing valid is selected.
+    QVariantMap selectedBrowseRom() const;
 
     // Swap the top-level stack between the connect screen and the live lobby.
     void     showConnectView(const QString& statusMessage = QString());
@@ -216,6 +224,7 @@ private:
     struct SeatRow
     {
         QWidget* row       = nullptr;
+        QLabel*  dragHandle = nullptr;    // ⋮⋮ — host-only drag grip (reorder)
         QLabel*  dotLabel  = nullptr;     // ● filled, ○ empty
         QLabel*  slotLabel = nullptr;     // "P1"
         QLabel*  nameLabel = nullptr;     // username or "Waiting…"
@@ -229,6 +238,29 @@ private:
     void renderSeatEmpty(SeatRow& row);
     void renderSeatFilled(SeatRow& row, const QString& username, bool isHost,
                           bool isSelf, int pingMs, bool canKick);
+
+    // Seat reorder (host, waiting): a seat's drag handle starts a QDrag carrying
+    // its slot; the seats container handles the drop and asks the server to swap.
+    void startSeatDrag(int slot, QWidget* card);
+    int  seatSlotAtPos(const QPoint& pos) const;
+
+    // Returns the local ROM path whose MD5 matches `md5` (case-insensitive), or
+    // empty if the user doesn't have that ROM. Gates joining a room and resolves
+    // the ROM at match start so both use identical matching.
+    QString localRomPathForMd5(const QString& md5) const;
+
+    // Cleanly abort a match that failed before emulation started (ROM missing or
+    // pre-match sync failed/timed out): reset await state, tell the server the
+    // match is over so the room returns to "waiting", reopen the ping anchor,
+    // and surface `reason` in room chat. Prevents the dialog from getting stuck
+    // on "Connecting…" with a half-started match.
+    void abortMatchStart(const QString& reason);
+
+    // Enable the host's Start button only once the room is startable: waiting,
+    // 2+ players seated, AND a ping measured for every seated peer. Re-run from
+    // both onRoomStateChanged (seats change) and onPingMeasured (ping lands),
+    // since pings arrive asynchronously after seats populate.
+    void refreshStartButton();
 
     LobbyClient* m_client = nullptr;
 
@@ -253,10 +285,10 @@ private:
     QTreeWidget* m_roomsTree     = nullptr;
     QTreeWidget* m_matchesTree   = nullptr;
     QTimer*      m_matchDurationTimer = nullptr;
-    QTabWidget*  m_chatTabs      = nullptr;
     QTextEdit*   m_chatViewLobby = nullptr;
-    QTextEdit*   m_chatViewRoom  = nullptr; // nullptr when not in a room
-    QLineEdit*   m_chatInput     = nullptr;
+    QTextEdit*   m_chatViewRoom  = nullptr; // room chat, shown in the in-room view
+    QLineEdit*   m_chatInput     = nullptr; // lobby chat input (middle column)
+    QLineEdit*   m_roomChatInput = nullptr; // room chat input (below the seats)
 
     // ── Stacked browse / in-room view ──
     QStackedWidget* m_roomsStack = nullptr;
@@ -305,6 +337,10 @@ private:
 
     // Seat rows (always 4 — slots beyond maxPlayers are hidden)
     SeatRow    m_seats[4];
+    QWidget*   m_seatsBox        = nullptr; // container that accepts seat drops
+    bool       m_canReorderSeats = false;   // host && room waiting
+    QPoint     m_seatDragStartPos;          // press point, to clear the drag threshold
+    int        m_seatDragSlot    = 0;       // slot being dragged (0 = none)
 
     // Drives PING_PROBE_REQUEST → UDP PROBE → PROBE_REPLY refresh cycle for
     // each peer seated in the current room. Started when a room is entered,

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -3460,19 +3460,39 @@ void MainWindow::timerEvent(QTimerEvent *event)
             const int liveFrame = this->ui_SpectateLiveFrame > 0
                 ? this->ui_SpectateLiveFrame
                 : n02::playbackGetTotalFrames();
-            const int target = 90; // ~1.5 s behind live
-            const int behind = liveFrame - n02::playbackGetCurrentFrame();
+            const int settle   = 90;  // once catching up, stop ~1.5 s behind live
+            const int reengage = 240; // but don't RE-start catch-up until ~4 s behind
+            const int behind   = liveFrame - n02::playbackGetCurrentFrame();
 
-            if (behind > target)
+            // Hysteresis: engage catch-up only when we're well behind, then run
+            // until we're close. Without the gap, normal live-stream jitter near
+            // the edge would flip the headless toggle on/off and flicker the
+            // screen. The initial join (behind = whole backlog) always engages.
+            const bool wantFastForward = this->ui_SpectateFastForward
+                ? (behind > settle)
+                : (behind > reengage);
+
+            if (wantFastForward)
             {
-                // Catch up headless: drop video/audio/pacing so the emulator
-                // runs uncapped (the krec still feeds via the PIF sync callback).
-                // Drains the backlog in ~1-2 s instead of crawling at rendered 5x.
+                // Fast-forward the buffered krec up to the broadcaster's live
+                // edge. Drop video+audio (headless) so rendering can't cap the
+                // rate, but keep PACING ON and drive the core's speed limiter —
+                // that's the mechanism that actually advances frames faster.
+                // (Dropping the pacing flag skips the limiter but, in practice,
+                // does NOT run uncapped — it crawls at ~1x, so the whole backlog
+                // took realtime to drain.) Speed is capped at the core's 1000%
+                // (10x) max; scale to the gap so a big backlog drains at full
+                // tilt and eases off as we approach the edge.
                 if (!this->ui_SpectateFastForward)
                 {
-                    CoreSetFrameOutput(CoreFrameOutput_Input);
+                    CoreSetFrameOutput(CoreFrameOutput_Input | CoreFrameOutput_Pacing);
                     this->ui_SpectateFastForward = true;
                 }
+                const int speed = behind > 900 ? 1000   // far behind: 10x
+                                : behind > 300 ? 500    // 5x
+                                :                200;   // near the edge: 2x
+                if (CoreGetSpeedFactor() != speed)
+                    CoreSetSpeedFactor(speed);
             }
             else if (this->ui_SpectateFastForward)
             {

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -4905,6 +4905,14 @@ void MainWindow::on_Lobby_SessionRequested(QString gameName, QStringList remoteP
                            localPlayer, int(remotePeers.size()) + 1);
     }
 
+#ifdef _WIN32
+    // Label the OSD ports with the seated players' usernames. The lobby's
+    // onMatchBegin captured them (slot-indexed) into recording_player_names; the
+    // Kaillera and direct-rollback paths set the labels the same way, but this
+    // lobby path was missing it — so port labels never appeared in lobby matches.
+    OnScreenDisplaySetKailleraPortLabels(int(remotePeers.size()) + 1, GetLiveKailleraPortLabelNames());
+#endif
+
     this->emulationThread->SetLobbyNetplay(remotePeers, localPort, localPlayer, frameDelay, predictionWindow);
     this->launchEmulationThread(romFile, "", false, -1, true);
 }

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -3474,32 +3474,46 @@ void MainWindow::timerEvent(QTimerEvent *event)
 
             if (wantFastForward)
             {
-                // Fast-forward the buffered krec up to the broadcaster's live
-                // edge. Drop video+audio (headless) so rendering can't cap the
-                // rate, but keep PACING ON and drive the core's speed limiter —
-                // that's the mechanism that actually advances frames faster.
-                // (Dropping the pacing flag skips the limiter but, in practice,
-                // does NOT run uncapped — it crawls at ~1x, so the whole backlog
-                // took realtime to drain.) Speed is capped at the core's 1000%
-                // (10x) max; scale to the gap so a big backlog drains at full
-                // tilt and eases off as we approach the edge.
+                // Fast-forward the buffered krec up to the broadcaster's live edge.
+                // We catch up HEADLESS (video off) so rendering can't cap the rate,
+                // keeping PACING ON and driving the core's speed limiter at its
+                // 1000% (10x) cap — that's the mechanism that actually advances
+                // frames faster (dropping the pacing flag skips the limiter but in
+                // practice crawls at ~1x). The OSD only draws on a presented frame,
+                // so to show the "buffering" banner during the headless stretch we
+                // bake it in first: on entry, set the banner and run ONE video-on
+                // tick so it gets presented onto the framebuffer; the next tick
+                // drops to headless and that frame (banner included) stays frozen
+                // on screen while we drain — exactly how the port labels persist.
                 if (!this->ui_SpectateFastForward)
                 {
-                    CoreSetFrameOutput(CoreFrameOutput_Input | CoreFrameOutput_Pacing);
+                    OnScreenDisplaySetCenterMessage("Stream is buffering...");
+                    CoreSetFrameOutput(CoreFrameOutput_Video | CoreFrameOutput_Pacing | CoreFrameOutput_Input);
                     this->ui_SpectateFastForward = true;
+                    this->ui_SpectateBannerPending = true;
                 }
-                const int speed = behind > 900 ? 1000   // far behind: 10x
-                                : behind > 300 ? 500    // 5x
-                                :                200;   // near the edge: 2x
-                if (CoreGetSpeedFactor() != speed)
-                    CoreSetSpeedFactor(speed);
+                else if (this->ui_SpectateBannerPending)
+                {
+                    // Banner has been presented at least once now — freeze it by
+                    // dropping to headless for the rest of the catch-up.
+                    CoreSetFrameOutput(CoreFrameOutput_Input | CoreFrameOutput_Pacing);
+                    this->ui_SpectateBannerPending = false;
+                }
+                // Flat-out at 10x until caught up — no taper near the edge. A
+                // spectator is data-bound: it can't pass the live edge (it idles
+                // once the buffer runs dry), so there's nothing to overshoot.
+                if (CoreGetSpeedFactor() != 1000)
+                    CoreSetSpeedFactor(1000);
             }
             else if (this->ui_SpectateFastForward)
             {
-                // Reached the live edge — resume rendering at realtime.
+                // Reached the live edge — clear the banner and resume rendering at
+                // realtime; the next presented frame drops the banner and goes live.
+                OnScreenDisplaySetCenterMessage("");
                 CoreSetFrameOutput(CoreFrameOutput_All);
                 CoreSetSpeedFactor(100);
                 this->ui_SpectateFastForward = false;
+                this->ui_SpectateBannerPending = false;
             }
         }
     }
@@ -4264,6 +4278,9 @@ void MainWindow::stopLobbySpectate()
         this->killTimer(this->ui_SpectateTimerId);
         this->ui_SpectateTimerId = 0;
     }
+    this->ui_SpectateFastForward = false;
+    this->ui_SpectateBannerPending = false;
+    OnScreenDisplaySetCenterMessage(""); // clear the buffering banner if we stop mid-catch-up
     CoreSetSpeedFactor(100);
     CoreSetFrameOutput(CoreFrameOutput_All); // undo any headless catch-up state
     n02::playbackStopStream();

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -4192,6 +4192,7 @@ void MainWindow::on_Lobby_SpectateLaunch(quint64 matchId, QString gameName)
     this->ui_SpectateActive    = true;
     this->ui_SpectateMatchId   = matchId;
     this->ui_SpectateLiveFrame = 0; // updated from broadcaster-stamped SPECTATE_DATA
+    this->ui_SpectateNamesShown = false; // set once the krec header arrives
 
     // ~60 Hz: drive the playback state machine + fast-forward.
     if (this->ui_SpectateTimerId == 0)
@@ -4210,6 +4211,18 @@ void MainWindow::on_Lobby_SpectateData(QByteArray bytes, int liveFrame)
     if (liveFrame > this->ui_SpectateLiveFrame)
         this->ui_SpectateLiveFrame = liveFrame;
     n02::playbackAppendBytes(bytes.constData(), static_cast<int>(bytes.size()));
+
+#ifdef _WIN32
+    // The krec header carries the slot-ordered player names; once it has been
+    // parsed (synchronously, in playbackAppendBytes above), label the OSD ports
+    // from it exactly like a live match does. Names ride in the stream, not a
+    // side channel, so the slot order is authoritative.
+    if (!this->ui_SpectateNamesShown && n02::playbackHeaderReady())
+    {
+        OnScreenDisplaySetKailleraPortLabels(n02::playbackNumPlayers(), GetLiveKailleraPortLabelNames());
+        this->ui_SpectateNamesShown = true;
+    }
+#endif
 }
 
 void MainWindow::on_Lobby_SpectateClosed(QString reason)
@@ -4822,11 +4835,33 @@ void MainWindow::on_Lobby_SessionRequested(QString gameName, QStringList remoteP
     {
         this->showErrorMessage("ROM Not Found",
             "Could not find ROM: " + gameName + "\n\nPlease add it to your ROM directory and refresh the list.");
+        // The lobby flagged itself "awaiting emulation" before emitting
+        // matchReady; clear it so the room doesn't stay stuck on "Connecting…".
+#ifdef NETPLAY
+        if (this->rollbackLobbyDialog != nullptr)
+            this->rollbackLobbyDialog->notifyEmulationFinished();
+#endif
         return;
     }
 
     if (this->emulationThread->isRunning())
     {
+        // ~2 s of 50 ms retries. If the previous game still won't stop after
+        // that it's wedged; bail out gracefully rather than retry forever (which
+        // left a hung game running in the background).
+        if (++this->ui_RollbackRelaunchAttempts > 40)
+        {
+            this->ui_RollbackRelaunchAttempts = 0;
+            CoreAddCallbackMessage(CoreDebugMessageType::Error,
+                "Lobby→LobbySession: previous emulation won't stop — giving up to avoid a hung instance");
+            this->showErrorMessage("Couldn't start match",
+                "The previous game is still shutting down. Please wait a moment and try again.");
+#ifdef NETPLAY
+            if (this->rollbackLobbyDialog != nullptr)
+                this->rollbackLobbyDialog->notifyEmulationFinished();
+#endif
+            return;
+        }
         CoreAddCallbackMessage(CoreDebugMessageType::Info,
             "Lobby→LobbySession: emulation thread running — stopping and retrying");
         CoreStopEmulation();
@@ -4837,6 +4872,7 @@ void MainWindow::on_Lobby_SessionRequested(QString gameName, QStringList remoteP
             });
         return;
     }
+    this->ui_RollbackRelaunchAttempts = 0;
 
     if (this->ui_RollbackNetplayLaunchActive)
     {
@@ -4931,6 +4967,11 @@ void MainWindow::on_Lobby_RoomChatReceived(QString nickname, QString message)
 
     nickname = nickname.trimmed();
     message = NormalizeOsdKailleraChatMessage(message);
+
+    // Carry room chat into the krec so broadcast spectators (and saved replays)
+    // see it too — a no-op unless a recording is open. The spectator's playback
+    // routes the embedded 0x08 record to its OSD like any other chat line.
+    n02::recordingQueueChat(nickname.toUtf8().constData(), message.toUtf8().constData());
 
     const std::string chatLine = "<" + nickname.toStdString() + "> " + message.toStdString();
     OnScreenDisplaySetKailleraChatMessage(chatLine);

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -3452,17 +3452,15 @@ void MainWindow::timerEvent(QTimerEvent *event)
                 this->stopLobbySpectate();
                 return;
             }
-            // Fast-forward toward the live edge, then settle at realtime so the
-            // spectator sits ~1.5 s behind the broadcaster.
-            //
-            // Target = the broadcaster-stamped live frame (authoritative). Until
-            // the first stamp arrives, fall back to the local received edge.
-            const int liveFrame = this->ui_SpectateLiveFrame > 0
-                ? this->ui_SpectateLiveFrame
-                : n02::playbackGetTotalFrames();
-            const int settle   = 90;  // once catching up, stop ~1.5 s behind live
+            // Fast-forward while there's buffered krec ahead of us, then settle near
+            // the buffered/live edge. We measure "behind" as buffered-but-unplayed
+            // frames (LOCAL to this stream) rather than the broadcaster's global live
+            // frame: in the keyframe path the krec tail starts at the keyframe frame,
+            // so the global stamp is far ahead of our local numbering and would never
+            // let us settle. Local buffered-remaining is correct for both paths.
+            const int settle   = 90;  // once catching up, stop ~1.5 s behind the edge
             const int reengage = 240; // but don't RE-start catch-up until ~4 s behind
-            const int behind   = liveFrame - n02::playbackGetCurrentFrame();
+            const int behind   = n02::playbackGetTotalFrames() - n02::playbackGetCurrentFrame();
 
             // Hysteresis: engage catch-up only when we're well behind, then run
             // until we're close. Without the gap, normal live-stream jitter near
@@ -3474,42 +3472,71 @@ void MainWindow::timerEvent(QTimerEvent *event)
 
             if (wantFastForward)
             {
-                // Fast-forward the buffered krec up to the broadcaster's live edge.
-                // We catch up HEADLESS (video off) so rendering can't cap the rate,
-                // keeping PACING ON and driving the core's speed limiter at its
-                // 1000% (10x) cap — that's the mechanism that actually advances
-                // frames faster (dropping the pacing flag skips the limiter but in
-                // practice crawls at ~1x). The OSD only draws on a presented frame,
-                // so to show the "buffering" banner during the headless stretch we
-                // bake it in first: on entry, set the banner and run ONE video-on
-                // tick so it gets presented onto the framebuffer; the next tick
-                // drops to headless and that frame (banner included) stays frozen
-                // on screen while we drain — exactly how the port labels persist.
+                // Fully headless catch-up (video off) — max speed, and headless boot-replay
+                // stays in sync. The OSD can't paint without a presented frame, so the
+                // loading bar lives in the WINDOW TITLE instead (set on the UI thread below,
+                // which runs regardless of whether the emulator presents anything).
+                const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
                 if (!this->ui_SpectateFastForward)
                 {
-                    OnScreenDisplaySetCenterMessage("Stream is buffering...");
-                    CoreSetFrameOutput(CoreFrameOutput_Video | CoreFrameOutput_Pacing | CoreFrameOutput_Input);
                     this->ui_SpectateFastForward = true;
-                    this->ui_SpectateBannerPending = true;
-                }
-                else if (this->ui_SpectateBannerPending)
-                {
-                    // Banner has been presented at least once now — freeze it by
-                    // dropping to headless for the rest of the catch-up.
-                    CoreSetFrameOutput(CoreFrameOutput_Input | CoreFrameOutput_Pacing);
                     this->ui_SpectateBannerPending = false;
+                    // Arm the loading-bar estimator + remember the title to restore.
+                    this->ui_SpectateInitialBehind  = behind > 1 ? behind : 1;
+                    this->ui_SpectateCatchupRate    = 0.0;
+                    this->ui_SpectateRateLastBehind = behind;
+                    this->ui_SpectateRateLastMs     = nowMs;
+                    this->ui_SpectateSavedTitle     = this->windowTitle();
                 }
-                // Flat-out at 10x until caught up — no taper near the edge. A
-                // spectator is data-bound: it can't pass the live edge (it idles
-                // once the buffer runs dry), so there's nothing to overshoot.
+                CoreSetFrameOutput(CoreFrameOutput_Pacing | CoreFrameOutput_Input); // headless (no Video)
+                // Flat-out until caught up — no taper near the edge. A spectator is
+                // data-bound: it can't pass the live edge (it idles once the buffer
+                // runs dry), so there's nothing to overshoot.
                 if (CoreGetSpeedFactor() != 1000)
                     CoreSetSpeedFactor(1000);
+
+                // Loading bar + ETA. The live edge grows while we catch up, so we
+                // estimate from how fast "behind" is actually shrinking (sampled ~10/s
+                // so the per-sample frame delta is meaningful), not an assumed speed
+                // multiplier. Progress is against the backlog we started this run with.
+                if (nowMs - this->ui_SpectateRateLastMs >= 100)
+                {
+                    const double dtSec  = (nowMs - this->ui_SpectateRateLastMs) / 1000.0;
+                    const double inst   = (this->ui_SpectateRateLastBehind - behind) / dtSec;
+                    this->ui_SpectateCatchupRate = (this->ui_SpectateCatchupRate <= 0.0)
+                        ? inst
+                        : (0.6 * this->ui_SpectateCatchupRate + 0.4 * inst);
+                    this->ui_SpectateRateLastBehind = behind;
+                    this->ui_SpectateRateLastMs     = nowMs;
+                }
+
+                // Progress over the backlog from start (initialBehind) down to the settle
+                // point, so it fills to 100% exactly as catch-up completes.
+                const int span = this->ui_SpectateInitialBehind - settle;
+                int pct = (span > 0)
+                    ? static_cast<int>(100.0 * (this->ui_SpectateInitialBehind - behind) / span)
+                    : 100;
+                if (pct < 0) pct = 0;
+                if (pct > 100) pct = 100;
+                constexpr int barW = 18;
+                const int filled = pct * barW / 100;
+                std::string msg = "Catching up  [" + std::string(filled, '#') +
+                                  std::string(barW - filled, '-') + "]  " + std::to_string(pct) + "%";
+                if (this->ui_SpectateCatchupRate > 1.0)
+                {
+                    const int rate   = static_cast<int>(this->ui_SpectateCatchupRate);
+                    const int etaSec = (behind + rate - 1) / rate; // ceil(behind/rate)
+                    msg += "  ~" + std::to_string(etaSec) + "s";
+                }
+                // Bar goes in the title (UI thread) so it updates even with zero presents.
+                this->setWindowTitle(QString::fromStdString(msg));
             }
             else if (this->ui_SpectateFastForward)
             {
-                // Reached the live edge — clear the banner and resume rendering at
-                // realtime; the next presented frame drops the banner and goes live.
+                // Reached the live edge — restore the title, resume rendering at realtime;
+                // the next presented frame goes live.
                 OnScreenDisplaySetCenterMessage("");
+                this->setWindowTitle(this->ui_SpectateSavedTitle);
                 CoreSetFrameOutput(CoreFrameOutput_All);
                 CoreSetSpeedFactor(100);
                 this->ui_SpectateFastForward = false;
@@ -4227,6 +4254,7 @@ void MainWindow::on_Lobby_SpectateLaunch(quint64 matchId, QString gameName)
     this->ui_SpectateMatchId   = matchId;
     this->ui_SpectateLiveFrame = 0; // updated from broadcaster-stamped SPECTATE_DATA
     this->ui_SpectateNamesShown = false; // set once the krec header arrives
+    CoreClearSpectateKeyframe(); // drop any stale keyframe from a previous spectate
 
     // ~60 Hz: drive the playback state machine + fast-forward.
     if (this->ui_SpectateTimerId == 0)
@@ -4259,6 +4287,21 @@ void MainWindow::on_Lobby_SpectateData(QByteArray bytes, int liveFrame)
 #endif
 }
 
+void MainWindow::on_Lobby_SpectateKeyframe(int frame, QByteArray savestate)
+{
+    if (!this->ui_SpectateActive || savestate.isEmpty() || frame < 0)
+    {
+        return;
+    }
+    // Stage the broadcaster's savestate so the spectator's emulation restores it (on
+    // its emulation thread) before consuming the first krec input. This arrives ahead
+    // of the SPECTATE_DATA krec tail (which starts at this frame), so it's staged
+    // before the emulation even starts — the load wins the race against the first poll
+    // and the replay continues from frame F's state instead of boot.
+    CoreStageSpectateKeyframe(reinterpret_cast<const unsigned char*>(savestate.constData()),
+                              static_cast<int>(savestate.size()), frame);
+}
+
 void MainWindow::on_Lobby_SpectateClosed(QString reason)
 {
     (void)reason;
@@ -4278,8 +4321,11 @@ void MainWindow::stopLobbySpectate()
         this->killTimer(this->ui_SpectateTimerId);
         this->ui_SpectateTimerId = 0;
     }
+    if (this->ui_SpectateFastForward) // stopped mid-catch-up — put the title back
+        this->setWindowTitle(this->ui_SpectateSavedTitle);
     this->ui_SpectateFastForward = false;
     this->ui_SpectateBannerPending = false;
+    CoreClearSpectateKeyframe(); // drop any staged keyframe
     OnScreenDisplaySetCenterMessage(""); // clear the buffering banner if we stop mid-catch-up
     CoreSetSpeedFactor(100);
     CoreSetFrameOutput(CoreFrameOutput_All); // undo any headless catch-up state
@@ -4716,6 +4762,8 @@ void MainWindow::ensureRollbackLobbyDialog()
             this, &MainWindow::on_Lobby_SpectateLaunch);
     connect(this->rollbackLobbyDialog, &Dialog::RollbackLobbyDialog::spectateStreamData,
             this, &MainWindow::on_Lobby_SpectateData);
+    connect(this->rollbackLobbyDialog, &Dialog::RollbackLobbyDialog::spectateStreamKeyframe,
+            this, &MainWindow::on_Lobby_SpectateKeyframe);
     connect(this->rollbackLobbyDialog, &Dialog::RollbackLobbyDialog::spectateStreamClosed,
             this, &MainWindow::on_Lobby_SpectateClosed);
 }

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -4815,13 +4815,14 @@ void MainWindow::on_Rollback_SessionRequested(QString gameName, QString remoteAd
 // LOBBY| branch and uses GekkoNet's built-in UDP transport instead of
 // the n02 P2P transport (which the lobby never initializes).
 // remotePeers contains N-1 entries, each pre-formatted as "<slot>,<ip>,<port>".
-void MainWindow::on_Lobby_SessionRequested(QString gameName, QStringList remotePeers, int localPort, int localPlayer, int frameDelay, int predictionWindow)
+void MainWindow::on_Lobby_SessionRequested(QString gameName, QString romFile, QStringList remotePeers, int localPort, int localPlayer, int frameDelay, int predictionWindow)
 {
     {
-        char buf[640];
+        char buf[768];
         std::snprintf(buf, sizeof(buf),
-            "Lobby→LobbySession: game='%s' peers=%d (%s) localPort=%d slot=%d delay=%d pred=%d emuRunning=%d launchActive=%d",
+            "Lobby→LobbySession: game='%s' rom='%s' peers=%d (%s) localPort=%d slot=%d delay=%d pred=%d emuRunning=%d launchActive=%d",
             gameName.toUtf8().constData(),
+            romFile.toUtf8().constData(),
             int(remotePeers.size()),
             remotePeers.join("; ").toUtf8().constData(),
             localPort, localPlayer, frameDelay, predictionWindow,
@@ -4830,7 +4831,13 @@ void MainWindow::on_Lobby_SessionRequested(QString gameName, QStringList remoteP
         CoreAddCallbackMessage(CoreDebugMessageType::Info, buf);
     }
 
-    QString romFile = this->findRomByName(gameName);
+    // The lobby resolved romFile from the room's MD5 (localRomPathForMd5), so it
+    // points at the byte-identical ROM every seat verified they have — including
+    // romhacks absent from the database, where findRomByName(gameName) fails
+    // because the display name is the file's name, not the GoodName it matches.
+    // Fall back to the name lookup only if the path somehow arrived empty.
+    if (romFile.isEmpty())
+        romFile = this->findRomByName(gameName);
     if (romFile.isEmpty())
     {
         this->showErrorMessage("ROM Not Found",
@@ -4866,9 +4873,9 @@ void MainWindow::on_Lobby_SessionRequested(QString gameName, QStringList remoteP
             "Lobby→LobbySession: emulation thread running — stopping and retrying");
         CoreStopEmulation();
         QTimer::singleShot(50, this,
-            [this, gameName, remotePeers, localPort, localPlayer, frameDelay, predictionWindow]()
+            [this, gameName, romFile, remotePeers, localPort, localPlayer, frameDelay, predictionWindow]()
             {
-                this->on_Lobby_SessionRequested(gameName, remotePeers, localPort, localPlayer, frameDelay, predictionWindow);
+                this->on_Lobby_SessionRequested(gameName, romFile, remotePeers, localPort, localPlayer, frameDelay, predictionWindow);
             });
         return;
     }

--- a/Source/RMG/UserInterface/MainWindow.hpp
+++ b/Source/RMG/UserInterface/MainWindow.hpp
@@ -169,6 +169,12 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     int     ui_SpectateLiveFrame   = 0;     // broadcaster's live krec frame (fast-forward target)
     bool    ui_SpectateFastForward = false; // true while headless-catching-up to the live edge
     bool    ui_SpectateBannerPending = false; // 1 video-on tick to bake the "buffering" banner in before going headless
+    // Catch-up loading-bar estimator (reset each time fast-forward engages).
+    int     ui_SpectateInitialBehind = 1;   // backlog (frames) when this catch-up started
+    double  ui_SpectateCatchupRate   = 0.0; // smoothed gap-closing rate (frames/sec)
+    int     ui_SpectateRateLastBehind = 0;  // "behind" at the last rate sample
+    qint64  ui_SpectateRateLastMs     = 0;  // wall-clock of the last rate sample
+    QString ui_SpectateSavedTitle;          // window title to restore after catch-up (bar lives in the title while headless)
     // Lazily creates rollbackLobbyDialog and wires its signals (once).
     void ensureRollbackLobbyDialog();
     // Creates the KailleraSessionManager + callback wiring if absent. Shared by
@@ -326,6 +332,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     void on_Lobby_SessionRequested(QString gameName, QString romFile, QStringList remotePeers, int localPort, int localPlayer, int frameDelay, int predictionWindow);
     void on_Lobby_SpectateLaunch(quint64 matchId, QString gameName);
     void on_Lobby_SpectateData(QByteArray bytes, int liveFrame);
+    void on_Lobby_SpectateKeyframe(int frame, QByteArray savestate);
     void on_Lobby_SpectateClosed(QString reason);
     void on_RomBrowser_RomListRefreshFinished(bool canceled);
 #endif

--- a/Source/RMG/UserInterface/MainWindow.hpp
+++ b/Source/RMG/UserInterface/MainWindow.hpp
@@ -322,7 +322,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     void on_Kaillera_GameEnded(void);
     void on_Kaillera_RecordingFileClosed(void);
     void on_Rollback_SessionRequested(QString gameName, QString remoteAddress, int localPort, int remotePort, int localPlayer, int frameDelay, int predictionWindow);
-    void on_Lobby_SessionRequested(QString gameName, QStringList remotePeers, int localPort, int localPlayer, int frameDelay, int predictionWindow);
+    void on_Lobby_SessionRequested(QString gameName, QString romFile, QStringList remotePeers, int localPort, int localPlayer, int frameDelay, int predictionWindow);
     void on_Lobby_SpectateLaunch(quint64 matchId, QString gameName);
     void on_Lobby_SpectateData(QByteArray bytes, int liveFrame);
     void on_Lobby_SpectateClosed(QString reason);

--- a/Source/RMG/UserInterface/MainWindow.hpp
+++ b/Source/RMG/UserInterface/MainWindow.hpp
@@ -156,11 +156,16 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     bool ui_RollbackLivePumpActive = false;
     bool ui_RollbackNetplayRoomActive = false;
     bool ui_RollbackNetplayLaunchActive = false;
+    // Bounds the "stop the old game, retry in 50ms" relaunch loop so a previous
+    // emulation that refuses to stop can't spin forever (hung background game).
+    int  ui_RollbackRelaunchAttempts = 0;
     // Spectating a broadcast match via streaming krec playback (distinct from the
     // lobby *match* flow above — the spectator runs playback, not GekkoNet).
     bool    ui_SpectateActive  = false;
     quint64 ui_SpectateMatchId = 0;
     int     ui_SpectateTimerId = 0;
+    bool    ui_SpectateNamesShown = false; // OSD port labels set from krec header
+
     int     ui_SpectateLiveFrame   = 0;     // broadcaster's live krec frame (fast-forward target)
     bool    ui_SpectateFastForward = false; // true while headless-catching-up to the live edge
     // Lazily creates rollbackLobbyDialog and wires its signals (once).

--- a/Source/RMG/UserInterface/MainWindow.hpp
+++ b/Source/RMG/UserInterface/MainWindow.hpp
@@ -168,6 +168,7 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
 
     int     ui_SpectateLiveFrame   = 0;     // broadcaster's live krec frame (fast-forward target)
     bool    ui_SpectateFastForward = false; // true while headless-catching-up to the live edge
+    bool    ui_SpectateBannerPending = false; // 1 video-on tick to bake the "buffering" banner in before going headless
     // Lazily creates rollbackLobbyDialog and wires its signals (once).
     void ensureRollbackLobbyDialog();
     // Creates the KailleraSessionManager + callback wiring if absent. Shared by

--- a/Source/RMG/VidExt.cpp
+++ b/Source/RMG/VidExt.cpp
@@ -611,6 +611,26 @@ static bool VidExt_OglSetup(int screenMode)
         return false;
     }
 
+    // Some drivers hand back a *valid* context at a lower version than requested
+    // (outdated AMD/Intel drivers, Microsoft Basic Render Driver, Remote Desktop,
+    // VMs). GLideN64 needs desktop OpenGL 3.3+; on a lower context it fails later
+    // with an opaque PLUGIN_FAIL, so catch it here and name the actual version.
+    {
+        const QSurfaceFormat actualFormat = (*l_OGLWidget)->GetContext()->format();
+        if (actualFormat.renderableType() != QSurfaceFormat::OpenGLES &&
+            (actualFormat.majorVersion() < 3 ||
+             (actualFormat.majorVersion() == 3 && actualFormat.minorVersion() < 3)))
+        {
+            const QString msg = QString(
+                "Your GPU/driver provides only OpenGL %1.%2, but the graphics plugin "
+                "needs OpenGL 3.3 or newer. Update your graphics driver — outdated AMD/Intel "
+                "drivers, Remote Desktop, and virtual machines commonly cause this.")
+                .arg(actualFormat.majorVersion()).arg(actualFormat.minorVersion());
+            CoreAddCallbackMessage(CoreDebugMessageType::Error, msg.toUtf8().constData());
+            return false;
+        }
+    }
+
     l_OpenGLInitialized = true;
     return true;
 }

--- a/Source/n02/n02_client.cpp
+++ b/Source/n02/n02_client.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <filesystem>
 #include <vector>
+#include <utility>
 
 #include "common/nThread.h"
 #include "common/k_socket.h"
@@ -120,6 +121,15 @@ static std::function<void(const void*, int)> recording_stream_sink;
 // broadcast drain to stamp BROADCAST_DATA so spectators know the live edge.
 static std::atomic<int> recording_frame_count{0};
 
+// Lobby room chat arrives on the UI thread, but RecordingBuffer is only safe to
+// touch on the emulation thread. Queue chat here and drain it into the krec (as
+// 0x08 records) on the emulation thread just before the next input frame, so the
+// buffer always has a single writer. recording_active gates enqueues so the
+// queue can't grow without bound while nothing is being recorded.
+static std::atomic<bool> recording_active{false};
+static std::mutex recording_chat_mutex;
+static std::vector<std::pair<std::string, std::string>> recording_chat_queue;
+
 static std::filesystem::path pathFromUtf8String(const std::string& utf8) {
 #if defined(__cpp_char8_t)
     std::u8string converted;
@@ -186,6 +196,11 @@ public:
 } RecordingBuffer;
 
 static void close_recording() {
+    recording_active.store(false, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lk(recording_chat_mutex);
+        recording_chat_queue.clear();
+    }
     if (recording_file.is_open()) {
         if (RecordingBuffer.len() > 0)
             RecordingBuffer.write();
@@ -195,6 +210,26 @@ static void close_recording() {
         if (callbacks.recordingFileClosedCallback) {
             callbacks.recordingFileClosedCallback();
         }
+    }
+}
+
+// Drain queued chat into the open krec as 0x08 records (nick\0 msg\0). Called on
+// the emulation thread before an input frame, so RecordingBuffer keeps a single
+// writer. Each record is flushed on its own; lines are length-bounded at enqueue
+// time so a record always fits RecordingBuffer's 500-byte buffer.
+static void drain_recording_chat() {
+    std::vector<std::pair<std::string, std::string>> pending;
+    {
+        std::lock_guard<std::mutex> lk(recording_chat_mutex);
+        if (recording_chat_queue.empty())
+            return;
+        pending.swap(recording_chat_queue);
+    }
+    for (auto& c : pending) {
+        RecordingBuffer.put_char(8);
+        RecordingBuffer.put_bytes(const_cast<char*>(c.first.c_str()),  (int)c.first.size()  + 1);
+        RecordingBuffer.put_bytes(const_cast<char*>(c.second.c_str()), (int)c.second.size() + 1);
+        RecordingBuffer.write();
     }
 }
 
@@ -325,6 +360,14 @@ static void openRecordingFile(const char* appName, const char* game, int player,
             if (recording_stream_sink)
                 recording_stream_sink(header, (int)sizeof(header));
         }
+
+        // Fresh recording: drop any chat queued before this session and arm chat
+        // capture only if the file actually opened.
+        {
+            std::lock_guard<std::mutex> lk(recording_chat_mutex);
+            recording_chat_queue.clear();
+        }
+        recording_active.store(recording_file.is_open(), std::memory_order_release);
 }
 
 static int gameCallbackWrapper(char *game, int player, int numplayers_arg) {
@@ -516,6 +559,17 @@ static bool parsePlaybackHeader() {
     pb.pos = 264;
     playerno = pb.load_int();
     numplayers = pb.load_int();
+
+    // Player names live at [272,400) on KRC1. Copy them into the shared global so
+    // a spectator can label the OSD ports from the stream, just like a live match
+    // does (KRC0 has no names — leave them blank).
+    memset(recording_player_names, 0, sizeof(recording_player_names));
+    if (isKRC1)
+    {
+        memcpy(recording_player_names, pb.data.data() + 272, sizeof(recording_player_names));
+        for (int i = 0; i < 4; i++)
+            recording_player_names[i][31] = '\0';
+    }
 
     pb.headerSize = hs;
     pb.pos = hs;
@@ -932,10 +986,25 @@ int modifyPlayValues(void *values, int size) {
     return -1;
 }
 
+void recordingQueueChat(const char* nick, const char* msg) {
+    if (!recording_active.load(std::memory_order_acquire))
+        return;
+    std::string n(nick ? nick : "");
+    std::string m(msg ? msg : "");
+    // Bound so a 0x08 record always fits RecordingBuffer (500 bytes) and the
+    // playback reader (nick[100] / msg[500]).
+    if (n.size() > 31)  n.resize(31);
+    if (m.size() > 255) m.resize(255);
+    std::lock_guard<std::mutex> lk(recording_chat_mutex);
+    if (recording_chat_queue.size() < 256) // backstop against runaway growth
+        recording_chat_queue.emplace_back(std::move(n), std::move(m));
+}
+
 void recordingWriteInputs(const void* values, int size) {
     if (!recording_file.is_open() || values == nullptr || size <= 0) {
         return;
     }
+    drain_recording_chat(); // flush any queued chat just ahead of this frame
     const short siz = (size > 0x7FFF) ? 0x7FFF : (short)size;
     RecordingBuffer.put_char(0x12);
     RecordingBuffer.put_short(siz);
@@ -1063,6 +1132,15 @@ int playbackGetCurrentFrame() {
 int playbackGetTotalFrames() {
     std::lock_guard<std::recursive_mutex> lock(playbackMutex);
     return (int)PlayBackBuffer.frameIndex.size();
+}
+
+bool playbackHeaderReady() {
+    std::lock_guard<std::recursive_mutex> lock(playbackMutex);
+    return PlayBackBuffer.headerParsed;
+}
+
+int playbackNumPlayers() {
+    return numplayers;
 }
 
 } // namespace n02

--- a/Source/n02/n02_client.h
+++ b/Source/n02/n02_client.h
@@ -48,6 +48,13 @@ void recordingWriteInputs(const void* values, int size);
 // onto the broadcast stream so spectators can fast-forward to it.
 int recordingFrameCount();
 
+// Queue a chat line to be embedded in the open recording as a 0x08 record. Safe
+// to call from any thread; the line is written into the krec on the emulation
+// thread just before the next input frame, and is a no-op when nothing is
+// recording. Lets the lobby — whose room chat arrives off the frame loop — carry
+// chat through to spectators and saved replays. nick/msg are length-bounded.
+void recordingQueueChat(const char* nick, const char* msg);
+
 // Open a new .krec recording for a session that bypasses n02's game-start
 // callback (the GekkoNet rollback lobby path). Closes any open recording first,
 // then writes a KRC1 header — but only when n02_kaillera_recording_enabled is
@@ -175,6 +182,15 @@ int playbackGetCurrentFrame();
 
 // Get the total number of frames in the loaded recording
 int playbackGetTotalFrames();
+
+// True once a streamed recording's header has been parsed — at which point the
+// game name, player count, and player names (in the recording_player_names
+// global) are available. Lets a live spectator know when it can label the OSD
+// ports from the krec header.
+bool playbackHeaderReady();
+
+// Player count from the parsed playback header (0 until playbackHeaderReady()).
+int playbackNumPlayers();
 
 } // namespace n02
 


### PR DESCRIPTION
## Summary
Merges the lobby revamp and spectate/broadcast work into `4player-rollback` (9 commits, no divergence).

- **Lobby UI revamp** — color, seat cards and tables; room-status badge unstick on "Connecting…"; spectator names + chat; relaunch hardening; driver-error handling.
- **Lobby plumbing** — persist ROM/username/room defaults to the real settings store; port-label usernames during matches; launch off-database ROMs by MD5-resolved path (not name).
- **Spectate / broadcast** — live-edge catch-up via the speed limiter (not pacing-off); "stream is buffering" banner + flat 10x catch-up; headless fast-forward to the live edge with a window-title progress bar + live ETA.

## Dormant
Keyframe / full-savestate spectate scaffolding is included but disabled via `kSpectateKeyframesEnabled = false` (rollback-savestate cold-load desync; left inert behind the flag). Active spectate path = full-spool replay from frame 0 + headless fast-forward.

## Server dependency
Chunked spectate streaming for long matches needs mupen-rollback-lobby#9 deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)