### PR TITLE
Fix Japanese text encoding in Kaillera server mode

### DIFF
--- a/Source/RMG/UserInterface/KailleraUIBridge.cpp
+++ b/Source/RMG/UserInterface/KailleraUIBridge.cpp
@@ -13,11 +13,17 @@
 
 #include "n02_client.h"
 #include "common/k_socket.h"  // for sockaddr_in
+#include "common/kaillera_encoding.h"
 
-// Helper: safely convert char* to QString (handles nullptr)
-static inline QString safeStr(const char* s)
+static inline QString safeUtf8Str(const char* s)
 {
     return QString::fromUtf8(s ? s : "");
+}
+
+static inline QString safeKailleraStr(const char* s)
+{
+    const std::string utf8 = n02::encoding::decodeKailleraText(s ? s : "");
+    return QString::fromUtf8(utf8.c_str());
 }
 
 KailleraUIBridge::KailleraUIBridge()
@@ -54,11 +60,11 @@ void KailleraUIBridge::registerCallbacks()
     // ---- P2P callbacks ----
 
     cb.p2pChatCallback = [this](char* nick, char* msg) {
-        emit p2pChatReceived(safeStr(nick), safeStr(msg));
+        emit p2pChatReceived(safeUtf8Str(nick), safeUtf8Str(msg));
     };
 
     cb.p2pGameCallback = [this](char* game, int player, int maxplayers) {
-        emit p2pGameStarted(safeStr(game), player, maxplayers);
+        emit p2pGameStarted(safeUtf8Str(game), player, maxplayers);
     };
 
     cb.p2pEndGameCallback = [this]() {
@@ -66,15 +72,15 @@ void KailleraUIBridge::registerCallbacks()
     };
 
     cb.p2pClientDroppedCallback = [this](char* nick, int player) {
-        emit p2pClientDropped(safeStr(nick), player);
+        emit p2pClientDropped(safeUtf8Str(nick), player);
     };
 
     cb.p2pDebugCallback = [this](char* msg) {
-        emit p2pDebugMessage(safeStr(msg));
+        emit p2pDebugMessage(safeUtf8Str(msg));
     };
 
     cb.p2pHostedGameCallback = [this](char* game) {
-        emit p2pHostedGame(safeStr(game));
+        emit p2pHostedGame(safeUtf8Str(game));
     };
 
     cb.p2pPingCallback = [this](int ping) {
@@ -90,7 +96,7 @@ void KailleraUIBridge::registerCallbacks()
     };
 
     cb.p2pPeerInfoCallback = [this](char* name, char* app) {
-        emit p2pPeerInfo(safeStr(name), safeStr(app));
+        emit p2pPeerInfo(safeUtf8Str(name), safeUtf8Str(app));
     };
 
     cb.p2pGetSelectedDelayCallback = [this]() -> int {
@@ -109,41 +115,41 @@ void KailleraUIBridge::registerCallbacks()
     };
 
     cb.p2pFodippCallback = [this](char* host) {
-        emit p2pFodippResult(safeStr(host));
+        emit p2pFodippResult(safeUtf8Str(host));
     };
 
     // ---- Kaillera server callbacks ----
 
     cb.kailleraUserAddCallback = [this](char* name, int ping, int status, unsigned short id, char conn) {
-        emit kailleraUserAdded(safeStr(name), ping, status, id, conn);
+        emit kailleraUserAdded(safeKailleraStr(name), ping, status, id, conn);
     };
 
     cb.kailleraGameAddCallback = [this](char* gname, unsigned int id, char* emulator, char* owner, char* users, char status) {
-        emit kailleraGameAdded(safeStr(gname), id, safeStr(emulator), safeStr(owner), safeStr(users), status);
+        emit kailleraGameAdded(safeKailleraStr(gname), id, safeKailleraStr(emulator), safeKailleraStr(owner), safeKailleraStr(users), status);
     };
 
     cb.kailleraChatCallback = [this](char* name, char* msg) {
-        emit kailleraChatReceived(safeStr(name), safeStr(msg));
+        emit kailleraChatReceived(safeKailleraStr(name), safeKailleraStr(msg));
     };
 
     cb.kailleraGameChatCallback = [this](char* name, char* msg) {
-        emit kailleraGameChatReceived(safeStr(name), safeStr(msg));
+        emit kailleraGameChatReceived(safeKailleraStr(name), safeKailleraStr(msg));
     };
 
     cb.kailleraMotdCallback = [this](char* name, char* msg) {
-        emit kailleraMotdReceived(safeStr(name), safeStr(msg));
+        emit kailleraMotdReceived(safeKailleraStr(name), safeKailleraStr(msg));
     };
 
     cb.kailleraUserJoinCallback = [this](char* name, int ping, unsigned short id, char conn) {
-        emit kailleraUserJoined(safeStr(name), ping, id, conn);
+        emit kailleraUserJoined(safeKailleraStr(name), ping, id, conn);
     };
 
     cb.kailleraUserLeaveCallback = [this](char* name, char* quitmsg, unsigned short id) {
-        emit kailleraUserLeft(safeStr(name), safeStr(quitmsg), id);
+        emit kailleraUserLeft(safeKailleraStr(name), safeKailleraStr(quitmsg), id);
     };
 
     cb.kailleraGameCreateCallback = [this](char* gname, unsigned int id, char* emulator, char* owner) {
-        emit kailleraGameCreated(safeStr(gname), id, safeStr(emulator), safeStr(owner));
+        emit kailleraGameCreated(safeKailleraStr(gname), id, safeKailleraStr(emulator), safeKailleraStr(owner));
     };
 
     cb.kailleraGameCloseCallback = [this](unsigned int id) {
@@ -167,15 +173,15 @@ void KailleraUIBridge::registerCallbacks()
     };
 
     cb.kailleraPlayerAddCallback = [this](char* name, int ping, unsigned short id, char conn) {
-        emit kailleraPlayerAdded(safeStr(name), ping, id, conn);
+        emit kailleraPlayerAdded(safeKailleraStr(name), ping, id, conn);
     };
 
     cb.kailleraPlayerJoinedCallback = [this](char* username, int ping, unsigned short uid, char connset) {
-        emit kailleraPlayerJoined(safeStr(username), ping, uid, connset);
+        emit kailleraPlayerJoined(safeKailleraStr(username), ping, uid, connset);
     };
 
     cb.kailleraPlayerLeftCallback = [this](char* user, unsigned short id) {
-        emit kailleraPlayerLeft(safeStr(user), id);
+        emit kailleraPlayerLeft(safeKailleraStr(user), id);
     };
 
     cb.kailleraUserKickedCallback = [this]() {
@@ -183,15 +189,15 @@ void KailleraUIBridge::registerCallbacks()
     };
 
     cb.kailleraLoginStatCallback = [this](char* lsmsg) {
-        emit kailleraLoginStatus(safeStr(lsmsg));
+        emit kailleraLoginStatus(safeKailleraStr(lsmsg));
     };
 
     cb.kailleraPlayerDroppedCallback = [this](char* user, int gdpl) {
-        emit kailleraPlayerDropped(safeStr(user), gdpl);
+        emit kailleraPlayerDropped(safeKailleraStr(user), gdpl);
     };
 
     cb.kailleraGameStartCallback = [this](char* game, char player, char players) {
-        emit kailleraGameStarted(safeStr(game), static_cast<int>(player), static_cast<int>(players));
+        emit kailleraGameStarted(safeKailleraStr(game), static_cast<int>(player), static_cast<int>(players));
     };
 
     cb.kailleraGameNetsyncWaitCallback = [this](int tx) {
@@ -203,11 +209,11 @@ void KailleraUIBridge::registerCallbacks()
     };
 
     cb.kailleraDebugCallback = [this](char* msg) {
-        emit kailleraDebugMessage(safeStr(msg));
+        emit kailleraDebugMessage(safeKailleraStr(msg));
     };
 
     cb.kailleraErrorCallback = [this](char* msg) {
-        emit kailleraErrorMessage(safeStr(msg));
+        emit kailleraErrorMessage(safeKailleraStr(msg));
     };
 
     cb.recordingFileClosedCallback = [this]() {

--- a/Source/n02/common/kaillera_encoding.h
+++ b/Source/n02/common/kaillera_encoding.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+#include <string>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace n02::encoding {
+
+#ifdef _WIN32
+inline bool multiByteToWide(UINT codePage, DWORD flags, const char* input, std::wstring& output)
+{
+    output.clear();
+    if (input == nullptr || input[0] == '\0')
+    {
+        return true;
+    }
+
+    const int inputLength = static_cast<int>(std::strlen(input));
+    const int wideLength = MultiByteToWideChar(
+        codePage,
+        flags,
+        input,
+        inputLength,
+        nullptr,
+        0);
+    if (wideLength <= 0)
+    {
+        return false;
+    }
+
+    output.resize(static_cast<std::size_t>(wideLength));
+    return MultiByteToWideChar(
+               codePage,
+               flags,
+               input,
+               inputLength,
+               output.data(),
+               wideLength) == wideLength;
+}
+
+inline bool wideToMultiByte(
+    UINT codePage,
+    DWORD flags,
+    const std::wstring& input,
+    std::string& output)
+{
+    output.clear();
+    if (input.empty())
+    {
+        return true;
+    }
+
+    const char replacement = '?';
+    BOOL usedDefaultCharacter = FALSE;
+    const char* replacementPtr = (codePage == CP_UTF8) ? nullptr : &replacement;
+    BOOL* usedDefaultPtr = (codePage == CP_UTF8) ? nullptr : &usedDefaultCharacter;
+
+    const int outputLength = WideCharToMultiByte(
+        codePage,
+        flags,
+        input.data(),
+        static_cast<int>(input.size()),
+        nullptr,
+        0,
+        replacementPtr,
+        usedDefaultPtr);
+    if (outputLength <= 0)
+    {
+        return false;
+    }
+
+    output.resize(static_cast<std::size_t>(outputLength));
+    return WideCharToMultiByte(
+               codePage,
+               flags,
+               input.data(),
+               static_cast<int>(input.size()),
+               output.data(),
+               outputLength,
+               replacementPtr,
+               usedDefaultPtr) == outputLength;
+}
+#endif
+
+// Convert text received from a traditional Kaillera server to UTF-8.
+// Valid UTF-8 is preserved so mixed environments and newer clients still work.
+inline std::string decodeKailleraText(const char* text)
+{
+    if (text == nullptr || text[0] == '\0')
+    {
+        return {};
+    }
+
+#ifdef _WIN32
+    std::wstring wide;
+    if (multiByteToWide(CP_UTF8, MB_ERR_INVALID_CHARS, text, wide))
+    {
+        return std::string(text);
+    }
+
+    if (!multiByteToWide(932, 0, text, wide))
+    {
+        return std::string(text);
+    }
+
+    std::string utf8;
+    if (!wideToMultiByte(CP_UTF8, 0, wide, utf8))
+    {
+        return std::string(text);
+    }
+    return utf8;
+#else
+    return std::string(text);
+#endif
+}
+
+// Convert UTF-8 text to Windows-31J/CP932 for traditional Kaillera servers.
+// Invalid UTF-8 is treated as already-encoded legacy text to avoid double conversion.
+inline std::string encodeKailleraText(const char* text)
+{
+    if (text == nullptr || text[0] == '\0')
+    {
+        return {};
+    }
+
+#ifdef _WIN32
+    std::wstring wide;
+    if (!multiByteToWide(CP_UTF8, MB_ERR_INVALID_CHARS, text, wide))
+    {
+        return std::string(text);
+    }
+
+    std::string cp932;
+    if (!wideToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, cp932))
+    {
+        return std::string(text);
+    }
+    return cp932;
+#else
+    return std::string(text);
+#endif
+}
+
+inline bool isCp932LeadByte(unsigned char byte)
+{
+    return (byte >= 0x81 && byte <= 0x9F) ||
+           (byte >= 0xE0 && byte <= 0xFC);
+}
+
+// Return the largest prefix that fits in maxBytes without cutting a CP932 character.
+inline std::size_t safeCp932PrefixLength(const std::string& text, std::size_t maxBytes)
+{
+    std::size_t position = 0;
+    while (position < text.size())
+    {
+        const unsigned char current = static_cast<unsigned char>(text[position]);
+        const std::size_t width = isCp932LeadByte(current) ? 2U : 1U;
+        if (position + width > text.size() || position + width > maxBytes)
+        {
+            break;
+        }
+        position += width;
+    }
+    return position;
+}
+
+} // namespace n02::encoding

--- a/Source/n02/common/kaillera_encoding.h
+++ b/Source/n02/common/kaillera_encoding.h
@@ -134,13 +134,22 @@ inline std::string encodeKailleraText(const char* text)
     std::wstring wide;
     if (!multiByteToWide(CP_UTF8, MB_ERR_INVALID_CHARS, text, wide))
     {
-        return std::string(text);
+        // If the input already looks legacy-encoded, normalize it through CP932.
+        if (multiByteToWide(932, 0, text, wide))
+        {
+            std::string cp932;
+            if (wideToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, cp932))
+            {
+                return cp932;
+            }
+        }
+        return "?";
     }
 
     std::string cp932;
     if (!wideToMultiByte(932, WC_NO_BEST_FIT_CHARS, wide, cp932))
     {
-        return std::string(text);
+        return "?";
     }
     return cp932;
 #else

--- a/Source/n02/kcore/k_instruction.h
+++ b/Source/n02/kcore/k_instruction.h
@@ -10,6 +10,9 @@
 #include <cstring>
 #include <climits>
 #include <algorithm>
+#include <string>
+
+#include "../common/kaillera_encoding.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 enum INSTRUCTION{
@@ -89,9 +92,11 @@ public:
     }
 
     void set_username(char * arg_0){
-        int p;
-        strncpy(user, arg_0, (p=std::min((int)strlen(arg_0), 31)));
-        user[p] = 0x00;
+        const std::string encoded = n02::encoding::encodeKailleraText(arg_0 ? arg_0 : "");
+        const std::size_t length = n02::encoding::safeCp932PrefixLength(encoded, 31);
+        if (length > 0)
+            memcpy(user, encoded.data(), length);
+        user[length] = 0x00;
     }
 
     void store_bytes(const void * arg_0, int arg_4){
@@ -110,7 +115,8 @@ public:
     }
 
     void store_string(const char * arg_0){
-        store_bytes(arg_0, (int)strlen(arg_0)+1);
+        const std::string encoded = n02::encoding::encodeKailleraText(arg_0 ? arg_0 : "");
+        store_bytes(encoded.c_str(), (int)encoded.size()+1);
     }
 
 	    void load_str(char * arg_0, unsigned int arg_4){

--- a/Source/n02/kcore/kaillera_core.cpp
+++ b/Source/n02/kcore/kaillera_core.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -78,6 +79,28 @@ static void SendPong() {
 	while(x < 4)
 		pong.store_int(x++);
 	KAILLERAC.connection->send_instruction(&pong);
+}
+
+static std::string normalizeKailleraWireText(const char* text)
+{
+	return n02::encoding::encodeKailleraText(text ? text : "");
+}
+
+static std::string normalizeKailleraUsernameForCompare(const char* text)
+{
+	const std::string encoded = normalizeKailleraWireText(text);
+	const std::size_t length = n02::encoding::safeCp932PrefixLength(encoded, 31);
+	return encoded.substr(0, length);
+}
+
+static bool kailleraWireEquals(const char* received, const char* local)
+{
+	return std::string(received ? received : "") == normalizeKailleraWireText(local);
+}
+
+static bool kailleraUsernameEquals(const char* received, const char* local)
+{
+	return std::string(received ? received : "") == normalizeKailleraUsernameForCompare(local);
 }
 
 void kaillera_print_core_status(){
@@ -360,8 +383,10 @@ void kaillera_ProcessGeneralInstruction(k_instruction * ki) {
 			kaillera_game_create_callback(gname, id, emulator, ki->user);
 			
 			if (KAILLERAC.game_id_requested) {
-				KAILLERAC.game_id = id;
-				if (strcmp(gname, KAILLERAC.GAME)==0 && strcmp(emulator, KAILLERAC.APP)==0 && strcmp(ki->user, KAILLERAC.USERNAME)==0) {
+				if (kailleraWireEquals(gname, KAILLERAC.GAME) &&
+					kailleraWireEquals(emulator, KAILLERAC.APP) &&
+					kailleraUsernameEquals(ki->user, KAILLERAC.USERNAME)) {
+					KAILLERAC.game_id = id;
 					KAILLERAC.game_id_requested = false;
 					KAILLERAC.user_id_requested = true;
 					
@@ -459,8 +484,8 @@ void kaillera_ProcessGeneralInstruction(k_instruction * ki) {
 			kaillera_player_joined_callback(username, ping, uid, connset);
 
 			if (KAILLERAC.user_id_requested) {
-				KAILLERAC.user_id = uid;
-				if (KAILLERAC.conset == connset && strcmp(username, KAILLERAC.USERNAME)==0) {
+				if (KAILLERAC.conset == connset && kailleraUsernameEquals(username, KAILLERAC.USERNAME)) {
+					KAILLERAC.user_id = uid;
 					KAILLERAC.user_id_requested = false;
 					KAILLERAC.USERSTAT = 3;
 					KAILLERAC.PLAYERSTAT = 0;


### PR DESCRIPTION
## What changed

- Added explicit Windows-31J / CP932 conversion helpers for traditional Kaillera servers.
- Decode incoming Kaillera server text as UTF-8 when valid, otherwise fall back to CP932.
- Encode outgoing Kaillera usernames, lobby chat, game chat, game names, and other protocol strings as CP932.
- Keep RMG-K/CMG-K P2P callbacks on UTF-8 so the independent P2P mode is not changed.
- Avoid cutting a double-byte CP932 character when truncating the 31-byte Kaillera username field.
- Compare room and player identity values using the wire-visible CP932 representation, so Japanese usernames can create and join rooms correctly.
- Assign local game and user IDs only after the corresponding notification has been matched.

## Root cause

The Qt UI treated all incoming Kaillera `char*` values as UTF-8 and sent Qt strings with `toUtf8()`. Traditional Japanese Kaillera clients and servers use Windows-31J / CP932, which caused:

- server MOTD, usernames, and Japanese chat to be garbled in CMG-K;
- Japanese sent by CMG-K to be garbled in Japanese Kaillera clients;
- room creation notifications for Japanese usernames to fail the local identity comparison;
- ASCII-only text to continue working, which made the mismatch less obvious.

## Expected impact

Japanese server text, usernames, lobby chat, game chat, and room creation should work correctly in traditional Kaillera server mode while leaving the separate P2P UTF-8 path unchanged.

## Validation

Tested on Windows 11 using MSYS2 UCRT64 at commit `b2204faf`.

- Debug build completed successfully.
- Japanese server MOTD displayed correctly.
- Japanese usernames displayed correctly in the server and game-room player lists.
- Japanese server chat and lobby chat could be sent and received correctly.
- A room could be created with a Japanese local username.
- The local client switched to the game room after creating it.
- A second CMG-K instance could join the room.
- Two local instances could start gameplay successfully through legacy Kaillera server mode.
- ASCII usernames and chat continued to work.

### Screenshot

Japanese usernames, server chat, and lobby chat displayed correctly in traditional Kaillera server mode.

![Japanese Kaillera server mode test](https://github.com/user-attachments/assets/41d9f347-3870-4431-8afb-11c8f6d6e944)

## Known limitations / follow-up checks

- A dedicated two-client P2P rollback regression test has not yet been completed.
- Very long Japanese game-chat messages may need a separate follow-up because the existing UI splits messages before CP932 conversion.
