### PR TITLE
Critical timing fixes

### DIFF
--- a/Source/3rdParty/mupen64plus-core/src/api/m64p_types.h
+++ b/Source/3rdParty/mupen64plus-core/src/api/m64p_types.h
@@ -71,6 +71,8 @@ typedef struct {
   void *user_data;
   int (*begin_frame)(void *user_data);
   int (*end_frame)(void *user_data);
+  /* RMG-K: enable buffered frontend/core pacing CSV traces. */
+  int pacing_trace_enabled;
 } m64p_rollback_execute_callbacks;
 typedef struct {
   uint64_t total_us;

--- a/Source/3rdParty/mupen64plus-core/src/api/m64p_types.h
+++ b/Source/3rdParty/mupen64plus-core/src/api/m64p_types.h
@@ -71,6 +71,9 @@ typedef struct {
   void *user_data;
   int (*begin_frame)(void *user_data);
   int (*end_frame)(void *user_data);
+  /* RMG-K: called by the core from the video plugin rendering callback,
+   * immediately before the plugin presents the visible rollback frame. */
+  void (*pace_before_present)(void *user_data);
   /* RMG-K: enable buffered frontend/core pacing CSV traces. */
   int pacing_trace_enabled;
 } m64p_rollback_execute_callbacks;

--- a/Source/3rdParty/mupen64plus-core/src/main/main.c
+++ b/Source/3rdParty/mupen64plus-core/src/main/main.c
@@ -143,8 +143,9 @@ static double l_RollbackTimesyncScale = 1.0;
 /* -------------------------------------------------------------------------
  * Buffered core speed-limiter trace.
  *
- * Enabled with RMGK_PACING_TRACE=1. Rows remain in memory during gameplay
- * and are written only after run_device() returns.
+ * Enabled by the frontend's Rollback -> Logging -> Pacing Trace setting.
+ * Rows remain in memory during gameplay and are written after run_device()
+ * returns, avoiding per-frame disk I/O.
  * ------------------------------------------------------------------------- */
 #define RMGK_PACING_TRACE_CAPACITY 60000u
 
@@ -365,17 +366,11 @@ static void rmgk_pacing_trace_flush(void)
     l_RmgkPacingEnabled = 0;
 }
 
-static void rmgk_pacing_trace_reset(void)
+static void rmgk_pacing_trace_reset(int enabled)
 {
-    const char* env;
-
     rmgk_pacing_trace_flush();
 
-    env = getenv("RMGK_PACING_TRACE");
-    l_RmgkPacingEnabled =
-        env != NULL &&
-        env[0] != '\0' &&
-        strcmp(env, "0") != 0;
+    l_RmgkPacingEnabled = enabled ? 1 : 0;
 
     if (!l_RmgkPacingEnabled)
         return;
@@ -2827,7 +2822,8 @@ m64p_error main_run(void)
     g_EmulatorRunning = 1;
     StateChanged(M64CORE_EMU_STATE, M64EMU_RUNNING);
 
-    rmgk_pacing_trace_reset();
+    rmgk_pacing_trace_reset(
+        l_RollbackExecuteCallbacks.pacing_trace_enabled);
     poweron_device(&g_dev);
     pif_bootrom_hle_execute(&g_dev.r4300);
     run_device(&g_dev);

--- a/Source/3rdParty/mupen64plus-core/src/main/main.c
+++ b/Source/3rdParty/mupen64plus-core/src/main/main.c
@@ -139,6 +139,271 @@ static int   l_FrameRunAudio = 1;
 static int   l_FrameRunPacing = 1;
 static int   l_FrameRunInput = 1;
 static double l_RollbackTimesyncScale = 1.0;
+
+/* -------------------------------------------------------------------------
+ * Buffered core speed-limiter trace.
+ *
+ * Enabled with RMGK_PACING_TRACE=1. Rows remain in memory during gameplay
+ * and are written only after run_device() returns.
+ * ------------------------------------------------------------------------- */
+#define RMGK_PACING_TRACE_CAPACITY 60000u
+
+enum rmgk_pacing_reset_reason
+{
+    RMGK_PACING_RESET_NONE = 0,
+    RMGK_PACING_RESET_INITIALIZE = 1,
+    RMGK_PACING_RESET_TOO_LATE = 2,
+    RMGK_PACING_RESET_TOO_EARLY = 3
+};
+
+struct rmgk_pacing_core_row
+{
+    uint64_t sequence;
+    uint32_t core_frame;
+
+    uint64_t entry_us;
+    uint64_t entry_delta_us;
+    uint64_t limiter_total_us;
+
+    double expected_refresh_hz;
+    int speed_factor;
+    double speed_factor_multiple;
+    double rollback_scale;
+    double adjusted_limit_ms;
+    int speed_limit_enabled;
+
+    int rollback_execute_active;
+    int visible_step_active;
+    int hidden_step_active;
+    int frame_output_pacing;
+
+    int reset_before;
+    int reset_after;
+    int reset_reason;
+    int presentation_pacer_bypass;
+
+    double total_elapsed_game_ms;
+    double elapsed_real_ms;
+    double sleep_before_ms;
+    double first_delay_request_ms;
+    double requested_delay_total_ms;
+    uint32_t delay_calls;
+    uint32_t zero_delay_calls;
+    uint64_t actual_delay_us;
+    uint64_t max_single_delay_us;
+    double sleep_after_ms;
+};
+
+static struct rmgk_pacing_core_row* l_RmgkPacingRows = NULL;
+static size_t l_RmgkPacingRowCount = 0;
+static uint64_t l_RmgkPacingLastEntryUs = 0;
+static int l_RmgkPacingEnabled = 0;
+
+static int l_RmgkPresentBaseHzPublished = 0;
+
+static int rmgk_rollback_present_pacer_enabled(void)
+{
+    return 1;
+}
+
+static void rmgk_publish_present_base_hz(
+    double expected_refresh_hz,
+    double speed_factor_multiple)
+{
+    char value[64];
+    double effective_hz;
+
+    if (l_RmgkPresentBaseHzPublished)
+        return;
+
+    if (expected_refresh_hz <= 0.0 ||
+        speed_factor_multiple <= 0.0)
+    {
+        return;
+    }
+
+    /*
+     * The frontend applies rollback_scale itself, so publish only the
+     * nominal VI rate after the ordinary core speed-factor adjustment.
+     */
+    effective_hz =
+        expected_refresh_hz /
+        speed_factor_multiple;
+
+    snprintf(
+        value,
+        sizeof(value),
+        "%.12f",
+        effective_hz);
+
+#if defined(_WIN32)
+    _putenv_s(
+        "RMGK_ROLLBACK_PRESENT_HZ_EFFECTIVE",
+        value);
+#else
+    setenv(
+        "RMGK_ROLLBACK_PRESENT_HZ_EFFECTIVE",
+        value,
+        1);
+#endif
+
+    l_RmgkPresentBaseHzPublished = 1;
+}
+
+static uint64_t rmgk_pacing_now_us(void)
+{
+    const uint64_t counter = SDL_GetPerformanceCounter();
+    const uint64_t frequency = SDL_GetPerformanceFrequency();
+
+    if (frequency == 0)
+        return 0;
+
+    return (counter / frequency) * 1000000ULL +
+           ((counter % frequency) * 1000000ULL) / frequency;
+}
+
+static void rmgk_pacing_trace_flush(void)
+{
+    char path[4096];
+    const char* directory;
+    const char* prefix;
+    FILE* file;
+    size_t i;
+
+    if (!l_RmgkPacingEnabled || l_RmgkPacingRows == NULL)
+        return;
+
+    directory = getenv("RMGK_ROLLBACK_LOG_DIR");
+    prefix = getenv("RMGK_ROLLBACK_LOG_PREFIX");
+
+    if (directory != NULL && directory[0] != '\0' &&
+        prefix != NULL && prefix[0] != '\0')
+    {
+        snprintf(
+            path,
+            sizeof(path),
+            "%s/%s_pacing_core.csv",
+            directory,
+            prefix);
+    }
+    else
+    {
+        snprintf(
+            path,
+            sizeof(path),
+            "rmgk_pacing_core.csv");
+    }
+
+    file = fopen(path, "wb");
+    if (file != NULL)
+    {
+        fprintf(
+            file,
+            "sequence,core_frame,entry_us,entry_delta_us,"
+            "limiter_total_us,expected_refresh_hz,speed_factor,"
+            "speed_factor_multiple,rollback_scale,adjusted_limit_ms,"
+            "speed_limit_enabled,rollback_execute_active,"
+            "visible_step_active,hidden_step_active,frame_output_pacing,"
+            "reset_before,reset_after,reset_reason,"
+            "presentation_pacer_bypass,"
+            "total_elapsed_game_ms,elapsed_real_ms,sleep_before_ms,"
+            "first_delay_request_ms,requested_delay_total_ms,"
+            "delay_calls,zero_delay_calls,actual_delay_us,"
+            "max_single_delay_us,sleep_after_ms\n");
+
+        for (i = 0; i < l_RmgkPacingRowCount; ++i)
+        {
+            const struct rmgk_pacing_core_row* row =
+                &l_RmgkPacingRows[i];
+
+            fprintf(
+                file,
+                "%llu,%u,%llu,%llu,%llu,"
+                "%.9f,%d,%.9f,%.9f,%.9f,"
+                "%d,%d,%d,%d,%d,"
+                "%d,%d,%d,%d,"
+                "%.9f,%.9f,%.9f,"
+                "%.9f,%.9f,%u,%u,%llu,%llu,%.9f\n",
+                (unsigned long long) row->sequence,
+                row->core_frame,
+                (unsigned long long) row->entry_us,
+                (unsigned long long) row->entry_delta_us,
+                (unsigned long long) row->limiter_total_us,
+                row->expected_refresh_hz,
+                row->speed_factor,
+                row->speed_factor_multiple,
+                row->rollback_scale,
+                row->adjusted_limit_ms,
+                row->speed_limit_enabled,
+                row->rollback_execute_active,
+                row->visible_step_active,
+                row->hidden_step_active,
+                row->frame_output_pacing,
+                row->reset_before,
+                row->reset_after,
+                row->reset_reason,
+                row->presentation_pacer_bypass,
+                row->total_elapsed_game_ms,
+                row->elapsed_real_ms,
+                row->sleep_before_ms,
+                row->first_delay_request_ms,
+                row->requested_delay_total_ms,
+                row->delay_calls,
+                row->zero_delay_calls,
+                (unsigned long long) row->actual_delay_us,
+                (unsigned long long) row->max_single_delay_us,
+                row->sleep_after_ms);
+        }
+
+        fclose(file);
+    }
+
+    free(l_RmgkPacingRows);
+    l_RmgkPacingRows = NULL;
+    l_RmgkPacingRowCount = 0;
+    l_RmgkPacingLastEntryUs = 0;
+    l_RmgkPacingEnabled = 0;
+}
+
+static void rmgk_pacing_trace_reset(void)
+{
+    const char* env;
+
+    rmgk_pacing_trace_flush();
+
+    env = getenv("RMGK_PACING_TRACE");
+    l_RmgkPacingEnabled =
+        env != NULL &&
+        env[0] != '\0' &&
+        strcmp(env, "0") != 0;
+
+    if (!l_RmgkPacingEnabled)
+        return;
+
+    l_RmgkPacingRows =
+        (struct rmgk_pacing_core_row*) calloc(
+            RMGK_PACING_TRACE_CAPACITY,
+            sizeof(struct rmgk_pacing_core_row));
+
+    if (l_RmgkPacingRows == NULL)
+        l_RmgkPacingEnabled = 0;
+}
+
+static void rmgk_pacing_trace_push(
+    const struct rmgk_pacing_core_row* row)
+{
+    if (!l_RmgkPacingEnabled ||
+        l_RmgkPacingRows == NULL ||
+        row == NULL)
+    {
+        return;
+    }
+
+    if (l_RmgkPacingRowCount >= RMGK_PACING_TRACE_CAPACITY)
+        return;
+
+    l_RmgkPacingRows[l_RmgkPacingRowCount++] = *row;
+}
 static m64p_rollback_execute_callbacks l_RollbackExecuteCallbacks;
 static int   l_RollbackExecuteActive = 0;
 static int   l_RollbackSingleStepActive = 0;
@@ -717,6 +982,7 @@ void main_set_rollback_execute_callbacks(m64p_rollback_execute_callbacks* callba
         l_RollbackVisibleStepCompleted = 0;
         l_RollbackHiddenStepActive = 0;
         l_RollbackHiddenStepCompleted = 0;
+        l_RmgkPresentBaseHzPublished = 0;
 #ifdef NEW_DYNAREC
         new_dynarec_rollback_stats_reset();
 #endif
@@ -1366,12 +1632,102 @@ static void apply_speed_limiter(void)
     static double totalElapsedGameTime = 0.0;
     static uint64_t StartFPSTime = 0;
     static const double defaultSpeedFactor = 100.0;
+
+    struct rmgk_pacing_core_row traceRow;
+    uint64_t traceEntryUs = 0;
+    uint64_t traceEntryDeltaUs = 0;
+    int traceResetReason = RMGK_PACING_RESET_NONE;
+
+    if (l_RmgkPacingEnabled)
+    {
+        memset(&traceRow, 0, sizeof(traceRow));
+        traceEntryUs = rmgk_pacing_now_us();
+        traceEntryDeltaUs =
+            l_RmgkPacingLastEntryUs == 0
+                ? 0
+                : traceEntryUs - l_RmgkPacingLastEntryUs;
+
+        traceRow.sequence =
+            (uint64_t) l_RmgkPacingRowCount;
+        traceRow.core_frame = (uint32_t) l_CurrentFrame;
+        traceRow.entry_us = traceEntryUs;
+        traceRow.entry_delta_us = traceEntryDeltaUs;
+        traceRow.speed_factor = l_SpeedFactor;
+        traceRow.rollback_scale = l_RollbackTimesyncScale;
+        traceRow.speed_limit_enabled = l_MainSpeedLimit;
+        traceRow.rollback_execute_active =
+            l_RollbackExecuteActive;
+        traceRow.visible_step_active =
+            l_RollbackVisibleStepActive;
+        traceRow.hidden_step_active =
+            l_RollbackHiddenStepActive;
+        traceRow.frame_output_pacing =
+            l_FrameOutputPacing;
+        traceRow.reset_before = resetOnce;
+    }
+
     uint64_t CurrentFPSTime = SDL_GetTicks();
 
     // calculate frame duration based upon ROM setting (50/60hz) and mupen64plus speed adjustment
     const double VILimitMilliseconds = 1000.0 / g_dev.vi.expected_refresh_rate;
     const double SpeedFactorMultiple = defaultSpeedFactor/l_SpeedFactor;
     const double AdjustedLimit = (VILimitMilliseconds * SpeedFactorMultiple) / l_RollbackTimesyncScale;
+
+    if (l_RmgkPacingEnabled)
+    {
+        traceRow.expected_refresh_hz =
+            g_dev.vi.expected_refresh_rate;
+        traceRow.speed_factor_multiple =
+            SpeedFactorMultiple;
+        traceRow.adjusted_limit_ms =
+            AdjustedLimit;
+    }
+
+    /*
+     * Experimental rollback presentation pacing.
+     *
+     * When enabled, do not spend the frame's idle budget here. The frontend
+     * waits immediately before SwapBuffers(), after hidden rollback
+     * resimulation and visible-frame rendering have completed.
+     *
+     * Reset the cumulative limiter state on every bypassed visible rollback
+     * frame so stale wall-clock debt cannot leak back in when rollback
+     * execution ends.
+     */
+    if (rmgk_rollback_present_pacer_enabled() &&
+        l_RollbackExecuteActive &&
+        l_RollbackVisibleStepActive &&
+        l_FrameOutputPacing)
+    {
+        rmgk_publish_present_base_hz(
+            g_dev.vi.expected_refresh_rate,
+            SpeedFactorMultiple);
+
+        StartFPSTime = 0;
+        totalVIs = 0;
+        totalElapsedGameTime = 0.0;
+        resetOnce = 0;
+        lastSpeedFactor = l_SpeedFactor;
+
+        if (l_RmgkPacingEnabled)
+        {
+            traceRow.presentation_pacer_bypass = 1;
+            traceRow.total_elapsed_game_ms = 0.0;
+            traceRow.elapsed_real_ms = 0.0;
+            traceRow.sleep_before_ms = 0.0;
+            traceRow.sleep_after_ms = 0.0;
+            traceRow.reset_after = resetOnce;
+            traceRow.reset_reason =
+                RMGK_PACING_RESET_NONE;
+            traceRow.limiter_total_us =
+                rmgk_pacing_now_us() - traceEntryUs;
+
+            rmgk_pacing_trace_push(&traceRow);
+            l_RmgkPacingLastEntryUs = traceEntryUs;
+        }
+
+        return;
+    }
 
     //if this is the first time or we are resuming from pause
     if(StartFPSTime == 0 || !resetOnce || lastSpeedFactor != l_SpeedFactor)
@@ -1380,6 +1736,7 @@ static void apply_speed_limiter(void)
        totalVIs = 0;
        totalElapsedGameTime = 0.0;
        resetOnce = 1;
+       traceResetReason = RMGK_PACING_RESET_INITIALIZE;
     }
     else
     {
@@ -1400,12 +1757,24 @@ static void apply_speed_limiter(void)
     double elapsedRealTime = CurrentFPSTime - StartFPSTime;
     double sleepTime = totalElapsedGameTime - elapsedRealTime;
 
+    if (l_RmgkPacingEnabled)
+    {
+        traceRow.total_elapsed_game_ms =
+            totalElapsedGameTime;
+        traceRow.elapsed_real_ms = elapsedRealTime;
+        traceRow.sleep_before_ms = sleepTime;
+    }
+
     //Reset if the sleep needed is an unreasonable value
     static const double minSleepNeeded = -50;
     static const double maxSleepNeeded = 50;
     if(sleepTime < minSleepNeeded || sleepTime > (maxSleepNeeded*SpeedFactorMultiple))
     {
        resetOnce = 0;
+       traceResetReason =
+           sleepTime < minSleepNeeded
+               ? RMGK_PACING_RESET_TOO_LATE
+               : RMGK_PACING_RESET_TOO_EARLY;
     }
 
     if (sleepTime < minSleepNeeded) {
@@ -1415,7 +1784,39 @@ static void apply_speed_limiter(void)
     if(l_MainSpeedLimit && sleepTime > 0 && sleepTime < maxSleepNeeded*SpeedFactorMultiple)
     {
         while(sleepTime >= 0) {
-            SDL_Delay((unsigned int) sleepTime);
+            const unsigned int requestedDelayMs =
+                (unsigned int) sleepTime;
+            uint64_t delayBeginUs = 0;
+            uint64_t actualDelayUs = 0;
+
+            if (l_RmgkPacingEnabled)
+            {
+                if (traceRow.delay_calls == 0)
+                    traceRow.first_delay_request_ms = sleepTime;
+
+                traceRow.requested_delay_total_ms +=
+                    (double) requestedDelayMs;
+                traceRow.delay_calls++;
+                if (requestedDelayMs == 0)
+                    traceRow.zero_delay_calls++;
+
+                delayBeginUs = rmgk_pacing_now_us();
+            }
+
+            SDL_Delay(requestedDelayMs);
+
+            if (l_RmgkPacingEnabled)
+            {
+                actualDelayUs =
+                    rmgk_pacing_now_us() - delayBeginUs;
+                traceRow.actual_delay_us += actualDelayUs;
+                if (actualDelayUs >
+                    traceRow.max_single_delay_us)
+                {
+                    traceRow.max_single_delay_us =
+                        actualDelayUs;
+                }
+            }
 
             CurrentFPSTime = SDL_GetTicks();
             elapsedRealTime = CurrentFPSTime - StartFPSTime;
@@ -1427,6 +1828,21 @@ static void apply_speed_limiter(void)
 #if defined(PROFILE)
     timed_section_end(TIMED_SECTION_IDLE);
 #endif
+
+    if (l_RmgkPacingEnabled)
+    {
+        traceRow.limiter_total_us =
+            rmgk_pacing_now_us() - traceEntryUs;
+        traceRow.reset_after = resetOnce;
+        traceRow.reset_reason = traceResetReason;
+        traceRow.total_elapsed_game_ms =
+            totalElapsedGameTime;
+        traceRow.elapsed_real_ms = elapsedRealTime;
+        traceRow.sleep_after_ms = sleepTime;
+
+        rmgk_pacing_trace_push(&traceRow);
+        l_RmgkPacingLastEntryUs = traceEntryUs;
+    }
 }
 
 /* TODO: make a GameShark module and move that there */
@@ -2411,9 +2827,11 @@ m64p_error main_run(void)
     g_EmulatorRunning = 1;
     StateChanged(M64CORE_EMU_STATE, M64EMU_RUNNING);
 
+    rmgk_pacing_trace_reset();
     poweron_device(&g_dev);
     pif_bootrom_hle_execute(&g_dev.r4300);
     run_device(&g_dev);
+    rmgk_pacing_trace_flush();
 
     /* now begin to shut down */
 #ifdef WITH_LIRC
@@ -2490,6 +2908,7 @@ on_gfx_open_failure:
     /* reset pif */
     close_pif();
 
+    rmgk_pacing_trace_flush();
     return failure_rval;
 }
 

--- a/Source/3rdParty/mupen64plus-core/src/main/main.c
+++ b/Source/3rdParty/mupen64plus-core/src/main/main.c
@@ -404,6 +404,10 @@ static int   l_RollbackExecuteActive = 0;
 static int   l_RollbackSingleStepActive = 0;
 static int   l_RollbackVisibleStepActive = 0;
 static int   l_RollbackVisibleStepCompleted = 0;
+/* Set only when the video plugin reached its pre-present rendering callback
+ * for the current visible rollback frame. If it does not, the ordinary core
+ * limiter remains active as a safety fallback. */
+static int   l_RollbackPresentPacedThisFrame = 0;
 static int   l_RollbackHiddenStepActive = 0;
 static int   l_RollbackHiddenStepCompleted = 0;
 static m64p_rollback_run_frame_stats l_RollbackRunFrameStats;
@@ -975,6 +979,7 @@ void main_set_rollback_execute_callbacks(m64p_rollback_execute_callbacks* callba
         l_RollbackExecuteActive = 0;
         l_RollbackVisibleStepActive = 0;
         l_RollbackVisibleStepCompleted = 0;
+        l_RollbackPresentPacedThisFrame = 0;
         l_RollbackHiddenStepActive = 0;
         l_RollbackHiddenStepCompleted = 0;
         l_RmgkPresentBaseHzPublished = 0;
@@ -1014,6 +1019,7 @@ void main_rollback_visible_frame_begin(void)
 {
     l_RollbackVisibleStepActive = 1;
     l_RollbackVisibleStepCompleted = 0;
+    l_RollbackPresentPacedThisFrame = 0;
 }
 
 int main_rollback_visible_frame_completed(void)
@@ -1577,6 +1583,23 @@ static void video_plugin_render_callback(int bScreenRedrawn)
     {
         input.renderCallback();
     }
+
+    /*
+     * All bundled video plugins invoke this rendering callback immediately
+     * before presenting: GLideN64/Angrylion before GL swap and Parallel before
+     * wsi->end_frame(). Pace here so OpenGL and Vulkan share one phase-locked
+     * presentation path. Guard against duplicate rendering callbacks in one VI.
+     */
+    if (l_RollbackExecuteActive &&
+        l_RollbackVisibleStepActive &&
+        l_FrameOutputPacing &&
+        !l_RollbackPresentPacedThisFrame &&
+        l_RollbackExecuteCallbacks.pace_before_present != NULL)
+    {
+        l_RollbackPresentPacedThisFrame = 1;
+        l_RollbackExecuteCallbacks.pace_before_present(
+            l_RollbackExecuteCallbacks.user_data);
+    }
 }
 
 void new_frame(void)
@@ -1679,11 +1702,12 @@ static void apply_speed_limiter(void)
     }
 
     /*
-     * Experimental rollback presentation pacing.
+     * Rollback presentation pacing.
      *
-     * When enabled, do not spend the frame's idle budget here. The frontend
-     * waits immediately before SwapBuffers(), after hidden rollback
-     * resimulation and visible-frame rendering have completed.
+     * The video plugin rendering callback runs immediately before the actual
+     * OpenGL/Vulkan present. Only bypass the ordinary core limiter if that hook
+     * really ran for this visible frame. Plugins which omit the hook therefore
+     * fall back to the core limiter instead of running unbounded.
      *
      * Reset the cumulative limiter state on every bypassed visible rollback
      * frame so stale wall-clock debt cannot leak back in when rollback
@@ -1692,7 +1716,8 @@ static void apply_speed_limiter(void)
     if (rmgk_rollback_present_pacer_enabled() &&
         l_RollbackExecuteActive &&
         l_RollbackVisibleStepActive &&
-        l_FrameOutputPacing)
+        l_FrameOutputPacing &&
+        l_RollbackPresentPacedThisFrame)
     {
         rmgk_publish_present_base_hz(
             g_dev.vi.expected_refresh_rate,

--- a/Source/RMG-Core/PreciseWait.hpp
+++ b/Source/RMG-Core/PreciseWait.hpp
@@ -1,0 +1,364 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+
+#if defined(_WIN32)
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <windows.h>
+
+#if defined(_M_IX86) || defined(_M_X64)
+#include <immintrin.h>
+#endif
+
+#elif defined(__linux__)
+
+#include <cerrno>
+#include <ctime>
+
+#if defined(__i386__) || defined(__x86_64__)
+#include <immintrin.h>
+#endif
+
+#endif
+
+namespace rmgk::timing
+{
+namespace detail
+{
+
+inline void CpuRelax() noexcept
+{
+#if defined(_M_IX86) || defined(_M_X64) || \
+    defined(__i386__) || defined(__x86_64__)
+
+    _mm_pause();
+
+#elif defined(__aarch64__)
+
+    __asm__ __volatile__("yield");
+
+#else
+
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+
+#endif
+}
+
+#if defined(_WIN32)
+
+inline std::int64_t QpcFrequency() noexcept
+{
+    static const std::int64_t frequency = [] {
+        LARGE_INTEGER value{};
+
+        if (!QueryPerformanceFrequency(&value) ||
+            value.QuadPart <= 0)
+        {
+            // QPC should be available on supported Windows versions.
+            // This fallback prevents division by zero.
+            return std::int64_t{10'000'000};
+        }
+
+        return static_cast<std::int64_t>(value.QuadPart);
+    }();
+
+    return frequency;
+}
+
+inline std::int64_t QpcNow() noexcept
+{
+    LARGE_INTEGER value{};
+    QueryPerformanceCounter(&value);
+    return static_cast<std::int64_t>(value.QuadPart);
+}
+
+inline std::int64_t MicrosecondsToQpcTicks(
+    std::int64_t microseconds) noexcept
+{
+    const std::int64_t frequency = QpcFrequency();
+
+    // Round upward so the requested deadline is not shortened.
+    return (microseconds * frequency + 999'999) / 1'000'000;
+}
+
+inline std::int64_t QpcTicksToMicroseconds(
+    std::int64_t ticks) noexcept
+{
+    return (ticks * 1'000'000) / QpcFrequency();
+}
+
+struct ThreadWaitableTimer
+{
+    HANDLE handle = nullptr;
+
+    ThreadWaitableTimer() noexcept
+    {
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
+
+        handle = CreateWaitableTimerExW(
+            nullptr,
+            nullptr,
+            CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+            TIMER_MODIFY_STATE | SYNCHRONIZE);
+
+        // Fallback for Windows versions or SDK configurations that do not
+        // support the high-resolution flag.
+        if (handle == nullptr)
+        {
+            handle = CreateWaitableTimerExW(
+                nullptr,
+                nullptr,
+                0,
+                TIMER_MODIFY_STATE | SYNCHRONIZE);
+        }
+    }
+
+    ~ThreadWaitableTimer()
+    {
+        if (handle != nullptr)
+        {
+            CloseHandle(handle);
+        }
+    }
+
+    ThreadWaitableTimer(const ThreadWaitableTimer&) = delete;
+    ThreadWaitableTimer& operator=(
+        const ThreadWaitableTimer&) = delete;
+};
+
+inline bool KernelWaitForMicroseconds(
+    std::int64_t microseconds) noexcept
+{
+    if (microseconds <= 0)
+    {
+        return true;
+    }
+
+    static thread_local ThreadWaitableTimer timer;
+
+    if (timer.handle == nullptr)
+    {
+        return false;
+    }
+
+    LARGE_INTEGER dueTime{};
+
+    // A negative value means a duration relative to the current time.
+    // Windows timer units are 100 nanoseconds.
+    dueTime.QuadPart =
+        -std::max<std::int64_t>(1, microseconds * 10);
+
+    if (!SetWaitableTimer(
+            timer.handle,
+            &dueTime,
+            0,
+            nullptr,
+            nullptr,
+            FALSE))
+    {
+        return false;
+    }
+
+    return WaitForSingleObject(
+               timer.handle,
+               INFINITE) == WAIT_OBJECT_0;
+}
+
+inline void SpinUntilQpc(std::int64_t deadline) noexcept
+{
+    for (;;)
+    {
+        // Avoid querying QPC after every single PAUSE instruction.
+        for (int i = 0; i < 32; ++i)
+        {
+            CpuRelax();
+        }
+
+        if (QpcNow() >= deadline)
+        {
+            return;
+        }
+    }
+}
+
+#elif defined(__linux__)
+
+inline std::int64_t MonotonicNowNanoseconds() noexcept
+{
+    timespec value{};
+    clock_gettime(CLOCK_MONOTONIC, &value);
+
+    return
+        static_cast<std::int64_t>(value.tv_sec) *
+            1'000'000'000LL +
+        static_cast<std::int64_t>(value.tv_nsec);
+}
+
+inline timespec NanosecondsToTimespec(
+    std::int64_t nanoseconds) noexcept
+{
+    timespec value{};
+
+    value.tv_sec = static_cast<time_t>(
+        nanoseconds / 1'000'000'000LL);
+
+    value.tv_nsec = static_cast<long>(
+        nanoseconds % 1'000'000'000LL);
+
+    return value;
+}
+
+inline void KernelSleepUntilNanoseconds(
+    std::int64_t deadlineNanoseconds) noexcept
+{
+    const timespec deadline =
+        NanosecondsToTimespec(deadlineNanoseconds);
+
+    int result;
+
+    do
+    {
+        result = clock_nanosleep(
+            CLOCK_MONOTONIC,
+            TIMER_ABSTIME,
+            &deadline,
+            nullptr);
+    }
+    while (result == EINTR);
+}
+
+inline void SpinUntilNanoseconds(
+    std::int64_t deadlineNanoseconds) noexcept
+{
+    for (;;)
+    {
+        for (int i = 0; i < 32; ++i)
+        {
+            CpuRelax();
+        }
+
+        if (MonotonicNowNanoseconds() >=
+            deadlineNanoseconds)
+        {
+            return;
+        }
+    }
+}
+
+#endif
+
+} // namespace detail
+
+//
+// Wait for approximately `duration`, never intentionally returning before
+// the monotonic deadline.
+//
+// `spinTail` controls how much of the end of the wait is busy-spun.
+// When spinTail >= duration, the entire wait is a busy wait.
+//
+inline void PreciseWaitFor(
+    std::chrono::microseconds duration,
+    std::chrono::microseconds spinTail =
+        std::chrono::microseconds{100}) noexcept
+{
+    const std::int64_t totalUs = duration.count();
+
+    if (totalUs <= 0)
+    {
+        return;
+    }
+
+    const std::int64_t tailUs =
+        std::clamp<std::int64_t>(
+            spinTail.count(),
+            0,
+            totalUs);
+
+#if defined(_WIN32)
+
+    const std::int64_t deadline =
+        detail::QpcNow() +
+        detail::MicrosecondsToQpcTicks(totalUs);
+
+    for (;;)
+    {
+        const std::int64_t remainingTicks =
+            deadline - detail::QpcNow();
+
+        const std::int64_t remainingUs =
+            detail::QpcTicksToMicroseconds(
+                remainingTicks);
+
+        if (remainingUs <= tailUs)
+        {
+            break;
+        }
+
+        const std::int64_t kernelWaitUs =
+            remainingUs - tailUs;
+
+        if (!detail::KernelWaitForMicroseconds(
+                kernelWaitUs))
+        {
+            std::this_thread::sleep_for(
+                std::chrono::microseconds{
+                    kernelWaitUs});
+        }
+    }
+
+    detail::SpinUntilQpc(deadline);
+
+#elif defined(__linux__)
+
+    const std::int64_t deadlineNs =
+        detail::MonotonicNowNanoseconds() +
+        totalUs * 1'000LL;
+
+    const std::int64_t kernelDeadlineNs =
+        deadlineNs - tailUs * 1'000LL;
+
+    if (kernelDeadlineNs >
+        detail::MonotonicNowNanoseconds())
+    {
+        detail::KernelSleepUntilNanoseconds(
+            kernelDeadlineNs);
+    }
+
+    detail::SpinUntilNanoseconds(deadlineNs);
+
+#else
+
+    // Portable fallback for other platforms.
+    const auto deadline =
+        std::chrono::steady_clock::now() + duration;
+
+    const auto kernelDeadline =
+        deadline - std::chrono::microseconds{tailUs};
+
+    if (kernelDeadline >
+        std::chrono::steady_clock::now())
+    {
+        std::this_thread::sleep_until(
+            kernelDeadline);
+    }
+
+    while (std::chrono::steady_clock::now() <
+           deadline)
+    {
+        detail::CpuRelax();
+    }
+
+#endif
+}
+
+} // namespace rmgk::timing

--- a/Source/RMG-Core/Settings.cpp
+++ b/Source/RMG-Core/Settings.cpp
@@ -356,6 +356,9 @@ static l_Setting get_setting(SettingsID settingId)
     case SettingsID::Rollback_StallDiagnostics:
         setting = {SETTING_SECTION_ROLLBACK, "StallDiagnostics", false};
         break;
+    case SettingsID::Rollback_PacingTrace:
+        setting = {SETTING_SECTION_ROLLBACK, "PacingTrace", false};
+        break;
     case SettingsID::Rollback_PacingMode:
         // 0 = symmetric/aggressive (default), 1 = asymmetric/Slippi-style.
         setting = {SETTING_SECTION_ROLLBACK, "PacingMode", 0};

--- a/Source/RMG-Core/Settings.hpp
+++ b/Source/RMG-Core/Settings.hpp
@@ -108,6 +108,7 @@ enum class SettingsID
     Rollback_VerbosePifInputLogging,
     Rollback_VerboseGlideInputLogging,
     Rollback_StallDiagnostics,
+    Rollback_PacingTrace,
     Rollback_PacingMode,
 
     // Core Plugin Settings

--- a/Source/RMG-Core/m64p/api/m64p_types.h
+++ b/Source/RMG-Core/m64p/api/m64p_types.h
@@ -71,6 +71,8 @@ typedef struct {
   void *user_data;
   int (*begin_frame)(void *user_data);
   int (*end_frame)(void *user_data);
+  /* RMG-K: enable buffered frontend/core pacing CSV traces. */
+  int pacing_trace_enabled;
 } m64p_rollback_execute_callbacks;
 typedef struct {
   uint64_t total_us;

--- a/Source/RMG-Core/m64p/api/m64p_types.h
+++ b/Source/RMG-Core/m64p/api/m64p_types.h
@@ -71,6 +71,9 @@ typedef struct {
   void *user_data;
   int (*begin_frame)(void *user_data);
   int (*end_frame)(void *user_data);
+  /* RMG-K: called by the core from the video plugin rendering callback,
+   * immediately before the plugin presents the visible rollback frame. */
+  void (*pace_before_present)(void *user_data);
   /* RMG-K: enable buffered frontend/core pacing CSV traces. */
   int pacing_trace_enabled;
 } m64p_rollback_execute_callbacks;

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -15,6 +15,8 @@
 #include "Library.hpp"
 #include "Settings.hpp"
 
+#include "PreciseWait.hpp"
+
 #ifdef RMGK_HAVE_GEKKONET
 #include <gekkonet.h>
 #ifdef RMGK_HAVE_P2P_TRANSPORT
@@ -1516,7 +1518,8 @@ int rollback_execute_begin_frame(void* userData)
             return 1;
         }
 
-        std::this_thread::sleep_for(std::chrono::microseconds(kGekkoWaitSleepUs));
+        //std::this_thread::sleep_for(std::chrono::microseconds(kGekkoWaitSleepUs)); // Not accurate enough in windows
+		rmgk::timing::PreciseWaitFor(std::chrono::microseconds{kGekkoWaitSleepUs}, std::chrono::microseconds{kGekkoWaitSleepUs});
     }
 }
 

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -202,6 +202,407 @@ long long g_GekkoLastSaveStateUs = 0;
 long long g_GekkoLastRunFrameUs = 0;
 long long g_GekkoLastPendingSaveUs = 0;
 
+// ---------------------------------------------------------------------------
+// Buffered rollback pacing trace.
+//
+// Enabled with RMGK_PACING_TRACE=1. Rows remain in memory during gameplay and
+// are written only when rollback execution ends, avoiding per-frame disk I/O.
+// ---------------------------------------------------------------------------
+constexpr std::size_t kRmgkPacingTraceCapacity = 60000;
+constexpr std::size_t kRmgkPacingTraceInvalidRow =
+    static_cast<std::size_t>(-1);
+
+struct RmgkPacingTraceRow
+{
+    std::uint64_t sequence = 0;
+    long long timestampUs = 0;
+
+    int coreFrameBegin = -1;
+    int coreFrameSwap = -1;
+    int coreFrameEnd = -1;
+
+    float framesAhead = 0.0f;
+    double targetScale = 1.0;
+    double internalScale = 1.0;
+    double clampedScale = 1.0;
+    int pacingMode = 0;
+    int sampleFrame = 0;
+
+    int events = 0;
+    int saves = 0;
+    int loads = 0;
+    int rollbackAdvances = 0;
+    int runaheadAdvances = 0;
+    int waitLoops = 0;
+
+    long long debugBeginUs = 0;
+    long long beginTotalUs = 0;
+    long long networkPollUs = 0;
+    long long pacingCalcUs = 0;
+    long long submitInputUs = 0;
+    long long updateSessionUs = 0;
+    long long latchInputUs = 0;
+    long long saveTotalUs = 0;
+    long long loadTotalUs = 0;
+    long long resimTotalUs = 0;
+    long long resimMaxUs = 0;
+    long long waitTotalUs = 0;
+    long long waitMaxUs = 0;
+
+    int presentPacerActive = 0;
+    int presentPacerFirstFrame = 0;
+    int presentPacerDeadlineMiss = 0;
+    double presentPacerScale = 1.0;
+    double presentPacerPeriodUs = 0.0;
+    long long presentIntervalBeforeWaitUs = 0;
+    long long presentWaitRequestedUs = 0;
+    long long presentWaitActualUs = 0;
+    long long presentLateUs = 0;
+    long long presentIntervalAfterWaitUs = 0;
+
+    long long swapUs = 0;
+    long long makeCurrentUs = 0;
+    int swapPath = 0; // 1 = native WGL, 2 = Qt OpenGL
+
+    long long endTotalUs = 0;
+    long long pendingSaveUs = 0;
+    long long debugEndUs = 0;
+};
+
+std::vector<RmgkPacingTraceRow> g_RmgkPacingTraceRows;
+bool g_RmgkPacingTraceEnabled = false;
+std::size_t g_RmgkPacingTraceActiveRow =
+    kRmgkPacingTraceInvalidRow;
+
+float g_RmgkTraceFramesAhead = 0.0f;
+double g_RmgkTraceTargetScale = 1.0;
+double g_RmgkTraceInternalScale = 1.0;
+double g_RmgkTraceClampedScale = 1.0;
+int g_RmgkTracePacingMode = 0;
+int g_RmgkTraceSampleFrame = 0;
+
+// ---------------------------------------------------------------------------
+// Rollback presentation pacer.
+//
+// The ordinary core limiter is bypassed for visible rollback frames. The
+// emulation thread then waits here, immediately before SwapBuffers(), until the
+// next phase-locked presentation deadline. Hidden rollback work therefore
+// consumes idle time instead of being added after an earlier core sleep.
+//
+// The core publishes the exact nominal VI rate before the first swap.
+// RMGK_ROLLBACK_PRESENT_HZ may be used as an explicit diagnostic override.
+// ---------------------------------------------------------------------------
+bool g_RollbackPresentPacerEnabled = true;
+double g_RollbackPresentBaseHz = 60.0;
+bool g_RollbackPresentBaseHzOverridden = false;
+bool g_RollbackPresentPacerInitialized = false;
+std::chrono::steady_clock::time_point g_RollbackPresentLastSwapTime;
+std::chrono::steady_clock::time_point g_RollbackPresentTargetTime;
+
+void reset_rollback_present_pacer()
+{
+    // The rollback presentation pacer is a permanent part of the rollback
+    // frame path. It remains gated below by the active session/execution checks.
+    g_RollbackPresentPacerEnabled = true;
+
+    g_RollbackPresentBaseHz = 60.0;
+    g_RollbackPresentBaseHzOverridden = false;
+
+    const char* hzEnv =
+        std::getenv("RMGK_ROLLBACK_PRESENT_HZ");
+
+    if (hzEnv != nullptr && hzEnv[0] != '\0')
+    {
+        char* end = nullptr;
+        const double value = std::strtod(hzEnv, &end);
+
+        if (end != hzEnv &&
+            value >= 30.0 &&
+            value <= 240.0)
+        {
+            g_RollbackPresentBaseHz = value;
+            g_RollbackPresentBaseHzOverridden = true;
+        }
+    }
+
+    g_RollbackPresentPacerInitialized = false;
+    g_RollbackPresentLastSwapTime =
+        std::chrono::steady_clock::time_point{};
+    g_RollbackPresentTargetTime =
+        std::chrono::steady_clock::time_point{};
+}
+
+void record_rollback_present_pacing(
+    int active,
+    int firstFrame,
+    int deadlineMiss,
+    double scale,
+    double periodUs,
+    long long intervalBeforeWaitUs,
+    long long waitRequestedUs,
+    long long waitActualUs,
+    long long lateUs,
+    long long intervalAfterWaitUs)
+{
+    if (!g_RmgkPacingTraceEnabled ||
+        g_RmgkPacingTraceActiveRow ==
+            kRmgkPacingTraceInvalidRow ||
+        g_RmgkPacingTraceActiveRow >=
+            g_RmgkPacingTraceRows.size())
+    {
+        return;
+    }
+
+    auto& row =
+        g_RmgkPacingTraceRows[
+            g_RmgkPacingTraceActiveRow];
+
+    row.presentPacerActive = active;
+    row.presentPacerFirstFrame = firstFrame;
+    row.presentPacerDeadlineMiss = deadlineMiss;
+    row.presentPacerScale = scale;
+    row.presentPacerPeriodUs = periodUs;
+    row.presentIntervalBeforeWaitUs =
+        intervalBeforeWaitUs;
+    row.presentWaitRequestedUs = waitRequestedUs;
+    row.presentWaitActualUs = waitActualUs;
+    row.presentLateUs = lateUs;
+    row.presentIntervalAfterWaitUs =
+        intervalAfterWaitUs;
+}
+
+long long rmgk_pacing_trace_now_us()
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+void rmgk_pacing_trace_flush()
+{
+    g_RmgkPacingTraceActiveRow = kRmgkPacingTraceInvalidRow;
+
+    if (!g_RmgkPacingTraceEnabled ||
+        g_RmgkPacingTraceRows.empty())
+    {
+        g_RmgkPacingTraceRows.clear();
+        return;
+    }
+
+    const std::string filename =
+        g_GekkoLogPrefix + "_pacing_frontend.csv";
+
+    const std::filesystem::path path =
+        g_GekkoLogDirectory.empty()
+            ? std::filesystem::path(filename)
+            : g_GekkoLogDirectory / filename;
+
+    std::ofstream file(path, std::ios::out | std::ios::trunc);
+    if (file)
+    {
+        file
+            << "sequence,timestamp_us,"
+            << "core_frame_begin,core_frame_swap,core_frame_end,"
+            << "frames_ahead,target_scale,internal_scale,clamped_scale,"
+            << "pacing_mode,sample_frame,"
+            << "events,saves,loads,rollback_advances,runahead_advances,"
+            << "wait_loops,debug_begin_us,begin_total_us,"
+            << "network_poll_us,pacing_calc_us,submit_input_us,"
+            << "update_session_us,latch_input_us,save_total_us,"
+            << "load_total_us,resim_total_us,resim_max_us,"
+            << "wait_total_us,wait_max_us,"
+            << "present_pacer_active,present_pacer_first_frame,"
+            << "present_pacer_deadline_miss,"
+            << "present_pacer_scale,present_pacer_period_us,"
+            << "present_interval_before_wait_us,"
+            << "present_wait_requested_us,present_wait_actual_us,"
+            << "present_late_us,present_interval_after_wait_us,"
+            << "swap_us,make_current_us,swap_path,"
+            << "end_total_us,pending_save_us,debug_end_us\n";
+
+        file << std::fixed << std::setprecision(9);
+
+        for (const auto& row : g_RmgkPacingTraceRows)
+        {
+            file
+                << row.sequence << ','
+                << row.timestampUs << ','
+                << row.coreFrameBegin << ','
+                << row.coreFrameSwap << ','
+                << row.coreFrameEnd << ','
+                << row.framesAhead << ','
+                << row.targetScale << ','
+                << row.internalScale << ','
+                << row.clampedScale << ','
+                << row.pacingMode << ','
+                << row.sampleFrame << ','
+                << row.events << ','
+                << row.saves << ','
+                << row.loads << ','
+                << row.rollbackAdvances << ','
+                << row.runaheadAdvances << ','
+                << row.waitLoops << ','
+                << row.debugBeginUs << ','
+                << row.beginTotalUs << ','
+                << row.networkPollUs << ','
+                << row.pacingCalcUs << ','
+                << row.submitInputUs << ','
+                << row.updateSessionUs << ','
+                << row.latchInputUs << ','
+                << row.saveTotalUs << ','
+                << row.loadTotalUs << ','
+                << row.resimTotalUs << ','
+                << row.resimMaxUs << ','
+                << row.waitTotalUs << ','
+                << row.waitMaxUs << ','
+                << row.presentPacerActive << ','
+                << row.presentPacerFirstFrame << ','
+                << row.presentPacerDeadlineMiss << ','
+                << row.presentPacerScale << ','
+                << row.presentPacerPeriodUs << ','
+                << row.presentIntervalBeforeWaitUs << ','
+                << row.presentWaitRequestedUs << ','
+                << row.presentWaitActualUs << ','
+                << row.presentLateUs << ','
+                << row.presentIntervalAfterWaitUs << ','
+                << row.swapUs << ','
+                << row.makeCurrentUs << ','
+                << row.swapPath << ','
+                << row.endTotalUs << ','
+                << row.pendingSaveUs << ','
+                << row.debugEndUs
+                << '\n';
+        }
+    }
+
+    g_RmgkPacingTraceRows.clear();
+}
+
+void rmgk_pacing_trace_reset()
+{
+    g_RmgkPacingTraceRows.clear();
+    g_RmgkPacingTraceActiveRow =
+        kRmgkPacingTraceInvalidRow;
+
+    const char* env = std::getenv("RMGK_PACING_TRACE");
+    g_RmgkPacingTraceEnabled =
+        env != nullptr &&
+        env[0] != '\0' &&
+        std::strcmp(env, "0") != 0;
+
+    if (g_RmgkPacingTraceEnabled)
+    {
+        g_RmgkPacingTraceRows.reserve(
+            kRmgkPacingTraceCapacity);
+    }
+
+    g_RmgkTraceFramesAhead = 0.0f;
+    g_RmgkTraceTargetScale = 1.0;
+    g_RmgkTraceInternalScale = 1.0;
+    g_RmgkTraceClampedScale = 1.0;
+    g_RmgkTracePacingMode = 0;
+    g_RmgkTraceSampleFrame = 0;
+}
+
+void rmgk_pacing_trace_begin_frame(
+    int events,
+    int saves,
+    int loads,
+    int rollbackAdvances,
+    int runaheadAdvances,
+    int waitLoops,
+    long long debugBeginUs,
+    long long beginTotalUs,
+    long long networkPollUs,
+    long long pacingCalcUs,
+    long long submitInputUs,
+    long long updateSessionUs,
+    long long latchInputUs,
+    long long saveTotalUs,
+    long long loadTotalUs,
+    long long resimTotalUs,
+    long long resimMaxUs,
+    long long waitTotalUs,
+    long long waitMaxUs)
+{
+    g_RmgkPacingTraceActiveRow =
+        kRmgkPacingTraceInvalidRow;
+
+    if (!g_RmgkPacingTraceEnabled ||
+        g_RmgkPacingTraceRows.size() >=
+            kRmgkPacingTraceCapacity)
+    {
+        return;
+    }
+
+    RmgkPacingTraceRow row;
+
+    row.sequence =
+        static_cast<std::uint64_t>(
+            g_RmgkPacingTraceRows.size());
+
+    row.timestampUs = rmgk_pacing_trace_now_us();
+    row.coreFrameBegin = CoreGetCurrentFrameCount();
+
+    row.framesAhead = g_RmgkTraceFramesAhead;
+    row.targetScale = g_RmgkTraceTargetScale;
+    row.internalScale = g_RmgkTraceInternalScale;
+    row.clampedScale = g_RmgkTraceClampedScale;
+    row.pacingMode = g_RmgkTracePacingMode;
+    row.sampleFrame = g_RmgkTraceSampleFrame;
+
+    row.events = events;
+    row.saves = saves;
+    row.loads = loads;
+    row.rollbackAdvances = rollbackAdvances;
+    row.runaheadAdvances = runaheadAdvances;
+    row.waitLoops = waitLoops;
+
+    row.debugBeginUs = debugBeginUs;
+    row.beginTotalUs = beginTotalUs;
+    row.networkPollUs = networkPollUs;
+    row.pacingCalcUs = pacingCalcUs;
+    row.submitInputUs = submitInputUs;
+    row.updateSessionUs = updateSessionUs;
+    row.latchInputUs = latchInputUs;
+    row.saveTotalUs = saveTotalUs;
+    row.loadTotalUs = loadTotalUs;
+    row.resimTotalUs = resimTotalUs;
+    row.resimMaxUs = resimMaxUs;
+    row.waitTotalUs = waitTotalUs;
+    row.waitMaxUs = waitMaxUs;
+
+    g_RmgkPacingTraceRows.push_back(row);
+    g_RmgkPacingTraceActiveRow =
+        g_RmgkPacingTraceRows.size() - 1;
+}
+
+void rmgk_pacing_trace_end_frame(
+    long long endTotalUs,
+    long long pendingSaveUs,
+    long long debugEndUs)
+{
+    if (!g_RmgkPacingTraceEnabled ||
+        g_RmgkPacingTraceActiveRow ==
+            kRmgkPacingTraceInvalidRow ||
+        g_RmgkPacingTraceActiveRow >=
+            g_RmgkPacingTraceRows.size())
+    {
+        return;
+    }
+
+    auto& row =
+        g_RmgkPacingTraceRows[
+            g_RmgkPacingTraceActiveRow];
+
+    row.coreFrameEnd = CoreGetCurrentFrameCount();
+    row.endTotalUs = endTotalUs;
+    row.pendingSaveUs = pendingSaveUs;
+    row.debugEndUs = debugEndUs;
+
+    g_RmgkPacingTraceActiveRow =
+        kRmgkPacingTraceInvalidRow;
+}
+
 // --- Spectate keyframe capture-and-hold (broadcaster side) ---
 // The UI requests a keyframe; we snapshot the live frame's state, then HOLD it until
 // the recording confirms that frame (flushes it to the krec, past the rollback
@@ -335,7 +736,10 @@ std::filesystem::path get_gekko_log_path()
 
 void reset_gekko_log()
 {
+    rmgk_pacing_trace_flush();
     reset_rollback_log_session();
+    rmgk_pacing_trace_reset();
+    reset_rollback_present_pacer();
 
     const char* logEnv = std::getenv("RMGK_GEKKO_LOG");
     g_GekkoLogEnabled = CoreSettingsGetBoolValue(SettingsID::Rollback_VerboseStats) ||
@@ -1028,6 +1432,15 @@ void apply_gekko_frame_pacing()
     g_GekkoSpeedScale += (g_GekkoTimesyncTargetScale - g_GekkoSpeedScale) * lerp;
     CoreRollbackSetTimesyncScale(g_GekkoSpeedScale);
 
+    g_RmgkTraceFramesAhead = framesAhead;
+    g_RmgkTraceTargetScale = g_GekkoTimesyncTargetScale;
+    g_RmgkTraceInternalScale = g_GekkoSpeedScale;
+    g_RmgkTraceClampedScale =
+        std::clamp(g_GekkoSpeedScale, 0.99, 1.01);
+    g_RmgkTracePacingMode =
+        static_cast<int>(g_GekkoPacingMode);
+    g_RmgkTraceSampleFrame = isSampleFrame ? 1 : 0;
+
     g_GekkoPacingLogFrames++;
     if (g_GekkoLogEnabled &&
         (g_GekkoTimesyncTargetScale != 1.0 || g_GekkoPacingLogFrames <= 10 || (g_GekkoPacingLogFrames % 60) == 0))
@@ -1098,6 +1511,8 @@ int rollback_execute_begin_frame(void* userData)
     long long summaryLoadUs = 0;
     long long summaryResimUs = 0;
     long long summaryMaxResimUs = 0;
+    long long summaryWaitUs = 0;
+    long long summaryMaxWaitUs = 0;
     long long summaryDebugBeginUs = 0;
 
     if (g_GekkoSession == nullptr)
@@ -1514,12 +1929,51 @@ int rollback_execute_begin_frame(void* userData)
                     write_gekko_log(stream.str());
                 }
             }
+            const auto traceBeginTotalUs =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - beginTime).count();
+
+            rmgk_pacing_trace_begin_frame(
+                summaryEventCount,
+                summarySaveCount,
+                summaryLoadCount,
+                summaryRollbackAdvanceCount,
+                summaryRunaheadAdvanceCount,
+                summaryWaitLoops,
+                summaryDebugBeginUs,
+                traceBeginTotalUs,
+                summaryNetworkPollUs,
+                summaryPacingUs,
+                summarySubmitInputUs,
+                summaryUpdateSessionUs,
+                summaryLatchInputUs,
+                summarySaveUs,
+                summaryLoadUs,
+                summaryResimUs,
+                summaryMaxResimUs,
+                summaryWaitUs,
+                summaryMaxWaitUs);
+
             write_gekko_log("begin_frame result=real_frame");
             return 1;
         }
 
         //std::this_thread::sleep_for(std::chrono::microseconds(kGekkoWaitSleepUs)); // Not accurate enough in windows
-		rmgk::timing::PreciseWaitFor(std::chrono::microseconds{kGekkoWaitSleepUs}, std::chrono::microseconds{kGekkoWaitSleepUs});
+        const auto traceWaitBegin =
+            std::chrono::steady_clock::now();
+
+        rmgk::timing::PreciseWaitFor(
+            std::chrono::microseconds{kGekkoWaitSleepUs},
+            std::chrono::microseconds{kGekkoWaitSleepUs});
+
+        const long long traceWaitUs =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() -
+                traceWaitBegin).count();
+
+        summaryWaitUs += traceWaitUs;
+        summaryMaxWaitUs =
+            std::max(summaryMaxWaitUs, traceWaitUs);
     }
 }
 
@@ -1551,6 +2005,16 @@ int rollback_execute_end_frame(void* userData)
                 std::chrono::steady_clock::now() - debugEndBeginTime).count();
     }
     g_GekkoHasLatchedInput = false;
+
+    const auto traceEndTotalUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - beginTime).count();
+
+    rmgk_pacing_trace_end_frame(
+        traceEndTotalUs,
+        pendingSaveUs,
+        debugEndUs);
+
     if (g_GekkoLogEnabled)
     {
         const auto totalUs =
@@ -2067,6 +2531,7 @@ CORE_EXPORT bool rmgk_gekko::start_local_session(const char* gameName, int playe
 CORE_EXPORT void rmgk_gekko::close_session()
 {
 #ifdef RMGK_HAVE_GEKKONET
+    rmgk_pacing_trace_flush();
     g_GekkoStopRequested.store(false, std::memory_order_relaxed);
     clear_core_input_callback();
     if (g_GekkoSession != nullptr)
@@ -2174,6 +2639,207 @@ CORE_EXPORT bool rmgk_gekko::is_netplay_session_active()
 #endif
 }
 
+
+CORE_EXPORT void rmgk_gekko::pace_before_swap()
+{
+#ifdef RMGK_HAVE_GEKKONET
+    if (!g_RollbackPresentPacerEnabled ||
+        g_GekkoSession == nullptr ||
+        !g_GekkoExecuting.load(std::memory_order_relaxed))
+    {
+        return;
+    }
+
+    /*
+     * The core publishes the exact nominal VI rate before the first bypassed
+     * visible-frame limiter call. An explicit environment override wins.
+     */
+    if (!g_RollbackPresentBaseHzOverridden)
+    {
+        const char* effectiveHzEnv =
+            std::getenv(
+                "RMGK_ROLLBACK_PRESENT_HZ_EFFECTIVE");
+
+        if (effectiveHzEnv != nullptr &&
+            effectiveHzEnv[0] != '\0')
+        {
+            char* end = nullptr;
+            const double value =
+                std::strtod(effectiveHzEnv, &end);
+
+            if (end != effectiveHzEnv &&
+                value >= 30.0 &&
+                value <= 240.0)
+            {
+                g_RollbackPresentBaseHz = value;
+            }
+        }
+    }
+
+    const double scale =
+        std::clamp(g_GekkoSpeedScale, 0.99, 1.01);
+
+    const double periodUs =
+        1000000.0 /
+        (g_RollbackPresentBaseHz * scale);
+
+    auto now = std::chrono::steady_clock::now();
+
+    if (!g_RollbackPresentPacerInitialized)
+    {
+        g_RollbackPresentPacerInitialized = true;
+        g_RollbackPresentLastSwapTime = now;
+        g_RollbackPresentTargetTime = now;
+
+        record_rollback_present_pacing(
+            1,
+            1,
+            0,
+            scale,
+            periodUs,
+            0,
+            0,
+            0,
+            0,
+            0);
+        return;
+    }
+
+    const auto period =
+        std::chrono::duration_cast<
+            std::chrono::steady_clock::duration>(
+                std::chrono::duration<
+                    double,
+                    std::micro>(periodUs));
+
+    const auto deadline =
+        g_RollbackPresentTargetTime + period;
+
+    const long long intervalBeforeWaitUs =
+        std::chrono::duration_cast<
+            std::chrono::microseconds>(
+                now -
+                g_RollbackPresentLastSwapTime).count();
+
+    long long waitRequestedUs = 0;
+    long long waitActualUs = 0;
+    long long lateUs = 0;
+    int deadlineMiss = 0;
+
+    if (now < deadline)
+    {
+        const auto remainingNs =
+            std::chrono::duration_cast<
+                std::chrono::nanoseconds>(
+                    deadline - now).count();
+
+        /*
+         * Round upward so microsecond conversion never intentionally
+         * shortens the requested deadline.
+         */
+        waitRequestedUs =
+            (remainingNs + 999) / 1000;
+
+        const auto waitBegin =
+            std::chrono::steady_clock::now();
+
+        rmgk::timing::PreciseWaitFor(
+            std::chrono::microseconds{
+                waitRequestedUs},
+            std::chrono::microseconds{
+                std::min<long long>(
+                    waitRequestedUs,
+                    100)});
+
+        now = std::chrono::steady_clock::now();
+
+        waitActualUs =
+            std::chrono::duration_cast<
+                std::chrono::microseconds>(
+                    now - waitBegin).count();
+    }
+    else
+    {
+        deadlineMiss = 1;
+        lateUs =
+            std::chrono::duration_cast<
+                std::chrono::microseconds>(
+                    now - deadline).count();
+    }
+
+    const long long intervalAfterWaitUs =
+        std::chrono::duration_cast<
+            std::chrono::microseconds>(
+                now -
+                g_RollbackPresentLastSwapTime).count();
+
+    /*
+     * Advance from the scheduled deadline rather than the actual late wake.
+     * Normal wait overshoot is therefore removed from the next wait instead
+     * of being permanently added to every frame interval.
+     *
+     * A stall which leaves us at least one complete period behind is rebased
+     * to the current time. This prevents a long pause from causing a burst of
+     * immediate catch-up swaps while still preserving phase across ordinary
+     * sub-frame scheduler jitter.
+     */
+    if (now >= deadline + period)
+    {
+        g_RollbackPresentTargetTime = now;
+    }
+    else
+    {
+        g_RollbackPresentTargetTime = deadline;
+    }
+
+    g_RollbackPresentLastSwapTime = now;
+
+    record_rollback_present_pacing(
+        1,
+        0,
+        deadlineMiss,
+        scale,
+        periodUs,
+        intervalBeforeWaitUs,
+        waitRequestedUs,
+        waitActualUs,
+        lateUs,
+        intervalAfterWaitUs);
+#else
+    return;
+#endif
+}
+
+CORE_EXPORT void rmgk_gekko::trace_swap_duration(
+    long long swapUs,
+    long long makeCurrentUs,
+    int path)
+{
+#ifdef RMGK_HAVE_GEKKONET
+    if (!g_RmgkPacingTraceEnabled ||
+        g_RmgkPacingTraceActiveRow ==
+            kRmgkPacingTraceInvalidRow ||
+        g_RmgkPacingTraceActiveRow >=
+            g_RmgkPacingTraceRows.size())
+    {
+        return;
+    }
+
+    auto& row =
+        g_RmgkPacingTraceRows[
+            g_RmgkPacingTraceActiveRow];
+
+    row.coreFrameSwap = CoreGetCurrentFrameCount();
+    row.swapUs = swapUs;
+    row.makeCurrentUs = makeCurrentUs;
+    row.swapPath = path;
+#else
+    (void)swapUs;
+    (void)makeCurrentUs;
+    (void)path;
+#endif
+}
+
 CORE_EXPORT bool rmgk_gekko::execute()
 {
 #ifndef RMGK_HAVE_GEKKONET
@@ -2190,6 +2856,8 @@ CORE_EXPORT bool rmgk_gekko::execute()
     g_GekkoExecuting.store(true, std::memory_order_relaxed);
     bool result = CoreRollbackExecute(callbacks);
     g_GekkoExecuting.store(false, std::memory_order_relaxed);
+    rmgk_pacing_trace_flush();
+    g_RollbackPresentPacerInitialized = false;
     return result;
 #endif
 }

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -2639,7 +2639,7 @@ CORE_EXPORT bool rmgk_gekko::is_netplay_session_active()
 }
 
 
-CORE_EXPORT void rmgk_gekko::pace_before_swap()
+CORE_EXPORT void rmgk_gekko::pace_before_present()
 {
 #ifdef RMGK_HAVE_GEKKONET
     if (!g_RollbackPresentPacerEnabled ||
@@ -2839,6 +2839,12 @@ CORE_EXPORT void rmgk_gekko::trace_swap_duration(
 #endif
 }
 
+static void rollback_pace_before_present(void* userData)
+{
+    (void)userData;
+    rmgk_gekko::pace_before_present();
+}
+
 CORE_EXPORT bool rmgk_gekko::execute()
 {
 #ifndef RMGK_HAVE_GEKKONET
@@ -2852,6 +2858,7 @@ CORE_EXPORT bool rmgk_gekko::execute()
     m64p_rollback_execute_callbacks callbacks = {};
     callbacks.begin_frame = rollback_execute_begin_frame;
     callbacks.end_frame = rollback_execute_end_frame;
+    callbacks.pace_before_present = rollback_pace_before_present;
     callbacks.pacing_trace_enabled =
         g_RmgkPacingTraceEnabled ? 1 : 0;
     g_GekkoExecuting.store(true, std::memory_order_relaxed);

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -205,8 +205,9 @@ long long g_GekkoLastPendingSaveUs = 0;
 // ---------------------------------------------------------------------------
 // Buffered rollback pacing trace.
 //
-// Enabled with RMGK_PACING_TRACE=1. Rows remain in memory during gameplay and
-// are written only when rollback execution ends, avoiding per-frame disk I/O.
+// Enabled by Settings -> Rollback -> Logging -> Pacing Trace. Rows remain in
+// memory during gameplay and are written only when rollback execution ends,
+// avoiding per-frame disk I/O.
 // ---------------------------------------------------------------------------
 constexpr std::size_t kRmgkPacingTraceCapacity = 60000;
 constexpr std::size_t kRmgkPacingTraceInvalidRow =
@@ -483,11 +484,9 @@ void rmgk_pacing_trace_reset()
     g_RmgkPacingTraceActiveRow =
         kRmgkPacingTraceInvalidRow;
 
-    const char* env = std::getenv("RMGK_PACING_TRACE");
     g_RmgkPacingTraceEnabled =
-        env != nullptr &&
-        env[0] != '\0' &&
-        std::strcmp(env, "0") != 0;
+        CoreSettingsGetBoolValue(
+            SettingsID::Rollback_PacingTrace);
 
     if (g_RmgkPacingTraceEnabled)
     {
@@ -2853,6 +2852,8 @@ CORE_EXPORT bool rmgk_gekko::execute()
     m64p_rollback_execute_callbacks callbacks = {};
     callbacks.begin_frame = rollback_execute_begin_frame;
     callbacks.end_frame = rollback_execute_end_frame;
+    callbacks.pacing_trace_enabled =
+        g_RmgkPacingTraceEnabled ? 1 : 0;
     g_GekkoExecuting.store(true, std::memory_order_relaxed);
     bool result = CoreRollbackExecute(callbacks);
     g_GekkoExecuting.store(false, std::memory_order_relaxed);

--- a/Source/RMG-Core/rmgk_gekko.hpp
+++ b/Source/RMG-Core/rmgk_gekko.hpp
@@ -56,6 +56,13 @@ class rmgk_gekko
     static void request_disconnect_player(int slot);
     static bool is_netplay_session_active();
     static bool execute();
+    // Rollback presentation pacer. This waits immediately before the real
+    // OpenGL swap so rollback work consumes the frame's otherwise-idle time.
+    static void pace_before_swap();
+
+    // Buffered rollback-pacing trace hook used by VidExt.cpp.
+    // No-op unless RMGK_PACING_TRACE is enabled.
+    static void trace_swap_duration(long long swapUs, long long makeCurrentUs, int path);
     static bool set_deterministic(bool enabled);
     static bool install_core_input_callback();
     static void clear_core_input_callback();

--- a/Source/RMG-Core/rmgk_gekko.hpp
+++ b/Source/RMG-Core/rmgk_gekko.hpp
@@ -56,9 +56,9 @@ class rmgk_gekko
     static void request_disconnect_player(int slot);
     static bool is_netplay_session_active();
     static bool execute();
-    // Rollback presentation pacer. This waits immediately before the real
-    // OpenGL swap so rollback work consumes the frame's otherwise-idle time.
-    static void pace_before_swap();
+    // Rollback presentation pacer. The core invokes this through the video
+    // plugin rendering callback immediately before OpenGL or Vulkan presents.
+    static void pace_before_present();
 
     // Buffered rollback-pacing trace hook used by VidExt.cpp.
     // No-op unless Rollback -> Logging -> Pacing Trace is enabled.

--- a/Source/RMG-Core/rmgk_gekko.hpp
+++ b/Source/RMG-Core/rmgk_gekko.hpp
@@ -61,7 +61,7 @@ class rmgk_gekko
     static void pace_before_swap();
 
     // Buffered rollback-pacing trace hook used by VidExt.cpp.
-    // No-op unless RMGK_PACING_TRACE is enabled.
+    // No-op unless Rollback -> Logging -> Pacing Trace is enabled.
     static void trace_swap_duration(long long swapUs, long long makeCurrentUs, int path);
     static bool set_deterministic(bool enabled);
     static bool install_core_input_callback();

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -240,11 +240,16 @@ SettingsDialog::SettingsDialog(QWidget *parent, QString file) : QDialog(parent)
         "network stats so you can see which player's input stopped arriving. Writes nothing\n"
         "during smooth play, so the log stays tiny — unlike verbose stats, which writes every\n"
         "frame. Safe to leave on; one player logging is enough to identify the culprit.");
+    this->rollbackPacingTraceCheckBox = new QCheckBox("Enable pacing trace logging", rollbackLoggingGroupBox);
+    this->rollbackPacingTraceCheckBox->setToolTip(
+        "Writes detailed frontend and core pacing CSV logs when a rollback session ends.\n"
+        "Enable this only while diagnosing frame pacing; it is disabled by default.");
     this->rollbackVerbosePifInputLoggingCheckBox = new QCheckBox("Enable verbose PIF input logging", rollbackLoggingGroupBox);
     this->rollbackVerboseGlideInputLoggingCheckBox = new QCheckBox("Enable verbose Glide input logging", rollbackLoggingGroupBox);
     rollbackLayout->addWidget(this->rollbackEnableLocalTestingCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackVerboseStatsCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackStallDiagnosticsCheckBox);
+    rollbackLoggingLayout->addWidget(this->rollbackPacingTraceCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackVerbosePifInputLoggingCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackVerboseGlideInputLoggingCheckBox);
     rollbackLayout->addWidget(rollbackLoggingGroupBox);
@@ -986,6 +991,7 @@ void SettingsDialog::loadRollbackSettings(void)
 {
     this->rollbackVerboseStatsCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_VerboseStats));
     this->rollbackStallDiagnosticsCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_StallDiagnostics));
+    this->rollbackPacingTraceCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_PacingTrace));
     this->rollbackEnableLocalTestingCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_EnableLocalTesting));
     this->rollbackVerbosePifInputLoggingCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_VerbosePifInputLogging));
     this->rollbackVerboseGlideInputLoggingCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_VerboseGlideInputLogging));
@@ -1203,6 +1209,7 @@ void SettingsDialog::loadDefaultRollbackSettings(void)
 {
     this->rollbackVerboseStatsCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_VerboseStats));
     this->rollbackStallDiagnosticsCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_StallDiagnostics));
+    this->rollbackPacingTraceCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_PacingTrace));
     this->rollbackEnableLocalTestingCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_EnableLocalTesting));
     this->rollbackVerbosePifInputLoggingCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_VerbosePifInputLogging));
     this->rollbackVerboseGlideInputLoggingCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_VerboseGlideInputLogging));
@@ -1478,6 +1485,7 @@ void SettingsDialog::saveRollbackSettings(void)
 {
     CoreSettingsSetValue(SettingsID::Rollback_VerboseStats, this->rollbackVerboseStatsCheckBox->isChecked());
     CoreSettingsSetValue(SettingsID::Rollback_StallDiagnostics, this->rollbackStallDiagnosticsCheckBox->isChecked());
+    CoreSettingsSetValue(SettingsID::Rollback_PacingTrace, this->rollbackPacingTraceCheckBox->isChecked());
     CoreSettingsSetValue(SettingsID::Rollback_EnableLocalTesting, this->rollbackEnableLocalTestingCheckBox->isChecked());
     CoreSettingsSetValue(SettingsID::Rollback_VerbosePifInputLogging, this->rollbackVerbosePifInputLoggingCheckBox->isChecked());
     CoreSettingsSetValue(SettingsID::Rollback_VerboseGlideInputLogging, this->rollbackVerboseGlideInputLoggingCheckBox->isChecked());

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
@@ -70,6 +70,7 @@ class SettingsDialog : public QDialog, private Ui::SettingsDialog
     QColor currentTextColor;
     QCheckBox* rollbackVerboseStatsCheckBox = nullptr;
     QCheckBox* rollbackStallDiagnosticsCheckBox = nullptr;
+    QCheckBox* rollbackPacingTraceCheckBox = nullptr;
     QCheckBox* rollbackEnableLocalTestingCheckBox = nullptr;
     QCheckBox* rollbackVerbosePifInputLoggingCheckBox = nullptr;
     QCheckBox* rollbackVerboseGlideInputLoggingCheckBox = nullptr;

--- a/Source/RMG/VidExt.cpp
+++ b/Source/RMG/VidExt.cpp
@@ -14,6 +14,7 @@
 #include <RMG-Core/Kaillera.hpp>
 #include <RMG-Core/Netplay.hpp>
 #include <RMG-Core/Settings.hpp>
+#include <RMG-Core/rmgk_gekko.hpp>
 #include <RMG-Core/VidExt.hpp>
 #include <RMG-Core/Video.hpp>
 
@@ -26,6 +27,8 @@
 #include <QByteArray>
 #include <QThread>
 #include <QScreen>
+
+#include <chrono>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -957,7 +960,29 @@ static m64p_error VidExt_GLSwapBuf(void)
     if (VidExt_NativeWglActive())
     {
         VidExt_NativeWglPollEvents();
+
+        /*
+         * Rollback-only presentation pacing happens after emulation,
+         * rollback resimulation, rendering, and OSD work, immediately
+         * before the real swap.
+         */
+        rmgk_gekko::pace_before_swap();
+
+        const auto swapBegin =
+            std::chrono::steady_clock::now();
+
         SwapBuffers(l_NativeWgl.hdc);
+
+        const auto swapUs =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() -
+                swapBegin).count();
+
+        rmgk_gekko::trace_swap_duration(
+            swapUs,
+            0,
+            1);
+
         return M64ERR_SUCCESS;
     }
 #endif
@@ -965,8 +990,39 @@ static m64p_error VidExt_GLSwapBuf(void)
     VidExt_UpdateOsdDisplaySize();
     OnScreenDisplayRender();
 
-    (*l_OGLWidget)->GetContext()->swapBuffers((*l_OGLWidget));
-    (*l_OGLWidget)->GetContext()->makeCurrent((*l_OGLWidget));
+    /*
+     * Rollback-only presentation pacing happens after all frame work,
+     * immediately before the real swap.
+     */
+    rmgk_gekko::pace_before_swap();
+
+    const auto swapBegin =
+        std::chrono::steady_clock::now();
+
+    (*l_OGLWidget)->GetContext()->swapBuffers(
+        (*l_OGLWidget));
+
+    const auto swapEnd =
+        std::chrono::steady_clock::now();
+
+    (*l_OGLWidget)->GetContext()->makeCurrent(
+        (*l_OGLWidget));
+
+    const auto makeCurrentEnd =
+        std::chrono::steady_clock::now();
+
+    const auto swapUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            swapEnd - swapBegin).count();
+
+    const auto makeCurrentUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            makeCurrentEnd - swapEnd).count();
+
+    rmgk_gekko::trace_swap_duration(
+        swapUs,
+        makeCurrentUs,
+        2);
 
     return M64ERR_SUCCESS;
 }

--- a/Source/RMG/VidExt.cpp
+++ b/Source/RMG/VidExt.cpp
@@ -961,13 +961,6 @@ static m64p_error VidExt_GLSwapBuf(void)
     {
         VidExt_NativeWglPollEvents();
 
-        /*
-         * Rollback-only presentation pacing happens after emulation,
-         * rollback resimulation, rendering, and OSD work, immediately
-         * before the real swap.
-         */
-        rmgk_gekko::pace_before_swap();
-
         const auto swapBegin =
             std::chrono::steady_clock::now();
 
@@ -989,12 +982,6 @@ static m64p_error VidExt_GLSwapBuf(void)
 
     VidExt_UpdateOsdDisplaySize();
     OnScreenDisplayRender();
-
-    /*
-     * Rollback-only presentation pacing happens after all frame work,
-     * immediately before the real swap.
-     */
-    rmgk_gekko::pace_before_swap();
 
     const auto swapBegin =
         std::chrono::steady_clock::now();

--- a/Source/n02/core/p2p_core.cpp
+++ b/Source/n02/core/p2p_core.cpp
@@ -170,7 +170,7 @@ void p2p_rollback_transport_clear(){
 //===========================================================
 //===========================================================
 DWORD p2p_initial_time;
-#define ADJUST_RATIO_T 1/30
+#define ADJUST_RATIO_T 1/30.f
 void p2p_InitializeTime(){
 	p2p_initial_time = GetTickCount();
 }


### PR DESCRIPTION
The changes are as follows:

- Resolved an integer division bug in old-style p2p
- Switched to a more accurate timer in one code path
- Significantly improved frame pacing during rollbacks. Previously might be 24ms-->8ms. Now should be 16.7ms->16.7ms.

Note: Linux has not yet been been properly tested.
I'd prefer a "squash and merge" but it's up to you. I'm embarrassed that my commit says "weights" instead of "waits"