### PR TITLE
Lobby: fix pre-match sync failures via ping-proven routes; stop cross-internet LAN probing

### DIFF
--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -1467,7 +1467,23 @@ void LobbyClient::resolvePeerEndpoints(QList<LobbyMatchPeer>& peers)
         if (peer.userId == m_selfUserId)
             continue;
 
-        const QList<UdpEndpointCandidate> candidates = peerEndpointCandidates(local, peer);
+        QList<UdpEndpointCandidate> candidates = peerEndpointCandidates(local, peer);
+
+        // The lobby ping engine has often already proven a working route to
+        // this peer (learned from inbound probe sources and successful
+        // replies). The server-advertised endpoint can be useless for
+        // peer-to-peer traffic (symmetric NAT, CGNAT) even while seat pings
+        // are green, so race the proven route too. No TTL check: a stale
+        // candidate only costs a few probe packets, and the cache is cleared
+        // when the peer disconnects.
+        const auto learnedIt = m_recentInboundPingEndpoints.constFind(peer.userId);
+        if (learnedIt != m_recentInboundPingEndpoints.constEnd())
+        {
+            UdpEndpointCandidate learned;
+            if (parseEndpointString(learnedIt->endpoint, learned, QStringLiteral("ping-learned")))
+                appendEndpointCandidate(candidates, learned.address.toString(), learned.port, learned.kind);
+        }
+
         if (candidates.isEmpty())
             continue;
 
@@ -1713,6 +1729,17 @@ void LobbyClient::punchPeerEndpoints(const QList<LobbyMatchPeer>& peers)
             appendEndpointCandidate(candidates, p.publicIp, p.publicPort, QStringLiteral("public"));
         }
 
+        // Also punch the route the ping engine proved works. Sending to it
+        // opens our NAT mapping/filter toward the peer's real source endpoint,
+        // which the advertised anchor endpoint may not match.
+        const auto learnedIt = m_recentInboundPingEndpoints.constFind(p.userId);
+        if (learnedIt != m_recentInboundPingEndpoints.constEnd())
+        {
+            UdpEndpointCandidate learned;
+            if (parseEndpointString(learnedIt->endpoint, learned, QStringLiteral("ping-learned")))
+                appendEndpointCandidate(candidates, learned.address.toString(), learned.port, learned.kind);
+        }
+
         if (candidates.isEmpty())
         {
             qWarning() << "Rollback lobby punch skipped peer"
@@ -1794,13 +1821,23 @@ bool LobbyClient::syncPrematchManifest(QList<LobbyMatchPeer>& peers, int localSl
         appendEndpointCandidate(endpoints, peer.selectedIp, peer.selectedPort,
                                 peer.selectedKind.isEmpty() ? QStringLiteral("selected") : peer.selectedKind);
 
-        // If the endpoint race did not receive a reply, continue racing during
-        // pre-match sync instead of committing to an unverified fallback.
-        if (!peer.selectedEndpointVerified)
+        // Keep the advertised candidates in play even after a verified
+        // lock-on. A verified route can still be transient or die mid-sync,
+        // and the receiver already handles duplicate manifests/ACKs, so the
+        // extra datagrams are cheap insurance.
+        const auto advertised = peerEndpointCandidates(local, peer);
+        for (const auto& candidate : advertised)
+            appendEndpointCandidate(endpoints, candidate.address.toString(), candidate.port, candidate.kind);
+
+        // And the route the lobby ping engine proved works — the advertised
+        // anchor endpoint can be dead for peer-to-peer traffic (symmetric
+        // NAT, CGNAT) even while seat pings are green.
+        const auto learnedIt = m_recentInboundPingEndpoints.constFind(peer.userId);
+        if (learnedIt != m_recentInboundPingEndpoints.constEnd())
         {
-            const auto advertised = peerEndpointCandidates(local, peer);
-            for (const auto& candidate : advertised)
-                appendEndpointCandidate(endpoints, candidate.address.toString(), candidate.port, candidate.kind);
+            UdpEndpointCandidate learned;
+            if (parseEndpointString(learnedIt->endpoint, learned, QStringLiteral("ping-learned")))
+                appendEndpointCandidate(endpoints, learned.address.toString(), learned.port, learned.kind);
         }
         return endpoints;
     };

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -327,8 +327,38 @@ namespace
     }
 
 
-    QString detectLocalIPv4()
+    bool isPrivateIPv4(const QHostAddress& address)
     {
+        if (address.protocol() != QAbstractSocket::IPv4Protocol || address.isLoopback())
+            return false;
+
+        const quint32 ipv4 = address.toIPv4Address();
+        return ((ipv4 & 0xff000000u) == 0x0a000000u) ||
+               ((ipv4 & 0xfff00000u) == 0xac100000u) ||
+               ((ipv4 & 0xffff0000u) == 0xc0a80000u);
+    }
+
+    QString detectLocalIPv4(const QString& routeProbeHost)
+    {
+        // Ask the OS routing table which source address real traffic toward
+        // the lobby server will use: connect() a UDP socket (no packet is
+        // sent) and read back the chosen source. Interface enumeration order
+        // is arbitrary, and VPN/overlay adapters carrying their own 10.x
+        // address can shadow the actual LAN IP (seen in the field as a
+        // detected_local_ip that belonged to no physical adapter).
+        {
+            QHostAddress target(routeProbeHost);
+            if (target.isNull() || target.protocol() != QAbstractSocket::IPv4Protocol)
+                target = QHostAddress(QStringLiteral("8.8.8.8"));
+
+            QUdpSocket probe;
+            probe.connectToHost(target, 53);
+            if (isPrivateIPv4(probe.localAddress()))
+                return probe.localAddress().toString();
+        }
+
+        // Fallback: first private address on any up interface (pre-existing
+        // behavior), for hosts where the route probe yields nothing usable.
         for (const QNetworkInterface& iface : QNetworkInterface::allInterfaces())
         {
             const auto flags = iface.flags();
@@ -341,20 +371,8 @@ namespace
 
             for (const QNetworkAddressEntry& entry : iface.addressEntries())
             {
-                const QHostAddress address = entry.ip();
-                if (address.protocol() != QAbstractSocket::IPv4Protocol ||
-                    address.isLoopback())
-                {
-                    continue;
-                }
-
-                const quint32 ipv4 = address.toIPv4Address();
-                const bool isPrivate =
-                    ((ipv4 & 0xff000000u) == 0x0a000000u) ||
-                    ((ipv4 & 0xfff00000u) == 0xac100000u) ||
-                    ((ipv4 & 0xffff0000u) == 0xc0a80000u);
-                if (isPrivate)
-                    return address.toString();
+                if (isPrivateIPv4(entry.ip()))
+                    return entry.ip().toString();
             }
         }
 
@@ -517,7 +535,7 @@ void LobbyClient::connectToServer(const QString& wsUrl, const QString& username,
 
     m_pendingUsername  = username;
     m_pendingRomHashes = romHashes;
-    m_pendingLocalIp   = detectLocalIPv4();
+    m_pendingLocalIp   = detectLocalIPv4(QUrl(wsUrl).host());
     m_selfUserId       = 0;
     m_users.clear();
     m_rooms.clear();

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -1026,7 +1026,21 @@ void LobbyClient::handlePingProbeReply(const QJsonObject& data)
     // New servers provide both candidates. targetEndpoint remains first for
     // old-server compatibility, while duplicate endpoints are collapsed.
     appendParsed(targetEndpoint, QStringLiteral("target"));
-    appendParsed(localEndpoint, QStringLiteral("local"));
+
+    // Only probe the peer's LAN candidate when they share our public IP.
+    // Across the internet a private address is dead weight at best, and on
+    // 10.x institutional networks the packets actually route into OUR local
+    // network, where bursts at strangers' addresses can trip IDS port-scan
+    // heuristics. Genuine same-router pairs lose nothing: the server already
+    // promotes the LAN endpoint to targetEndpoint for them.
+    UdpEndpointCandidate peerPublic;
+    if (!m_observedIp.isEmpty() &&
+        parseEndpointString(publicEndpoint, peerPublic, QStringLiteral("public")) &&
+        peerPublic.address == QHostAddress(m_observedIp))
+    {
+        appendParsed(localEndpoint, QStringLiteral("local"));
+    }
+
     appendParsed(publicEndpoint, QStringLiteral("public"));
     if (candidates.isEmpty())
     {


### PR DESCRIPTION
## Problem

Since the v0.9.10 + server rollout, some pairs (e.g. Este + GG.) show a healthy seat ping but every match attempt fails pre-match sync on both sides ('Pre-match sync timed out — never heard from the host' / 'a player didn't respond').

Root cause: the ping engine finds working routes via learned inbound endpoints and reciprocal bursts, but the match-start path (endpoint race, NAT punch, pre-match manifest exchange) only ever used the server-advertised anchor endpoints — which can be dead for peer-to-peer traffic (symmetric NAT, CGNAT) even while pings are green. Additionally, once the race 'verified' a route, pre-match sync sent **only** there, dropping the advertised endpoints v0.9.9 used to hammer for the full window.

## Changes

1. **Use ping-proven routes for match start** — seed the endpoint race, NAT punch, and pre-match sync candidates with the peer's learned route from `m_recentInboundPingEndpoints` (kind `ping-learned`, visible in existing race/punch logs), and keep advertised candidates in play even after a verified lock-on.
2. **Only ping a peer's LAN candidate behind a shared public IP** — bursts were probing peers' private addresses across the internet (dead weight; on routed 10.x networks it can look like port scanning). Gating this also roughly halves total ping-burst traffic. Same-router pairs are unaffected: the server already promotes the LAN endpoint to `targetEndpoint`, which is always probed.

## Compatibility

Wire-compatible with stock v0.9.10 in either seat — no new packet types or formats, only different/additional destinations for existing packets, and duplicate manifests/ACKs are already handled by receivers. One-sided benefit applies whichever seat runs this build.

## Testing

Needs a build in the hands of an affected pair (Este + GG.). Success signature in logs: `endpoint race selected … kind "ping-learned"` or `prematch probe selected`, followed by 'Pre-match sync complete.'
