### PR TITLE
Lobby: use the RMG-K logo as the window icon

### DIFF
--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
@@ -19,6 +19,7 @@
 #include <QDialogButtonBox>
 #include <QSettings>
 #include <QFileInfo>
+#include <QIcon>
 
 using namespace UserInterface::Dialog;
 
@@ -28,6 +29,7 @@ CreateRoomDialog::CreateRoomDialog(const QString& defaultUsername, const QString
     : QDialog(parent)
 {
     setWindowTitle("Create Room");
+    setWindowIcon(QIcon(":Resource/RMG.png"));
     setModal(true);
     // The game comes from the lobby's shared picker, not a picker of our own.
     m_romName = gameName;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyConnectDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyConnectDialog.cpp
@@ -19,6 +19,7 @@
 #include <QSettings>
 #include <QDialogButtonBox>
 #include <QFont>
+#include <QIcon>
 
 using namespace UserInterface::Dialog;
 
@@ -45,6 +46,7 @@ LobbyConnectDialog::LobbyConnectDialog(QWidget* parent)
     : QDialog(parent)
 {
     setWindowTitle("Join Rollback Netplay");
+    setWindowIcon(QIcon(":Resource/RMG.png"));
     setModal(true);
     setMinimumWidth(380);
     buildUi();

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -348,6 +348,7 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
               | Qt::WindowCloseButtonHint)
 {
     setWindowTitle("RMG-K Lobby");
+    setWindowIcon(QIcon(":Resource/RMG.png"));
     setWindowModality(Qt::NonModal);
     resize(1180, 720);
     setObjectName("RollbackLobbyDialog");


### PR DESCRIPTION
The rollback lobby, Join, and Create Room dialogs had no window icon; give all three the same :Resource/RMG.png the app's other RMG-branded dialogs use.