### PR TITLE
Add Qt localization infrastructure and language selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y upgrade
           sudo apt-get -y install cmake libusb-1.0-0-dev libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libfreetype6-dev \
-            libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev libqt6websockets6-dev libvulkan-dev \
+            libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-tools-dev qt6-translations-l10n libqt6svg6-dev libqt6websockets6-dev libvulkan-dev \
             build-essential nasm git zip appstream xvfb qt6ct mesa-vulkan-drivers
 
           # sdl3 dependencies

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -50,6 +50,25 @@ fi
 
 cp "$bin_dir/usr/share/applications/com.github.Rosalie241.RMG.desktop" "$bin_dir"
 cp "$bin_dir/usr/share/icons/hicolor/scalable/apps/com.github.Rosalie241.RMG.svg" "$bin_dir"
+qtpaths="$(command -v qtpaths6 || true)"
+if [[ -z "$qtpaths" && -x /usr/lib/qt6/bin/qtpaths6 ]]
+then
+	qtpaths=/usr/lib/qt6/bin/qtpaths6
+fi
+if [[ -z "$qtpaths" ]]
+then
+	echo "qtpaths6 is required to locate qtbase_ja.qm" >&2
+	exit 1
+fi
+
+qtbase_translation="$($qtpaths --query QT_INSTALL_TRANSLATIONS)/qtbase_ja.qm"
+if [[ ! -f "$qtbase_translation" ]]
+then
+	echo "qtbase_ja.qm is required to build a Japanese-localized AppImage" >&2
+	exit 1
+fi
+mkdir -p "$bin_dir/usr/share/RMG/Translations"
+cp "$qtbase_translation" "$bin_dir/usr/share/RMG/Translations/"
 ln -s com.github.Rosalie241.RMG.svg "$bin_dir"/.DirIcon
 mv "$bin_dir/usr/share" "$bin_dir/share"
 mv "$bin_dir/usr" "$bin_dir/shared"

--- a/Source/RMG-Core/Settings.cpp
+++ b/Source/RMG-Core/Settings.cpp
@@ -188,6 +188,9 @@ static l_Setting get_setting(SettingsID settingId)
     case SettingsID::GUI_IconTheme:
         setting = {SETTING_SECTION_GUI, "IconTheme", std::string("Automatic")};
         break;
+    case SettingsID::GUI_Language:
+        setting = {SETTING_SECTION_GUI, "Language", std::string("system")};
+        break;
     case SettingsID::GUI_CheckForUpdates:
         setting = {SETTING_SECTION_GUI, "CheckForUpdates", true};
         break;

--- a/Source/RMG-Core/Settings.hpp
+++ b/Source/RMG-Core/Settings.hpp
@@ -47,6 +47,7 @@ enum class SettingsID
     GUI_StatusBar,
     GUI_Theme,
     GUI_IconTheme,
+    GUI_Language,
     GUI_CheckForUpdates,
     GUI_LastUpdateCheck,
     GUI_ConfirmExitWhileInGame,

--- a/Source/RMG/CMakeLists.txt
+++ b/Source/RMG/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 COMPONENTS Gui Widgets Core REQUIRED)
+find_package(Qt6 6.2 COMPONENTS Gui Widgets Core LinguistTools REQUIRED)
 
 if (NOT WIN32)
     find_package(Qt6 REQUIRED COMPONENTS DBus)
@@ -86,6 +86,7 @@ set(RMG_SOURCES
     Thread/EmulationThread.cpp
     Utilities/QtKeyToSdl3Key.cpp
     Utilities/QtMessageBox.cpp
+    Utilities/Translation.cpp
     OnScreenDisplay.cpp
     Callbacks.cpp
     VidExt.cpp
@@ -179,6 +180,26 @@ target_include_directories(RMG PRIVATE
 )
 
 target_link_libraries(RMG Qt6::Gui Qt6::Widgets ${HIDAPI_LIBRARIES})
+
+set(RMG_TRANSLATION_TS
+    ${CMAKE_CURRENT_SOURCE_DIR}/Translations/rmg_ja_JP.ts
+)
+qt_add_lupdate(RMG
+    TS_FILES ${RMG_TRANSLATION_TS}
+    SOURCES ${RMG_SOURCES} Utilities/Translation.hpp
+)
+qt_add_lrelease(RMG
+    TS_FILES ${RMG_TRANSLATION_TS}
+    QM_FILES_OUTPUT_VARIABLE RMG_TRANSLATION_QM_FILES
+)
+add_custom_command(TARGET RMG POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:RMG>/Data/Translations"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${RMG_TRANSLATION_QM_FILES}
+        "$<TARGET_FILE_DIR:RMG>/Data/Translations"
+)
+install(FILES ${RMG_TRANSLATION_QM_FILES}
+    DESTINATION ${DATA_INSTALL_PATH}/Translations
+)
 
 if (WIN32)
     target_link_libraries(RMG opengl32 gdi32 user32)

--- a/Source/RMG/Translations/rmg_ja_JP.ts
+++ b/Source/RMG/Translations/rmg_ja_JP.ts
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja_JP">
+    <context>
+        <name>SettingsDialog</name>
+        <message>
+            <source>Language</source>
+            <translation>言語</translation>
+        </message>
+        <message>
+            <source>System Default</source>
+            <translation>システムの既定</translation>
+        </message>
+        <message>
+            <source>English</source>
+            <translation>英語</translation>
+        </message>
+        <message>
+            <source>Japanese</source>
+            <translation>日本語</translation>
+        </message>
+        <message>
+            <source>Language changes take effect after restarting the application.</source>
+            <translation>言語の変更は、アプリケーションの再起動後に反映されます。</translation>
+        </message>
+    </context>
+</TS>

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -215,6 +215,10 @@ SettingsDialog::SettingsDialog(QWidget *parent, QString file) : QDialog(parent)
 {
     this->setupUi(this);
 
+    this->languageComboBox->setItemData(0, "system");
+    this->languageComboBox->setItemData(1, "en");
+    this->languageComboBox->setItemData(2, "ja_JP");
+
     connect(this->showLegacyThemesCheckBox, &QCheckBox::toggled, this, [this](bool checked)
     {
         const QString currentTheme = selectedThemeValue(this->themeComboBox);
@@ -869,6 +873,9 @@ void SettingsDialog::loadInterfaceGeneralSettings(void)
     this->showLegacyThemesCheckBox->blockSignals(blocked);
     populateThemeCombo(this->themeComboBox, themeOptions, showLegacy, currentTheme);
     this->iconThemeComboBox->setCurrentText(QString::fromStdString(CoreSettingsGetStringValue(SettingsID::GUI_IconTheme)));
+    const int languageIndex = this->languageComboBox->findData(
+        QString::fromStdString(CoreSettingsGetStringValue(SettingsID::GUI_Language)));
+    this->languageComboBox->setCurrentIndex(languageIndex >= 0 ? languageIndex : 0);
     this->autoStartNetplayOnStartupCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::GUI_AutoStartNetplayOnStartup));
 #ifdef UPDATER
     this->checkForUpdatesCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::GUI_CheckForUpdates));
@@ -1134,6 +1141,7 @@ void SettingsDialog::loadDefaultInterfaceGeneralSettings(void)
     this->showLegacyThemesCheckBox->blockSignals(blocked);
     populateThemeCombo(this->themeComboBox, themeOptions, showLegacy, defaultTheme);
     this->iconThemeComboBox->setCurrentText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::GUI_IconTheme)));
+    this->languageComboBox->setCurrentIndex(0);
     this->autoStartNetplayOnStartupCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::GUI_AutoStartNetplayOnStartup));
 #ifdef UPDATER
     this->checkForUpdatesCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::GUI_CheckForUpdates));
@@ -1418,6 +1426,7 @@ void SettingsDialog::saveInterfaceGeneralSettings(void)
 {
     CoreSettingsSetValue(SettingsID::GUI_Theme, selectedThemeValue(this->themeComboBox).toStdString());
     CoreSettingsSetValue(SettingsID::GUI_IconTheme, this->iconThemeComboBox->currentText().toStdString());
+    CoreSettingsSetValue(SettingsID::GUI_Language, this->languageComboBox->currentData().toString().toStdString());
     CoreSettingsSetValue(SettingsID::GUI_AutoStartNetplayOnStartup, this->autoStartNetplayOnStartupCheckBox->isChecked());
 #ifdef UPDATER
     CoreSettingsSetValue(SettingsID::GUI_CheckForUpdates, this->checkForUpdatesCheckBox->isChecked());

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
@@ -106,7 +106,47 @@
                    </item>
                   </widget>
                  </item>
+               </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="languageLayout">
+                 <item>
+                  <widget class="QLabel" name="languageLabel">
+                   <property name="text">
+                    <string>Language</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="languageComboBox">
+                   <item>
+                    <property name="text">
+                     <string>System Default</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>English</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Japanese</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
                 </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="languageRestartNoteLabel">
+                 <property name="text">
+                  <string>Language changes take effect after restarting the application.</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
                </item>
                <item>
                 <widget class="QCheckBox" name="checkForUpdatesCheckBox">

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -1598,12 +1598,6 @@ MainWindow::~MainWindow()
 
 bool MainWindow::Init(QApplication* app, bool showUI, bool launchROM)
 {
-    if (!CoreInit())
-    {
-        this->showErrorMessage("CoreInit() Failed", QString::fromStdString(CoreGetError()));
-        return false;
-    }
-
     if (!CoreApplyPluginSettings())
     {
         this->showErrorMessage("CoreApplyPluginSettings() Failed", QString::fromStdString(CoreGetError()));
@@ -1876,9 +1870,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
 #ifdef _WIN32
     this->restoreDisplayMode();
 #endif
-    CoreSettingsSave();
-    CoreShutdown();
-
     QMainWindow::closeEvent(event);
 }
 

--- a/Source/RMG/Utilities/Translation.cpp
+++ b/Source/RMG/Utilities/Translation.cpp
@@ -1,0 +1,99 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ *  Copyright (C) 2020-2025 Rosalie Wanders <rosalie@mailbox.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 3.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "Translation.hpp"
+
+#include <RMG-Core/Directories.hpp>
+#include <RMG-Core/Settings.hpp>
+
+#include <QApplication>
+#include <QDebug>
+#include <QLibraryInfo>
+#include <QLocale>
+#include <QTranslator>
+
+namespace
+{
+QString resolve_language()
+{
+    const QString configuredLanguage = QString::fromStdString(
+        CoreSettingsGetStringValue(SettingsID::GUI_Language));
+
+    if (configuredLanguage == "ja_JP" || configuredLanguage == "en")
+    {
+        return configuredLanguage;
+    }
+
+    if (configuredLanguage != "system")
+    {
+        qWarning("Unknown GUI language setting; falling back to English");
+        return "en";
+    }
+
+    for (const QString& language : QLocale::system().uiLanguages())
+    {
+        const QString normalizedLanguage = language.toLower().replace('_', '-');
+        if (normalizedLanguage == "ja" || normalizedLanguage.startsWith("ja-"))
+        {
+            return "ja_JP";
+        }
+    }
+
+    return "en";
+}
+
+QString application_translation_directory()
+{
+    QString directory = QString::fromStdString(CoreGetSharedDataDirectory().string());
+    directory += CORE_DIR_SEPERATOR_STR;
+    directory += "Translations";
+    return directory;
+}
+} // namespace
+
+namespace Translation
+{
+QString ResolvedLanguage(void)
+{
+    return resolve_language();
+}
+
+void Install(QApplication& application, QTranslator& qtTranslator, QTranslator& applicationTranslator)
+{
+    if (ResolvedLanguage() != "ja_JP")
+    {
+        return;
+    }
+
+    const QString translationDirectory = application_translation_directory();
+    const bool qtTranslationLoaded =
+        qtTranslator.load("qtbase_ja.qm", translationDirectory) ||
+        qtTranslator.load("qtbase_ja.qm", QLibraryInfo::path(QLibraryInfo::TranslationsPath));
+    const bool applicationTranslationLoaded =
+        applicationTranslator.load("rmg_ja_JP.qm", translationDirectory);
+
+    if (qtTranslationLoaded)
+    {
+        application.installTranslator(&qtTranslator);
+    }
+    else
+    {
+        qWarning("Failed to load Qt base translation");
+    }
+
+    if (applicationTranslationLoaded)
+    {
+        application.installTranslator(&applicationTranslator);
+    }
+    else
+    {
+        qWarning("Failed to load application translation; application strings will use English");
+    }
+}
+} // namespace Translation

--- a/Source/RMG/Utilities/Translation.hpp
+++ b/Source/RMG/Utilities/Translation.hpp
@@ -1,0 +1,23 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ *  Copyright (C) 2020-2025 Rosalie Wanders <rosalie@mailbox.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 3.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef RMG_UTILITIES_TRANSLATION_HPP
+#define RMG_UTILITIES_TRANSLATION_HPP
+
+class QApplication;
+class QString;
+class QTranslator;
+
+namespace Translation
+{
+QString ResolvedLanguage(void);
+void Install(QApplication& application, QTranslator& qtTranslator, QTranslator& applicationTranslator);
+}
+
+#endif // RMG_UTILITIES_TRANSLATION_HPP

--- a/Source/RMG/main.cpp
+++ b/Source/RMG/main.cpp
@@ -8,6 +8,7 @@
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 #include <UserInterface/MainWindow.hpp>
+#include <Utilities/Translation.hpp>
 #if defined(_WIN32) && defined(NETPLAY)
 #include <Utilities/KailleraExport/KrecMp4Export.hpp>
 #endif
@@ -16,6 +17,7 @@
 #include <QApplication>
 #include <QFile>
 #include <QDir>
+#include <QTranslator>
 
 #include <iostream>
 #include <cstdlib>
@@ -30,6 +32,9 @@
 #endif
 
 #include <RMG-Core/Directories.hpp>
+#include <RMG-Core/Core.hpp>
+#include <RMG-Core/Error.hpp>
+#include <RMG-Core/Settings.hpp>
 #include <RMG-Core/Version.hpp>
 
 //
@@ -302,38 +307,59 @@ int main(int argc, char **argv)
 #endif
     }
 
-    UserInterface::MainWindow window;
-
-    // print debug callbacks to stdout if needed
-    CoreSetPrintDebugCallback(parser.isSet(debugMessagesOption));
-
-    // specified ROM path to launch
-    QStringList args = parser.positionalArguments();
-
-    CoreAddCallbackMessage(CoreDebugMessageType::Info, 
-            "Initializing on " + QGuiApplication::platformName().toStdString());
-
-    // initialize window
-    if (!window.Init(&app, !parser.isSet(noGuiOption), !args.empty()))
+    if (!CoreInit())
     {
+        std::cerr << "CoreInit() Failed: " << CoreGetError() << std::endl;
         return 1;
     }
 
-    if (!args.empty())
-    {
-        bool parsedNumber = false;
-        int saveStateSlot = parser.value(loadStateSlot).toInt(&parsedNumber);
-        if (parser.value(loadStateSlot).isEmpty() || !parsedNumber ||
-            saveStateSlot < 0 || saveStateSlot > 9)
-        {
-            saveStateSlot = -1;
-        }
+    QTranslator qtTranslator;
+    QTranslator applicationTranslator;
+    Translation::Install(app, qtTranslator, applicationTranslator);
 
-        window.OpenROM(args.at(0), parser.value(diskOption), parser.isSet(fullscreenOption), parser.isSet(quitAfterEmulationOption), saveStateSlot);
+    int exitCode = 1;
+    bool windowInitialized = false;
+    {
+        UserInterface::MainWindow window;
+
+        // print debug callbacks to stdout if needed
+        CoreSetPrintDebugCallback(parser.isSet(debugMessagesOption));
+
+        // specified ROM path to launch
+        QStringList args = parser.positionalArguments();
+
+        CoreAddCallbackMessage(CoreDebugMessageType::Info,
+                "Initializing on " + QGuiApplication::platformName().toStdString());
+
+        // initialize window
+        if (window.Init(&app, !parser.isSet(noGuiOption), !args.empty()))
+        {
+            windowInitialized = true;
+
+            if (!args.empty())
+            {
+                bool parsedNumber = false;
+                int saveStateSlot = parser.value(loadStateSlot).toInt(&parsedNumber);
+                if (parser.value(loadStateSlot).isEmpty() || !parsedNumber ||
+                    saveStateSlot < 0 || saveStateSlot > 9)
+                {
+                    saveStateSlot = -1;
+                }
+
+                window.OpenROM(args.at(0), parser.value(diskOption), parser.isSet(fullscreenOption), parser.isSet(quitAfterEmulationOption), saveStateSlot);
+            }
+
+            // show window
+            window.show();
+
+            exitCode = app.exec();
+        }
     }
 
-    // show window
-    window.show();
-
-    return app.exec();
+    if (windowInitialized)
+    {
+        CoreSettingsSave();
+    }
+    CoreShutdown();
+    return exitCode;
 }

--- a/Source/Script/BundleDependencies.sh
+++ b/Source/Script/BundleDependencies.sh
@@ -38,6 +38,35 @@ done
 "$path/windeployqt6" --exclude-plugins qpdf,qwebp,qgif,qtga,qtuiotouchplugin,qglib,qtiff,qmng,qwbmp \
 				--no-translations "$exe"
 
+qtpaths=""
+if command -v qtpaths6 >/dev/null 2>&1
+then
+    qtpaths="$(command -v qtpaths6)"
+elif command -v qtpaths >/dev/null 2>&1
+then
+    qtpaths="$(command -v qtpaths)"
+elif [ -x "$path/qtpaths6" ]
+then
+    qtpaths="$path/qtpaths6"
+fi
+
+if [ -z "$qtpaths" ]
+then
+    echo "ERROR: Could not find qtpaths6 or qtpaths; cannot bundle qtbase_ja.qm." >&2
+    exit 1
+fi
+
+qt_translations_dir="$("$qtpaths" --query QT_INSTALL_TRANSLATIONS)"
+qtbase_translation="$qt_translations_dir/qtbase_ja.qm"
+if [ ! -f "$qtbase_translation" ]
+then
+    echo "ERROR: qtbase_ja.qm was not found in $qt_translations_dir." >&2
+    exit 1
+fi
+
+mkdir -p "$bin_dir/Data/Translations"
+cp "$qtbase_translation" "$bin_dir/Data/Translations/qtbase_ja.qm"
+
 # remove D3Dcompiler_47.dll - causes conflicts with Discord overlay injection
 # RMG-K uses OpenGL exclusively; Windows system copy is used if ever needed
 rm -f "$bin_dir/D3Dcompiler_47.dll"


### PR DESCRIPTION
## Summary

Add a small, generic Qt localization foundation for RMG-K.

## Motivation

RMG-K currently has no application-level language selection or translation loading path. This change provides the infrastructure needed to add UI translations incrementally without changing unsupported locales away from English.

## What changed

- Add a persisted GUI language setting using `system`, `en`, and locale IDs.
- Add a language selector under Settings > Interface > General.
- Add Qt LinguistTools integration to build and install application translation catalogs.
- Load both the application catalog and Qt base catalog before the main window is created.
- Keep translator objects alive for the lifetime of the application event loop.
- Bundle the Japanese Qt base catalog for Windows portable builds and AppImage packaging.
- Include only a minimal Japanese bootstrap catalog for the language selector itself.

## Behavior

The default setting follows the system locale. Japanese system locales currently resolve to `ja_JP`; unsupported locales fall back to English.

Missing application or Qt translation catalogs do not prevent startup. Application strings fall back to English when the RMG-K catalog is unavailable, while Qt base translations are loaded independently when available.

Language changes take effect after restarting the application.

## Validation

Validated on Windows 11 with MSYS2 UCRT64:

- Release configure/build/install/bundle completed successfully.
- `rmg_ja_JP.qm` and `qtbase_ja.qm` were generated/deployed in the portable runtime.
- `System Default`, `English`, and `Japanese` language selection were verified after restart.
- The selected language persisted across restarts.
- Removing only `rmg_ja_JP.qm` produced a safe English application fallback while Qt base translations remained available.
- `git diff --check` and translation catalog validation passed.

## Scope / non-goals

This PR adds localization infrastructure and the minimum Japanese strings needed to exercise the language selector and translation loading path. It does not add broad UI translations.

It also does not change branding, release/update routing, Kaillera protocol handling, chat encoding, or other netplay behavior.

Kaillera CP932 handling is independent from this work and remains covered separately by #156.

## Follow-up

Follow-up PRs can mark existing UI strings as translation-ready and then expand language catalogs in focused areas such as the core UI, netplay UI, and updater UI.