### PR TITLE
Lobby: shared anchor socket transport, ping overhaul, and player-list redesign

### DIFF
--- a/Source/RMG-Core/Settings.cpp
+++ b/Source/RMG-Core/Settings.cpp
@@ -359,6 +359,9 @@ static l_Setting get_setting(SettingsID settingId)
     case SettingsID::Rollback_PingDiagnostics:
         setting = {SETTING_SECTION_ROLLBACK, "PingDiagnostics", false};
         break;
+    case SettingsID::Rollback_HideLocation:
+        setting = {SETTING_SECTION_ROLLBACK, "HideLocation", false};
+        break;
     case SettingsID::Rollback_PacingTrace:
         setting = {SETTING_SECTION_ROLLBACK, "PacingTrace", false};
         break;

--- a/Source/RMG-Core/Settings.hpp
+++ b/Source/RMG-Core/Settings.hpp
@@ -111,6 +111,7 @@ enum class SettingsID
     Rollback_PacingTrace,
     Rollback_PacingMode,
     Rollback_PingDiagnostics,
+    Rollback_HideLocation,
 
     // Core Plugin Settings
     Core_GFX_Plugin,

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -7,6 +7,19 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+// winsock2.h must precede any windows.h (pulled in by later headers), or the
+// legacy winsock.h it would otherwise drag in conflicts with these APIs.
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <cerrno>
+#include <unistd.h>
+#endif
+
 #define CORE_INTERNAL
 #include "rmgk_gekko.hpp"
 
@@ -910,6 +923,133 @@ GekkoNetAdapter g_GekkoP2PAdapter{
     p2p_adapter_free
 };
 #endif
+
+// ── n02-style shared transport ───────────────────────────────────────
+// The lobby's anchor socket, adopted for the duration of a lobby session so
+// the port and its NAT mappings never change hands (n02 keeps one k_socket
+// alive for lobby and game alike; this is that model). The descriptor is
+// borrowed from Qt on the UI thread and used for sendto/recvfrom here on the
+// emulation thread — concurrent use of one UDP socket from two threads is
+// well-defined, and the lobby side stops *reading* while a session runs so
+// datagrams are never stolen from GekkoNet (the same reader-discipline n02
+// uses between p2p_step and p2p_modify_play_values).
+#ifdef _WIN32
+using ExtSocket = SOCKET;
+constexpr ExtSocket kExtSocketNone = INVALID_SOCKET;
+#else
+using ExtSocket = int;
+constexpr ExtSocket kExtSocketNone = -1;
+#endif
+static std::atomic<ExtSocket> g_GekkoExternalSocket{kExtSocketNone};
+// True while the CURRENT session runs on the adopted socket (latched at
+// start_lobby_session so a mid-session clear can't strand the adapter).
+static bool g_GekkoUsingExternalSocket = false;
+static std::vector<GekkoNetResult*> g_GekkoExtResults;
+
+static void ext_adapter_send(GekkoNetAddress* addr, const char* data, int length)
+{
+    const ExtSocket fd = g_GekkoExternalSocket.load();
+    if (fd == kExtSocketNone || addr == nullptr || addr->data == nullptr)
+    {
+        return;
+    }
+    // Address arrives as an "ip:port" string, same contract as the default
+    // asio adapter (see STOE in gekkonet.cpp).
+    const std::string endpoint(reinterpret_cast<const char*>(addr->data), addr->size);
+    const std::string::size_type colon = endpoint.rfind(':');
+    if (colon == std::string::npos)
+    {
+        return;
+    }
+    sockaddr_in out{};
+    out.sin_family = AF_INET;
+    out.sin_port = htons(static_cast<unsigned short>(std::atoi(endpoint.c_str() + colon + 1)));
+    if (inet_pton(AF_INET, endpoint.substr(0, colon).c_str(), &out.sin_addr) != 1)
+    {
+        return;
+    }
+    sendto(fd, data, length, 0, reinterpret_cast<const sockaddr*>(&out), sizeof(out));
+}
+
+static GekkoNetResult** ext_adapter_receive(int* length)
+{
+    g_GekkoExtResults.clear();
+    if (length == nullptr)
+    {
+        return g_GekkoExtResults.data();
+    }
+    const ExtSocket fd = g_GekkoExternalSocket.load();
+    if (fd == kExtSocketNone)
+    {
+        *length = 0;
+        return g_GekkoExtResults.data();
+    }
+
+    for (;;)
+    {
+        char buffer[2048];
+        sockaddr_in from{};
+#ifdef _WIN32
+        int fromLen = static_cast<int>(sizeof(from));
+#else
+        socklen_t fromLen = sizeof(from);
+#endif
+        const int received = static_cast<int>(recvfrom(fd, buffer, static_cast<int>(sizeof(buffer)), 0,
+                                                       reinterpret_cast<sockaddr*>(&from), &fromLen));
+        if (received <= 0)
+        {
+            break; // WOULDBLOCK / no more datagrams (socket is non-blocking)
+        }
+
+        // Lobby traffic (anchor keepalive acks, ping probes) shares this
+        // socket and is RMGK-magic prefixed; it isn't GekkoNet's to parse.
+        if (received >= 4 && std::memcmp(buffer, "RMGK", 4) == 0)
+        {
+            continue;
+        }
+
+        char addrText[INET_ADDRSTRLEN] = {};
+        if (inet_ntop(AF_INET, &from.sin_addr, addrText, sizeof(addrText)) == nullptr)
+        {
+            continue;
+        }
+        const std::string endpoint = std::string(addrText) + ":" + std::to_string(ntohs(from.sin_port));
+
+        GekkoNetResult* result = reinterpret_cast<GekkoNetResult*>(std::malloc(sizeof(*result)));
+        if (result == nullptr)
+        {
+            break;
+        }
+        result->addr.data = std::malloc(endpoint.size());
+        result->data = std::malloc(static_cast<size_t>(received));
+        if (result->addr.data == nullptr || result->data == nullptr)
+        {
+            std::free(result->addr.data);
+            std::free(result->data);
+            std::free(result);
+            break;
+        }
+        result->addr.size = static_cast<unsigned int>(endpoint.size());
+        std::memcpy(result->addr.data, endpoint.data(), endpoint.size());
+        result->data_len = static_cast<unsigned int>(received);
+        std::memcpy(result->data, buffer, static_cast<size_t>(received));
+        g_GekkoExtResults.push_back(result);
+    }
+
+    *length = static_cast<int>(g_GekkoExtResults.size());
+    return g_GekkoExtResults.data();
+}
+
+static void ext_adapter_free(void* data_ptr)
+{
+    std::free(data_ptr);
+}
+
+static GekkoNetAdapter g_GekkoExternalAdapter{
+    ext_adapter_send,
+    ext_adapter_receive,
+    ext_adapter_free
+};
 
 const char* gekko_session_event_name(GekkoSessionEventType type)
 {
@@ -2306,24 +2446,38 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
     config.check_distance = 10;
     gekko_start(g_GekkoSession, &config);
 
-    // Use GekkoNet's built-in UDP adapter directly — the lobby doesn't
-    // initialize n02's P2P core, so the n02-based transport used by
-    // start_p2p_session would have no socket to ride on. The lobby's
-    // anchor socket was released just before this call so the OS port
-    // is free for gekko_default_adapter to bind.
-    try
+    // Preferred transport: the lobby's own anchor socket, adopted whole
+    // (n02-style — one socket for lobby and game, so the port and every
+    // peer's NAT mapping to us survive the match boundary). Falls back to
+    // GekkoNet's built-in adapter binding localPort when no socket was lent
+    // (the old handoff model; the anchor was released before this call).
+    g_GekkoUsingExternalSocket = (g_GekkoExternalSocket.load() != kExtSocketNone);
+    if (g_GekkoUsingExternalSocket)
     {
-        gekko_net_adapter_set(g_GekkoSession, gekko_default_adapter(localPort));
+        gekko_net_adapter_set(g_GekkoSession, &g_GekkoExternalAdapter);
+        if (g_GekkoLogEnabled)
+        {
+            std::ostringstream stream;
+            stream << "start_lobby_session transport=shared_anchor_socket local_port=" << localPort;
+            write_gekko_log(stream.str());
+        }
     }
-    catch (const std::exception& e)
+    else
     {
-        std::ostringstream stream;
-        stream << "start_lobby_session result=fail reason=adapter local_port=" << localPort
-               << " error=" << e.what();
-        write_gekko_log(stream.str());
-        CoreSetError("GekkoNet adapter initialization failed: " + std::string(e.what()));
-        close_session();
-        return false;
+        try
+        {
+            gekko_net_adapter_set(g_GekkoSession, gekko_default_adapter(localPort));
+        }
+        catch (const std::exception& e)
+        {
+            std::ostringstream stream;
+            stream << "start_lobby_session result=fail reason=adapter local_port=" << localPort
+                   << " error=" << e.what();
+            write_gekko_log(stream.str());
+            CoreSetError("GekkoNet adapter initialization failed: " + std::string(e.what()));
+            close_session();
+            return false;
+        }
     }
 
     gekko_set_runahead(g_GekkoSession, 0);
@@ -2568,6 +2722,22 @@ CORE_EXPORT bool rmgk_gekko::start_local_session(const char* gameName, int playe
 #endif
 }
 
+CORE_EXPORT void rmgk_gekko::set_external_socket(uintptr_t socketDescriptor)
+{
+#ifdef RMGK_HAVE_GEKKONET
+    g_GekkoExternalSocket.store(static_cast<ExtSocket>(socketDescriptor));
+#else
+    (void)socketDescriptor;
+#endif
+}
+
+CORE_EXPORT void rmgk_gekko::clear_external_socket()
+{
+#ifdef RMGK_HAVE_GEKKONET
+    g_GekkoExternalSocket.store(kExtSocketNone);
+#endif
+}
+
 CORE_EXPORT void rmgk_gekko::close_session()
 {
 #ifdef RMGK_HAVE_GEKKONET
@@ -2577,8 +2747,16 @@ CORE_EXPORT void rmgk_gekko::close_session()
     if (g_GekkoSession != nullptr)
     {
         gekko_destroy(&g_GekkoSession);
-        gekko_default_adapter_destroy();
+        // The adopted anchor socket is borrowed — the lobby client owns and
+        // keeps it; only the default adapter's own socket is ours to destroy.
+        if (!g_GekkoUsingExternalSocket)
+        {
+            gekko_default_adapter_destroy();
+        }
     }
+    g_GekkoUsingExternalSocket = false;
+    g_GekkoExternalSocket.store(kExtSocketNone);
+    g_GekkoExtResults.clear();
     g_GekkoSession = nullptr;
     g_GekkoPlayers = 0;
     g_GekkoActors = 0;

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -2444,7 +2444,15 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
     const int clampedPredictionWindow = std::clamp(predictionWindow, 1, 10);
 
     GekkoConfig config = {};
-    config.num_players = static_cast<unsigned char>(players);
+    // ACTOR count, not seat count. GekkoNet's frame advance
+    // (SyncSystem::GetCurrentInputs) requires an input in every buffer
+    // 0..num_players-1, and handles are handed out densely in add order — so
+    // sizing the session by the highest occupied seat leaves the buffers above
+    // the actor count owned by nobody, no frame ever advances, and a sparse
+    // room (P1+P2+P4 with P3 empty) sits on a black screen. Seats stay sparse
+    // at the PORT layer: g_GekkoPlayers keeps the seat count and
+    // latch_gekko_input maps seat -> dense handle, zeroing the holes.
+    config.num_players = static_cast<unsigned char>(numRemotes + 1);
     config.max_spectators = 0;
     config.input_prediction_window = static_cast<unsigned char>(clampedPredictionWindow);
     config.input_size = static_cast<unsigned int>(inputSize);

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -2394,7 +2394,15 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
     (void)predictionWindow;
     return false;
 #else
+    // The lobby lends its anchor descriptor immediately before starting the
+    // match, but close_session() treats the descriptor as session state and
+    // clears it. Latch the lend across the cleanup, or every lobby match falls
+    // through to the default adapter and tries to bind a port the lobby's own
+    // socket still holds — which can never succeed under the shared-socket
+    // model (the anchor is deliberately never released).
+    const ExtSocket lentSocket = g_GekkoExternalSocket.load();
     close_session();
+    g_GekkoExternalSocket.store(lentSocket);
 
     g_GekkoLocalPlayer = localPlayer;
     g_GekkoStopRequested.store(false, std::memory_order_relaxed);

--- a/Source/RMG-Core/rmgk_gekko.hpp
+++ b/Source/RMG-Core/rmgk_gekko.hpp
@@ -45,6 +45,13 @@ class rmgk_gekko
         const LobbyRemotePeer* remotes, int numRemotes,
         int localDelay, int predictionWindow);
     static bool start_local_session(const char* gameName, int players, int inputSize, int localDelay);
+    // n02-style shared transport: adopt an already-bound UDP socket (the
+    // lobby's anchor) for the next lobby session instead of binding our own.
+    // The socket is borrowed, never closed by us; close_session clears the
+    // adoption. When no socket is adopted, start_lobby_session falls back to
+    // GekkoNet's own adapter binding localPort (the old handoff model).
+    static void set_external_socket(uintptr_t socketDescriptor);
+    static void clear_external_socket();
     static void close_session();
     static void request_stop();
     // Thread-safe: queue a remote slot (1-indexed N64 controller) to be force-

--- a/Source/RMG/CMakeLists.txt
+++ b/Source/RMG/CMakeLists.txt
@@ -199,7 +199,8 @@ endif(KCA_DRAG_DROP)
 if (NETPLAY)
     target_link_libraries(RMG Qt6::WebSockets Qt6::Network)
     if (WIN32)
-        target_link_libraries(RMG SDL3::SDL3 OpenGL::GL)
+        # ws2_32: LobbyClient calls WSAIoctl directly on the anchor socket.
+        target_link_libraries(RMG SDL3::SDL3 OpenGL::GL ws2_32)
         target_include_directories(RMG PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/../n02
         )

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -6,6 +6,19 @@
  */
 #ifdef NETPLAY
 
+// Must precede anything that could pull in <windows.h>, which otherwise drags
+// in the old winsock.h and collides with winsock2.h.
+#ifdef _WIN32
+#include <winsock2.h>
+// SIO_UDP_CONNRESET lives in mswsock.h under MinGW-w64 and in mstcpip.h under
+// the MSVC SDK, so pull in both and fall back to the documented control code.
+#include <mswsock.h>
+#include <mstcpip.h>
+#ifndef SIO_UDP_CONNRESET
+#define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
+#endif
+#endif
+
 #include "LobbyClient.hpp"
 
 #include <RMG-Core/Cheats.hpp>
@@ -992,6 +1005,32 @@ void LobbyClient::sendProbeBurst(const QHostAddress& addr, quint16 port, quint64
 
 void LobbyClient::onProbeRetryTimer()
 {
+    // Poll the socket rather than trusting readyRead alone. Qt disables read
+    // notification for an unbuffered socket whose readyRead goes unserviced,
+    // and re-arms it on the next successful read — but during a match our slot
+    // deliberately reads nothing (GekkoNet's thread owns recvfrom), so the
+    // notification is off by the time the match ends. Whether it ever comes
+    // back then depends on there happening to be a datagram queued at that
+    // instant, which is precisely the coin-flip seen in the field: the client
+    // whose match-end drain found datagrams recovered, the one that found an
+    // empty buffer stayed deaf until the process restarted. A socket serviced
+    // from two threads can't rely on Qt's notifier bookkeeping, so poll it —
+    // this is the same discipline n02 uses. Cheap: a no-op when nothing is
+    // pending, and this timer already runs continuously.
+    if (m_udp && !m_anchorLent && !m_inPrematchSync)
+    {
+        m_drainedDatagrams = 0;
+        onUdpReadyRead();
+        if (m_drainedDatagrams > 0)
+        {
+            // The notifier missed these — readyRead would have drained them
+            // already. Logged because a run of these is the signature of the
+            // stall above, and their absence means it isn't happening.
+            writePingDiagnostic(QStringLiteral("POLL_DRAIN"),
+                                QStringLiteral("datagrams=%1").arg(m_drainedDatagrams));
+        }
+    }
+
     if (m_pendingProbes.isEmpty())
         return;
 
@@ -1338,6 +1377,7 @@ void LobbyClient::initiateUdpAnchor()
 
     m_anchorRetryDeadlineMs = 0;
     m_anchorRetryTimer->stop();
+    disableUdpConnReset();
     const quint16 previousPort = m_anchorLocalPort;
     m_anchorLocalPort = m_udp->localPort();
     writePingDiagnostic(QStringLiteral("UDP_BIND"),
@@ -1347,6 +1387,34 @@ void LobbyClient::initiateUdpAnchor()
                             .arg(previousPort));
     sendUdpRegister();
     m_udpKeepaliveTimer->start();
+}
+
+// Windows delivers ICMP "port unreachable" to a *connectionless* UDP socket as
+// a WSAECONNRESET on the next receive. One peer's port going away (a match
+// partner quitting, a game socket closing) therefore poisons receives on the
+// socket that sent to it — and under the shared-transport model that is the
+// one socket the lobby also depends on, so the client keeps sending fine while
+// silently receiving nothing until the process restarts. SIO_UDP_CONNRESET
+// off is the standard fix: unreachable peers are simply ignored, which is the
+// right semantics for peer-to-peer UDP where peers come and go. No-op on
+// non-Windows; failure here is not fatal, so it's logged rather than raised.
+void LobbyClient::disableUdpConnReset()
+{
+#ifdef _WIN32
+    if (!m_udp)
+        return;
+    const qintptr fd = m_udp->socketDescriptor();
+    if (fd == -1)
+        return;
+    BOOL enable = FALSE;
+    DWORD returned = 0;
+    if (::WSAIoctl(static_cast<SOCKET>(fd), SIO_UDP_CONNRESET, &enable, sizeof(enable),
+                   nullptr, 0, &returned, nullptr, nullptr) == SOCKET_ERROR)
+    {
+        writePingDiagnostic(QStringLiteral("UDP_CONNRESET"),
+                            QStringLiteral("result=fail error=%1").arg(::WSAGetLastError()));
+    }
+#endif
 }
 
 void LobbyClient::sendUdpRegister()
@@ -1757,8 +1825,24 @@ void LobbyClient::reclaimAnchorFromMatch()
         m_udpKeepaliveTimer->start();
     // Drain anything that arrived between GekkoNet's last poll and now, so no
     // stale datagram sits in the buffer wedging the read notifier.
-    if (m_udp->hasPendingDatagrams())
-        onUdpReadyRead();
+    //
+    // Unconditional on purpose. Throughout the lend our readyRead slot returns
+    // without reading, and Qt disables the read notification for an unbuffered
+    // socket whose readyRead went unserviced — it is re-armed by the next read,
+    // not by time. Gating this drain on hasPendingDatagrams() meant that a
+    // reclaim landing on a momentarily empty buffer performed no read at all
+    // and left the notifier disabled, so the socket kept sending while silently
+    // receiving nothing until the process restarted. onUdpReadyRead is a
+    // read-until-empty loop and is safe to call with nothing pending.
+    m_drainedDatagrams = 0;
+    onUdpReadyRead();
+    // How much had piled up while nobody was reading tells us which failure we
+    // are looking at when a peer goes deaf after a match: a large backlog means
+    // datagrams were arriving and going unserviced (our reader / the notifier),
+    // while zero means nothing reached the socket at all (blocked inbound —
+    // firewall or NAT), which no amount of draining would fix.
+    writePingDiagnostic(QStringLiteral("ANCHOR_DRAIN"),
+                        QStringLiteral("datagrams=%1").arg(m_drainedDatagrams));
 }
 
 void LobbyClient::onUdpReadyRead()
@@ -1777,6 +1861,7 @@ void LobbyClient::onUdpReadyRead()
         quint16 senderPort = 0;
         datagram.resize(int(m_udp->pendingDatagramSize()));
         m_udp->readDatagram(datagram.data(), datagram.size(), &sender, &senderPort);
+        m_drainedDatagrams++;
 
         if (datagram.size() < 5 || std::memcmp(datagram.constData(), ANCHOR_MAGIC, 4) != 0)
             continue;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -462,6 +462,15 @@ void LobbyClient::onWsConnected()
 
 void LobbyClient::onWsDisconnected()
 {
+    stopPingDiagnosticLog(QStringLiteral("connection_lost"));
+    // Passive drops (server restart, network cut, server-side kick) never go
+    // through disconnectFromServer, so the anchor socket used to stay bound —
+    // and the next connect's pinned-port bind then failed against our own
+    // zombie socket, with the fallback bind failing too (a failed bind leaves
+    // QUdpSocket needing a reset before it can bind again). The session ran
+    // anchorless from there. Tear the socket down on every disconnect path.
+    if (m_udp)
+        m_udp->abort();
     m_heartbeatTimer->stop();
     m_udpKeepaliveTimer->stop();
     m_isModerator = false; // role is per-connection; must re-auth after reconnect
@@ -1191,6 +1200,11 @@ bool LobbyClient::eventFilter(QObject* watched, QEvent* event)
 
 void LobbyClient::initiateUdpAnchor()
 {
+    // A socket that is already bound (zombie from a passive disconnect) or
+    // left over from a failed bind cannot bind again until it's reset.
+    if (m_udp->state() != QAbstractSocket::UnconnectedState)
+        m_udp->abort();
+
     // Reclaim the port we've been using all session. Only the very first bind
     // asks the OS to pick one; every rebind after a match must land on the same
     // port or every peer's cached endpoint for us goes stale at once.
@@ -1212,6 +1226,10 @@ void LobbyClient::initiateUdpAnchor()
             writePingDiagnostic(QStringLiteral("UDP_BIND"),
                                 QStringLiteral("result=port_taken wanted=%1 error=%2")
                                     .arg(m_anchorLocalPort).arg(m_udp->errorString()));
+            // A failed bind leaves the socket unable to bind again until it's
+            // reset — without this the fallback below failed right after the
+            // pinned-port failure and the whole session ran anchorless.
+            m_udp->abort();
         }
     }
     if (!bound)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -1032,8 +1032,13 @@ void LobbyClient::onProbeRetryTimer()
     // empty buffer stayed deaf until the process restarted. A socket serviced
     // from two threads can't rely on Qt's notifier bookkeeping, so poll it —
     // this is the same discipline n02 uses. Cheap: a no-op when nothing is
-    // pending, and this timer already runs continuously.
-    if (m_udp && !m_anchorLent && !m_inPrematchSync)
+    // pending, and this timer already runs continuously. BoundState matters:
+    // this timer also ticks before connect and after disconnect, when the
+    // socket object exists but isn't bound, and hasPendingDatagrams() on an
+    // unbound socket emits a qWarning every call — ten a second, straight to
+    // the terminal on Linux.
+    if (m_udp && m_udp->state() == QAbstractSocket::BoundState &&
+        !m_anchorLent && !m_inPrematchSync)
     {
         m_drainedDatagrams = 0;
         onUdpReadyRead();

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -45,6 +45,11 @@ namespace
     constexpr int HEARTBEAT_INTERVAL_MS  = 15'000;
     constexpr int UDP_KEEPALIVE_INTERVAL = 20'000;
 
+    // Pinned-anchor-port rebind retry (see initiateUdpAnchor): attempt cadence
+    // and how long to keep trying before surrendering the port.
+    constexpr int ANCHOR_PORT_RETRY_INTERVAL_MS = 250;
+    constexpr qint64 ANCHOR_PORT_RETRY_WINDOW_MS = 4'000;
+
     // No keyboard/mouse input for this long => report "away" on the heartbeat.
     // Presence-only; nothing functional hangs off it.
     constexpr qint64 AWAY_AFTER_MS = 5 * 60'000;
@@ -313,6 +318,21 @@ LobbyClient::LobbyClient(QObject* parent)
     connect(m_probeRetryTimer, &QTimer::timeout, this, &LobbyClient::onProbeRetryTimer);
     m_probeRetryTimer->start();
 
+    // Single-shot; each failed pinned-port bind schedules the next attempt.
+    m_anchorRetryTimer = new QTimer(this);
+    m_anchorRetryTimer->setSingleShot(true);
+    m_anchorRetryTimer->setInterval(ANCHOR_PORT_RETRY_INTERVAL_MS);
+    connect(m_anchorRetryTimer, &QTimer::timeout, this, [this]() {
+        // Abandon the retry if the connection went away mid-window; a fresh
+        // connect starts its own window.
+        if (m_state != ConnectionState::Connected)
+        {
+            m_anchorRetryDeadlineMs = 0;
+            return;
+        }
+        initiateUdpAnchor();
+    });
+
     // Watch app-wide input for the away flag. Cheap: the filter only stamps a
     // timestamp for input-type events and passes everything through.
     m_lastActivityMs = QDateTime::currentMSecsSinceEpoch();
@@ -370,6 +390,9 @@ void LobbyClient::connectToServer(const QString& wsUrl, const QString& username,
 void LobbyClient::disconnectFromServer()
 {
     stopPingDiagnosticLog(QStringLiteral("disconnect"));
+    if (m_anchorRetryTimer)
+        m_anchorRetryTimer->stop();
+    m_anchorRetryDeadlineMs = 0;
     m_heartbeatTimer->stop();
     m_udpKeepaliveTimer->stop();
     if (m_ws && m_ws->state() != QAbstractSocket::UnconnectedState)
@@ -471,6 +494,9 @@ void LobbyClient::onWsDisconnected()
     // anchorless from there. Tear the socket down on every disconnect path.
     if (m_udp)
         m_udp->abort();
+    if (m_anchorRetryTimer)
+        m_anchorRetryTimer->stop();
+    m_anchorRetryDeadlineMs = 0;
     m_heartbeatTimer->stop();
     m_udpKeepaliveTimer->stop();
     m_isModerator = false; // role is per-connection; must re-auth after reconnect
@@ -1216,20 +1242,35 @@ void LobbyClient::initiateUdpAnchor()
         reusedPort = bound;
         if (!bound)
         {
-            // GekkoNet may not have let go of it yet. Falling back to an
-            // ephemeral port loses endpoint continuity — the old behaviour —
-            // but that beats having no anchor at all, and the peers relearn us
-            // from the REGISTER below. Logged loudly because if this fires
-            // often the release/rebind ordering is what needs fixing, not this.
-            qWarning() << "lobby: could not rebind anchor port" << m_anchorLocalPort
-                       << "-" << m_udp->errorString() << "- falling back to a new port";
-            writePingDiagnostic(QStringLiteral("UDP_BIND"),
-                                QStringLiteral("result=port_taken wanted=%1 error=%2")
-                                    .arg(m_anchorLocalPort).arg(m_udp->errorString()));
-            // A failed bind leaves the socket unable to bind again until it's
-            // reset — without this the fallback below failed right after the
-            // pinned-port failure and the whole session ran anchorless.
+            // GekkoNet hasn't let go of the port yet — the emulation thread is
+            // still tearing down while the UI-side room cleanup runs, a race
+            // of about a second. A failed bind holds nothing, and a UDP port
+            // frees the instant its socket closes (no TIME_WAIT), so instead
+            // of surrendering the port immediately — which invalidates every
+            // peer's route to us and can permanently break pairs with
+            // strict-NAT peers who can't re-punch fresh mappings — retry it
+            // briefly on a timer. Ephemeral fallback only once the window
+            // expires.
             m_udp->abort();
+
+            const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+            if (m_anchorRetryDeadlineMs == 0)
+                m_anchorRetryDeadlineMs = nowMs + ANCHOR_PORT_RETRY_WINDOW_MS;
+            if (nowMs < m_anchorRetryDeadlineMs)
+            {
+                writePingDiagnostic(QStringLiteral("UDP_BIND"),
+                                    QStringLiteral("result=port_taken_retrying wanted=%1 window_left_ms=%2")
+                                        .arg(m_anchorLocalPort)
+                                        .arg(m_anchorRetryDeadlineMs - nowMs));
+                m_anchorRetryTimer->start();
+                return;
+            }
+
+            qWarning() << "lobby: could not rebind anchor port" << m_anchorLocalPort
+                       << "after retries -" << m_udp->errorString() << "- falling back to a new port";
+            writePingDiagnostic(QStringLiteral("UDP_BIND"),
+                                QStringLiteral("result=port_retry_exhausted wanted=%1 error=%2")
+                                    .arg(m_anchorLocalPort).arg(m_udp->errorString()));
         }
     }
     if (!bound)
@@ -1240,9 +1281,12 @@ void LobbyClient::initiateUdpAnchor()
         qWarning() << "lobby: udp bind failed:" << m_udp->errorString();
         writePingDiagnostic(QStringLiteral("UDP_BIND"),
                             QStringLiteral("result=fail error=%1").arg(m_udp->errorString()));
+        m_anchorRetryDeadlineMs = 0;
         return;
     }
 
+    m_anchorRetryDeadlineMs = 0;
+    m_anchorRetryTimer->stop();
     const quint16 previousPort = m_anchorLocalPort;
     m_anchorLocalPort = m_udp->localPort();
     writePingDiagnostic(QStringLiteral("UDP_BIND"),
@@ -1570,6 +1614,11 @@ quint16 LobbyClient::localUdpPort() const
 
 void LobbyClient::releaseUdpAnchor()
 {
+    // A match is taking the socket over — the pinned port now legitimately
+    // belongs to GekkoNet, so any pending rebind retry must not fight it.
+    if (m_anchorRetryTimer)
+        m_anchorRetryTimer->stop();
+    m_anchorRetryDeadlineMs = 0;
     if (m_udpKeepaliveTimer)
         m_udpKeepaliveTimer->stop();
     if (m_udp && m_udp->state() != QAbstractSocket::UnconnectedState)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -399,7 +399,9 @@ void LobbyClient::disconnectFromServer()
     {
         m_ws->close();
     }
-    if (m_udp)
+    // See onWsDisconnected: a socket lent to a running match must survive the
+    // lobby connection; it's recycled by the next connect's pre-bind abort.
+    if (m_udp && !m_anchorLent)
     {
         m_udp->close();
     }
@@ -492,7 +494,12 @@ void LobbyClient::onWsDisconnected()
     // zombie socket, with the fallback bind failing too (a failed bind leaves
     // QUdpSocket needing a reset before it can bind again). The session ran
     // anchorless from there. Tear the socket down on every disconnect path.
-    if (m_udp)
+    // While a match borrows the socket, leave both the socket and the lent
+    // flag alone: aborting would cut the game's transport out from under
+    // GekkoNet, and clearing the flag would re-enable our reads mid-match
+    // (stealing game packets). The match ends through its own path; the next
+    // connect's pre-bind abort recycles the socket safely.
+    if (m_udp && !m_anchorLent)
         m_udp->abort();
     if (m_anchorRetryTimer)
         m_anchorRetryTimer->stop();
@@ -893,6 +900,14 @@ void LobbyClient::sendProbeTo(quint64 userId, const QString& endpoint)
                             QStringLiteral("peer=%1 reason=no_socket").arg(pingUserLabel(userId)));
         return;
     }
+    if (m_anchorLent)
+    {
+        // Sends would work, but the echoes come back on the lent socket where
+        // GekkoNet's filter drops them — the probe could never complete.
+        writePingDiagnostic(QStringLiteral("PROBE_SKIP"),
+                            QStringLiteral("peer=%1 reason=anchor_lent").arg(pingUserLabel(userId)));
+        return;
+    }
 
     const int colon = endpoint.lastIndexOf(':');
     if (colon <= 0)
@@ -1226,6 +1241,16 @@ bool LobbyClient::eventFilter(QObject* watched, QEvent* event)
 
 void LobbyClient::initiateUdpAnchor()
 {
+    // Reconnected to the lobby while a match still borrows the socket: leave
+    // the match's transport untouched and run without an anchor for now — the
+    // match-end reclaim will register this same socket with the fresh session.
+    if (m_anchorLent)
+    {
+        writePingDiagnostic(QStringLiteral("UDP_BIND"),
+                            QStringLiteral("result=deferred reason=anchor_lent"));
+        return;
+    }
+
     // A socket that is already bound (zombie from a passive disconnect) or
     // left over from a failed bind cannot bind again until it's reset.
     if (m_udp->state() != QAbstractSocket::UnconnectedState)
@@ -1639,6 +1664,12 @@ void LobbyClient::releaseUdpAnchor()
 
 void LobbyClient::reopenUdpAnchor()
 {
+    // Shared-socket model: the socket never went away — just resume our side.
+    if (m_anchorLent)
+    {
+        reclaimAnchorFromMatch();
+        return;
+    }
     if (m_state == ConnectionState::Connected && m_udp &&
         m_udp->state() == QAbstractSocket::UnconnectedState)
     {
@@ -1646,9 +1677,59 @@ void LobbyClient::reopenUdpAnchor()
     }
 }
 
+qintptr LobbyClient::lendAnchorToMatch()
+{
+    if (!m_udp || m_udp->state() == QAbstractSocket::UnconnectedState)
+        return -1;
+    const qintptr fd = m_udp->socketDescriptor();
+    if (fd == -1)
+        return -1;
+
+    if (m_anchorRetryTimer)
+        m_anchorRetryTimer->stop();
+    m_anchorRetryDeadlineMs = 0;
+    // Keepalives pause: GekkoNet's receive filter drops RMGK-tagged datagrams,
+    // so acks would vanish anyway, and the server keeps our endpoint entry —
+    // reclaim re-registers the same address the moment the match ends.
+    if (m_udpKeepaliveTimer)
+        m_udpKeepaliveTimer->stop();
+    m_anchorLent = true;
+    qInfo() << "Rollback lobby lending anchor socket to match"
+            << "localPort" << m_udp->localPort();
+    writePingDiagnostic(QStringLiteral("ANCHOR_LENT"),
+                        QStringLiteral("port=%1").arg(m_udp->localPort()));
+    return fd;
+}
+
+void LobbyClient::reclaimAnchorFromMatch()
+{
+    if (!m_anchorLent)
+        return;
+    m_anchorLent = false;
+    if (!m_udp || m_udp->state() == QAbstractSocket::UnconnectedState ||
+        m_state != ConnectionState::Connected)
+        return;
+    // Same socket, same port, same NAT mappings — nothing to rebind. The
+    // REGISTER is a refresh, not a re-punch; peers' learned routes to us are
+    // still valid, which is the whole point of the shared-socket model.
+    writePingDiagnostic(QStringLiteral("ANCHOR_RECLAIMED"),
+                        QStringLiteral("port=%1").arg(m_udp->localPort()));
+    sendUdpRegister();
+    if (m_udpKeepaliveTimer)
+        m_udpKeepaliveTimer->start();
+    // Drain anything that arrived between GekkoNet's last poll and now, so no
+    // stale datagram sits in the buffer wedging the read notifier.
+    if (m_udp->hasPendingDatagrams())
+        onUdpReadyRead();
+}
+
 void LobbyClient::onUdpReadyRead()
 {
     if (m_inPrematchSync)
+        return;
+    // While the socket is lent to GekkoNet, its thread owns recvfrom; reading
+    // here would steal game packets (the n02 "packet stealing" race).
+    if (m_anchorLent)
         return;
 
     while (m_udp->hasPendingDatagrams())

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -514,6 +514,7 @@ void LobbyClient::onWsDisconnected()
     // user ids are stale, so retrying them would burst at whoever now holds
     // those ids and emit failure notices for peers we're no longer talking to.
     m_pendingProbes.clear();
+    m_probeFailStreak.clear();
     m_recentlyMatchedNonces.clear();
     // Learned routes are keyed by user id too — same recycled-id hazard.
     m_learnedRoutes.clear();
@@ -1015,7 +1016,7 @@ void LobbyClient::onProbeRetryTimer()
                                     .arg(PROBE_BURST)
                                     .arg(nowMs - it->sendMs));
             it = m_pendingProbes.erase(it);
-            emit pingProbeFailed(uid);
+            noteProbeSeriesFailed(uid);
             continue;
         }
 
@@ -1024,7 +1025,7 @@ void LobbyClient::onProbeRetryTimer()
         {
             const quint64 uid = it->targetUserId;
             it = m_pendingProbes.erase(it);
-            emit pingProbeFailed(uid);
+            noteProbeSeriesFailed(uid);
             continue;
         }
 
@@ -1046,6 +1047,31 @@ void LobbyClient::onProbeRetryTimer()
         emit pingProbeRetrying(it->targetUserId, it->attempt, PROBE_ATTEMPTS);
         ++it;
     }
+}
+
+void LobbyClient::noteProbeSeriesFailed(quint64 userId)
+{
+    const int streak = ++m_probeFailStreak[userId];
+    // A peer we've never measured gets the hard verdict immediately — there is
+    // no number to fall back on and first contact failing is the case the
+    // retry/unreachable UI exists for. An established peer gets one free miss:
+    // right after a match the far side is usually still handing its socket
+    // back, and one aged-out series proves nothing.
+    if (streak >= 2 || !m_measuredPing.contains(userId))
+        emit pingProbeFailed(userId);
+    else
+        emit pingProbeSoftFailed(userId);
+}
+
+void LobbyClient::cancelPendingProbes(const QString& reason)
+{
+    if (m_pendingProbes.isEmpty())
+        return;
+    writePingDiagnostic(QStringLiteral("PROBE_CANCELLED"),
+                        QStringLiteral("count=%1 reason=%2")
+                            .arg(m_pendingProbes.size())
+                            .arg(reason));
+    m_pendingProbes.clear();
 }
 
 void LobbyClient::handlePingProbeReply(const QJsonObject& data)
@@ -1646,6 +1672,11 @@ void LobbyClient::releaseUdpAnchor()
     m_anchorRetryDeadlineMs = 0;
     if (m_udpKeepaliveTimer)
         m_udpKeepaliveTimer->stop();
+    // Same reasoning as lendAnchorToMatch: an in-flight series can't survive
+    // the socket going away, and letting it age out would report the match
+    // peer as unreachable.
+    cancelPendingProbes(QStringLiteral("anchor_released"));
+    m_probeFailStreak.clear();
     if (m_udp && m_udp->state() != QAbstractSocket::UnconnectedState)
     {
         qInfo() << "Rollback lobby releasing UDP anchor"
@@ -1693,6 +1724,13 @@ qintptr LobbyClient::lendAnchorToMatch()
     // reclaim re-registers the same address the moment the match ends.
     if (m_udpKeepaliveTimer)
         m_udpKeepaliveTimer->stop();
+    // A series caught in flight by the handoff would burn its retries against
+    // a socket whose echoes GekkoNet drops, then age out into a failure signal
+    // — flagging the very peer we're starting a match with as unreachable, and
+    // nothing clears it until probing resumes at match end. Drop them quietly;
+    // the miss streak resets too so the first post-match cycle starts clean.
+    cancelPendingProbes(QStringLiteral("anchor_lent"));
+    m_probeFailStreak.clear();
     m_anchorLent = true;
     qInfo() << "Rollback lobby lending anchor socket to match"
             << "localPort" << m_udp->localPort();
@@ -1815,6 +1853,7 @@ void LobbyClient::onUdpReadyRead()
                 m_recentlyMatchedNonces.clear();
             m_recentlyMatchedNonces.insert(nonce);
             m_measuredPing[uid] = rttMs;
+            m_probeFailStreak.remove(uid);
             writePingDiagnostic(QStringLiteral("RTT"),
                                 QStringLiteral("peer=%1 rtt_ms=%2 attempt=%3/%4 nonce=%5 from=%6:%7")
                                     .arg(pingUserLabel(uid))
@@ -2002,6 +2041,13 @@ void LobbyClient::swapSeats(int slotA, int slotB)
 
 void LobbyClient::requestPingProbe(quint64 targetUserId)
 {
+    // While a match borrows the socket the probe could never complete
+    // (GekkoNet's filter eats the echo), so don't even ask the server —
+    // otherwise every tick spends a round-trip to arrive at a skip. The
+    // ANCHOR_LENT/ANCHOR_RECLAIMED pair already brackets the quiet stretch
+    // in the diagnostic log.
+    if (m_anchorLent)
+        return;
     QJsonObject d;
     d["targetUserId"] = QJsonValue(qint64(targetUserId));
     sendEnvelope("PING_PROBE_REQUEST", d);

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -491,6 +491,11 @@ void LobbyClient::onWsConnected()
     const QString transport = detectTransportMedium(m_ws->localAddress());
     if (!transport.isEmpty())
         data["connection"] = transport;
+    // Ask the server to withhold our country from presence and flag us
+    // anonymous, so peers show no flag at all (not even the region badge).
+    // The coarse region still flows — it drives ping estimation only.
+    if (CoreSettingsGetBoolValue(SettingsID::Rollback_HideLocation))
+        data["anonymous"] = true;
     // Standard (non-DST) UTC offset — the server uses it to split the North
     // America country bucket into east/central/west (New York -5 h, Chicago
     // -6 h, Denver -7 h, Los Angeles -8 h). standardTimeOffset is DST-immune,
@@ -2262,6 +2267,7 @@ LobbyClient::LobbyUser LobbyClient::parsePresenceUser(const QJsonObject& obj)
     u.country         = obj.value("country").toString();
     u.clientVersion   = obj.value("clientVersion").toString();
     u.connection      = obj.value("connection").toString();
+    u.anonymous       = obj.value("anonymous").toBool();
     u.pingToServer    = static_cast<quint16>(obj.value("pingToServer").toInt());
     u.currentRoomId   = static_cast<quint64>(obj.value("currentRoomId").toDouble());
     u.currentRoomName = obj.value("currentRoomName").toString();

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -396,6 +396,11 @@ void LobbyClient::connectToServer(const QString& wsUrl, const QString& username,
     }
 
     setState(ConnectionState::Connecting);
+    // Narrate the connect stages to the terminal (visible on Linux, DebugView
+    // on Windows): this line, then "WebSocket connected", then "authenticated".
+    // Whichever line is missing names the stage that stalled — a silent gap
+    // after this one means TCP itself is black-holing toward this address.
+    qInfo() << "Rollback lobby connecting to" << url.toString();
     m_ws->open(url);
 }
 
@@ -481,6 +486,7 @@ static QString detectTransportMedium(const QHostAddress& localAddress)
 
 void LobbyClient::onWsConnected()
 {
+    qInfo() << "Rollback lobby WebSocket connected, authenticating";
     setState(ConnectionState::Authenticating);
 
     QJsonObject data;
@@ -615,6 +621,8 @@ void LobbyClient::handleHelloOk(const QJsonObject& data)
     m_selfUserId  = static_cast<quint64>(data.value("userId").toDouble());
     m_observedIp  = data.value("observedIp").toString();
     m_region      = data.value("region").toString();
+    qInfo() << "Rollback lobby authenticated" << "userId" << m_selfUserId
+            << "observedIp" << m_observedIp << "region" << m_region;
 
     const QString udpAnchor = data.value("udpAnchor").toString();
     if (!udpAnchor.isEmpty() && udpAnchor != "TODO:6364")

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -36,7 +36,6 @@
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QNetworkInterface>
-#include <QNetworkInformation>
 #include <QDateTime>
 #include <QTimeZone>
 #include <QCoreApplication>
@@ -447,27 +446,37 @@ void LobbyClient::sendEnvelope(const QString& type, const QJsonObject& data, con
 
 // -------- WebSocket lifecycle --------
 
-// Best-effort detection of this machine's transport medium ("wifi"/"lan"/...),
-// reported in HELLO so peers can gauge connection-quality risk Slippi-style.
-// Returns an empty string when the OS backend can't say.
-static QString detectTransportMedium()
+// Classify the transport actually carrying the lobby connection ("lan"/
+// "wifi"), reported in HELLO so peers can gauge connection-quality risk
+// Slippi-style. Deliberately NOT QNetworkInformation: its Windows transport
+// support is written against C++/WinRT and compiled out of MinGW Qt builds
+// (the backend loads but never claims the feature), and its Linux backend
+// needs both a plugin the AppImage doesn't bundle and a running
+// NetworkManager. QNetworkInterface avoids all of that — plain Win32 / sysfs
+// underneath — and is more truthful anyway: the connected socket's local
+// address names the interface the OS actually routed the lobby through, so a
+// machine with ethernet and wifi both up reports the one really in use.
+// Returns empty for anything unclassifiable (VPNs, virtual adapters) rather
+// than guessing.
+static QString detectTransportMedium(const QHostAddress& localAddress)
 {
-    if (!QNetworkInformation::instance() &&
-        !QNetworkInformation::loadBackendByFeatures(QNetworkInformation::Feature::TransportMedium))
+    if (localAddress.isNull())
         return QString();
-
-    const auto* info = QNetworkInformation::instance();
-    if (info == nullptr)
-        return QString();
-
-    switch (info->transportMedium())
+    for (const QNetworkInterface& ifc : QNetworkInterface::allInterfaces())
     {
-    case QNetworkInformation::TransportMedium::Ethernet:  return QStringLiteral("lan");
-    case QNetworkInformation::TransportMedium::WiFi:      return QStringLiteral("wifi");
-    case QNetworkInformation::TransportMedium::Cellular:  return QStringLiteral("cellular");
-    case QNetworkInformation::TransportMedium::Bluetooth: return QStringLiteral("bluetooth");
-    default:                                              return QString();
+        for (const QNetworkAddressEntry& entry : ifc.addressEntries())
+        {
+            if (entry.ip() != localAddress)
+                continue;
+            switch (ifc.type())
+            {
+            case QNetworkInterface::Ethernet: return QStringLiteral("lan");
+            case QNetworkInterface::Wifi:     return QStringLiteral("wifi");
+            default:                          return QString();
+            }
+        }
     }
+    return QString();
 }
 
 void LobbyClient::onWsConnected()
@@ -477,7 +486,9 @@ void LobbyClient::onWsConnected()
     QJsonObject data;
     data["username"]      = m_pendingUsername;
     data["clientVersion"] = QString::fromStdString(CoreGetVersion());
-    const QString transport = detectTransportMedium();
+    // The WebSocket is connected by the time this slot runs, so its local
+    // address reflects the route the OS actually chose for lobby traffic.
+    const QString transport = detectTransportMedium(m_ws->localAddress());
     if (!transport.isEmpty())
         data["connection"] = transport;
     // Standard (non-DST) UTC offset — the server uses it to split the North

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -250,6 +250,12 @@ signals:
     void pingProbeRetrying(quint64 targetUserId, int attempt, int maxAttempts);
     // Every attempt went unanswered — that peer is unreachable for now.
     void pingProbeFailed(quint64 targetUserId);
+    // A series died, but the peer has answered before and this is the first
+    // consecutive miss — almost always transient (their socket is lent to a
+    // match, or they're mid-rebind after one). The UI should fall back to the
+    // last measurement rather than declare unreachable; a second consecutive
+    // miss emits pingProbeFailed instead.
+    void pingProbeSoftFailed(quint64 targetUserId);
 
     void matchBegin(quint64 matchId, const QList<LobbyClient::LobbyMatchPeer>& peers);
     void matchPeerLeft(quint64 matchId, quint64 userId, int slot, const QString& reason);
@@ -308,6 +314,13 @@ private:
     void sendProbeTo(quint64 userId, const QString& endpoint);
     // Emit one burst of identical PROBE packets for an existing series.
     void sendProbeBurst(const QHostAddress& addr, quint16 port, quint64 nonce);
+    // A probe series ran out of attempts. Routes to pingProbeFailed or
+    // pingProbeSoftFailed based on the peer's consecutive-miss streak.
+    void noteProbeSeriesFailed(quint64 userId);
+    // Drop every in-flight series without emitting failure signals — for the
+    // moments we stop probing for our own reasons (socket lent to a match),
+    // where an aged-out series says nothing about the peer.
+    void cancelPendingProbes(const QString& reason);
 
     // Opt-in on-disk trace of the whole probe pipeline, for diagnosing peer
     // pings that never resolve. Off unless Rollback_PingDiagnostics is set;
@@ -423,6 +436,12 @@ private:
         qint64  nextAttemptMs = 0;
     };
     QHash<quint64, ProbeInFlight> m_pendingProbes;
+
+    // Consecutive exhausted probe series per peer, reset by any successful
+    // reply and when a match borrows the socket. A single miss on a peer
+    // we've measured before shows as a soft failure (the seat keeps its
+    // number); the streak has to reach 2 before the UI says unreachable.
+    QHash<quint64, int> m_probeFailStreak;
 
     // The address a peer's packets *actually* arrive from, learned from inbound
     // PROBE/PROBE_REPLY traffic — n02-style reply-to-observed-source, kept.

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -335,6 +335,10 @@ private:
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_udpKeepaliveTimer = nullptr;
     QTimer* m_probeRetryTimer = nullptr;
+    // Retries the pinned anchor port while GekkoNet's teardown still holds it
+    // (see initiateUdpAnchor). 0 deadline = no retry window active.
+    QTimer* m_anchorRetryTimer = nullptr;
+    qint64  m_anchorRetryDeadlineMs = 0;
     bool m_inPrematchSync = false;
 
     // Incoming spectate keyframe reassembly (chunked SPECTATE_KEYFRAME messages).

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -343,6 +343,9 @@ private:
     void handleModList(const QJsonObject& data);
 
     void initiateUdpAnchor();
+    // Stop Windows from failing receives with WSAECONNRESET when a peer's port
+    // becomes unreachable (see the definition). No-op elsewhere.
+    void disableUdpConnReset();
     void sendUdpRegister();
     void sendUdpKeepalive();
     // Walks m_pendingProbes and re-bursts anything that's due. Runs on a short
@@ -398,6 +401,10 @@ private:
     // Ping diagnostics (see startPingDiagnosticLog).
     QFile*  m_pingDiagnosticFile    = nullptr;
     qint64  m_pingDiagnosticStartMs = 0;
+
+    // Datagrams read since the counter was last reset. Only consulted by the
+    // match-end drain, to record how much had queued up while nobody read.
+    int m_drainedDatagrams = 0;
 
     // True while GekkoNet borrows the anchor socket (see lendAnchorToMatch):
     // suppresses our reads and probe sends without touching the socket.

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -58,6 +58,10 @@ public:
         QString country;         // ISO 3166-1 alpha-2 from the server; "" on old servers
         QString clientVersion;   // peer's self-reported RMG-K build
         QString connection;      // peer's self-reported transport ("wifi"/"lan"/...)
+        // User asked the server to withhold their location: country comes back
+        // empty and the UI must not fall back to the region badge either. The
+        // region string itself still flows for ping estimation.
+        bool anonymous = false;
         quint16 pingToServer = 0;
         quint64 currentRoomId = 0;
         QString currentRoomName;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -196,6 +196,17 @@ public:
     void releaseUdpAnchor();
     void reopenUdpAnchor();
 
+    // n02-style shared transport: instead of releasing the anchor socket for
+    // GekkoNet to rebind (a handoff with a whole family of races), lend the
+    // live socket itself. Returns the native descriptor, or -1 if there is no
+    // bound socket. While lent, this side stops READING (GekkoNet's thread
+    // owns recvfrom — same reader discipline n02 uses between p2p_step and
+    // p2p_modify_play_values); the port, and every peer's NAT mapping to it,
+    // never change. reclaim is idempotent and safe to call whether or not a
+    // lend happened.
+    qintptr lendAnchorToMatch();
+    void reclaimAnchorFromMatch();
+
     // Fire a burst of UDP punch packets from the anchor socket to each peer's
     // public endpoint. Call this *before* releaseUdpAnchor() so the punch goes
     // out from the same NAT mapping GekkoNet will inherit when it re-binds.
@@ -374,6 +385,10 @@ private:
     // Ping diagnostics (see startPingDiagnosticLog).
     QFile*  m_pingDiagnosticFile    = nullptr;
     qint64  m_pingDiagnosticStartMs = 0;
+
+    // True while GekkoNet borrows the anchor socket (see lendAnchorToMatch):
+    // suppresses our reads and probe sends without touching the socket.
+    bool m_anchorLent = false;
 
     // Away detection: last app-wide input, and whether the last heartbeat
     // reported us away (so the first input after can snap us back immediately

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -381,6 +381,7 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
     connect(m_client, &LobbyClient::pingProbeMeasured,    this, &RollbackLobbyDialog::onPingMeasured);
     connect(m_client, &LobbyClient::pingProbeRetrying,    this, &RollbackLobbyDialog::onPingProbeRetrying);
     connect(m_client, &LobbyClient::pingProbeFailed,      this, &RollbackLobbyDialog::onPingProbeFailed);
+    connect(m_client, &LobbyClient::pingProbeSoftFailed,  this, &RollbackLobbyDialog::onPingProbeSoftFailed);
     connect(m_client, &LobbyClient::spectateBegan,        this, &RollbackLobbyDialog::onSpectateBegan);
     connect(m_client, &LobbyClient::spectateData,         this, &RollbackLobbyDialog::onSpectateData);
     connect(m_client, &LobbyClient::spectateKeyframe,     this, &RollbackLobbyDialog::onSpectateKeyframe);
@@ -3192,7 +3193,21 @@ void RollbackLobbyDialog::refreshSeatMeta(quint64 userId, const QString& statusH
 
 void RollbackLobbyDialog::onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts)
 {
+    // Retry progress is first-contact feedback. Once a seat has a number the
+    // number *is* the display — a routine re-check that needs a second burst
+    // (typical right after a match, while the peer reclaims their socket)
+    // shouldn't churn it through amber every time.
+    if (m_client && m_client->measuredPingMs(userId) >= 0)
+        return;
     refreshSeatMeta(userId, seatProbeStatusHtml(attempt, maxAttempts, false, isDarkTheme()));
+}
+
+void RollbackLobbyDialog::onPingProbeSoftFailed(quint64 userId)
+{
+    // Clear any retry text; with no status the seat renders the cached
+    // measurement. The client escalates to onPingProbeFailed if the next
+    // series also dies, so a real outage still surfaces within two cycles.
+    refreshSeatMeta(userId, QString());
 }
 
 void RollbackLobbyDialog::onPingProbeFailed(quint64 userId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -327,6 +327,37 @@ namespace
         if (bold) f.setBold(true);
         w->setFont(f);
     }
+
+    // Column-0 role carrying "this player is searching for a match" for the
+    // sort override below. Qt::UserRole itself already carries the user id.
+    constexpr int kSearchingSortRole = Qt::UserRole + 1;
+
+    // Player-list row that pins searching players to the top of the list no
+    // matter which column or direction the user sorts by. Qt places items
+    // that compare "less" first in ascending order and last in descending,
+    // so the priority comparison pre-inverts on descending to land searching
+    // rows on top either way. Ties (both searching, or neither) fall through
+    // to the normal column comparison, so the user's chosen sort still
+    // orders each group internally.
+    class PlayerListItem : public QTreeWidgetItem
+    {
+    public:
+        using QTreeWidgetItem::QTreeWidgetItem;
+
+        bool operator<(const QTreeWidgetItem& other) const override
+        {
+            const bool a = data(0, kSearchingSortRole).toBool();
+            const bool b = other.data(0, kSearchingSortRole).toBool();
+            if (a != b)
+            {
+                const Qt::SortOrder order = treeWidget()
+                    ? treeWidget()->header()->sortIndicatorOrder()
+                    : Qt::AscendingOrder;
+                return order == Qt::AscendingOrder ? a : b;
+            }
+            return QTreeWidgetItem::operator<(other);
+        }
+    };
 } // namespace
 
 // ──────────────────────────────────────────────────────────────────────
@@ -2139,7 +2170,7 @@ void RollbackLobbyDialog::onPresenceFull()
     m_userItems.clear();
     for (auto it = m_client->users().constBegin(); it != m_client->users().constEnd(); ++it)
     {
-        auto* row = new QTreeWidgetItem(m_playersTree);
+        auto* row = new PlayerListItem(m_playersTree);
         refreshPlayerRow(row, it.value());
         m_userItems.insert(it.key(), row);
     }
@@ -2152,9 +2183,14 @@ void RollbackLobbyDialog::onUserAdded(quint64 userId)
     auto it = users.constFind(userId);
     if (it == users.constEnd()) return;
 
-    auto* row = new QTreeWidgetItem(m_playersTree);
+    auto* row = new PlayerListItem(m_playersTree);
     refreshPlayerRow(row, it.value());
     m_userItems.insert(userId, row);
+    // A user can join already searching (quick-match from the launcher);
+    // make sure the priority placement applies from their first paint.
+    if (it.value().state == QLatin1String("searching"))
+        m_playersTree->sortItems(m_playersTree->header()->sortIndicatorSection(),
+                                 m_playersTree->header()->sortIndicatorOrder());
     updateServerMeta();
 }
 
@@ -2174,7 +2210,14 @@ void RollbackLobbyDialog::onUserUpdated(quint64 userId)
     const auto& users = m_client->users();
     auto userIt = users.constFind(userId);
     if (userIt == users.constEnd()) return;
+    const bool wasSearching = it.value()->data(0, kSearchingSortRole).toBool();
     refreshPlayerRow(it.value(), userIt.value());
+    // Qt only re-sorts when data in the current sort column changes; a state
+    // flip doesn't touch the Region column, so a viewer sorted by Region
+    // would never see the row move. Force the pass on the transition.
+    if (it.value()->data(0, kSearchingSortRole).toBool() != wasSearching)
+        m_playersTree->sortItems(m_playersTree->header()->sortIndicatorSection(),
+                                 m_playersTree->header()->sortIndicatorOrder());
 }
 
 void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyClient::LobbyUser& u)
@@ -2191,6 +2234,7 @@ void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyCli
         item->setForeground(0, QColor(dark ? QStringLiteral("#4aa3ff")
                                            : QStringLiteral("#0078D7")));
     }
+    item->setData(0, kSearchingSortRole, u.state == QLatin1String("searching"));
     item->setText(1, stateGlyph(u.state));
     item->setForeground(1, QColor(stateHex(u.state, dark)));
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -40,6 +40,8 @@
 
 #include <QApplication>
 #include <QPalette>
+#include <QStyledItemDelegate>
+#include <QPainter>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QSplitter>
@@ -332,6 +334,12 @@ namespace
     // sort override below. Qt::UserRole itself already carries the user id.
     constexpr int kSearchingSortRole = Qt::UserRole + 1;
 
+    // Column-2 roles backing the painted Ping column (see PlayersItemDelegate).
+    constexpr int kPingMsRole       = Qt::UserRole + 2; // int; -1 = unknown
+    constexpr int kPingEstimateRole = Qt::UserRole + 3; // value is a region estimate
+    constexpr int kWirelessRole     = Qt::UserRole + 4; // peer self-reports wifi/cellular
+    constexpr int kShowPingRole     = Qt::UserRole + 5; // false for the self row
+
     // Player-list row that pins searching players to the top of the list no
     // matter which column or direction the user sorts by. Qt places items
     // that compare "less" first in ascending order and last in descending,
@@ -355,7 +363,105 @@ namespace
                     : Qt::AscendingOrder;
                 return order == Qt::AscendingOrder ? a : b;
             }
+            // The Ping column has no cell text (the delegate paints bars), so
+            // sort it numerically via the backing role. Unknown (-1) sinks
+            // below any real value in ascending order.
+            if (treeWidget() && treeWidget()->sortColumn() == 2)
+            {
+                const int msA = data(2, kPingMsRole).toInt();
+                const int msB = other.data(2, kPingMsRole).toInt();
+                const int kA = msA < 0 ? (1 << 30) : msA;
+                const int kB = msB < 0 ? (1 << 30) : msB;
+                if (kA != kB)
+                    return kA < kB;
+            }
             return QTreeWidgetItem::operator<(other);
+        }
+    };
+
+    // Paints the players list: column 0 gets its decoration (the country
+    // flag) moved to the RIGHT edge of the name cell, and column 2 has no
+    // text at all — it's drawn as Fightcade-style signal bars. Three bars
+    // lit = good, two = fair, one = rough, matching pingHex()'s tiers so
+    // the bars and every "N ms" elsewhere always tell the same story. A
+    // value that is only a region estimate draws translucent until a real
+    // measurement replaces it, and a peer who self-reports a wireless
+    // transport gets a warning "!" over the bars.
+    class PlayersItemDelegate : public QStyledItemDelegate
+    {
+    public:
+        using QStyledItemDelegate::QStyledItemDelegate;
+
+    protected:
+        void initStyleOption(QStyleOptionViewItem* option, const QModelIndex& index) const override
+        {
+            QStyledItemDelegate::initStyleOption(option, index);
+            if (index.column() == 0)
+                option->decorationPosition = QStyleOptionViewItem::Right;
+        }
+
+        void paint(QPainter* painter, const QStyleOptionViewItem& option,
+                   const QModelIndex& index) const override
+        {
+            if (index.column() != 2)
+            {
+                QStyledItemDelegate::paint(painter, option, index);
+                return;
+            }
+
+            // Draw the item chrome (selection, hover, alternate stripe) with
+            // no content, then paint the bars over it.
+            QStyleOptionViewItem opt = option;
+            initStyleOption(&opt, index);
+            opt.text.clear();
+            opt.icon = QIcon();
+            QStyle* style = opt.widget ? opt.widget->style() : QApplication::style();
+            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+
+            if (!index.data(kShowPingRole).toBool())
+                return;
+
+            const int  ping     = index.data(kPingMsRole).toInt();
+            const bool estimate = index.data(kPingEstimateRole).toBool();
+            const bool wireless = index.data(kWirelessRole).toBool();
+            const int  level    = ping < 0 ? 0 : ping <= 60 ? 3 : ping <= 120 ? 2 : 1;
+
+            QColor lit(pingHex(ping));
+            if (estimate)
+                lit.setAlpha(150);
+            QColor unlit = opt.palette.text().color();
+            unlit.setAlpha(56);
+
+            constexpr int barW = 4, gap = 2, maxH = 14;
+            const QRect r = opt.rect;
+            const int baseY = r.center().y() + maxH / 2;
+            const int x0 = r.x() + 8;
+
+            painter->save();
+            painter->setRenderHint(QPainter::Antialiasing, false);
+            painter->setPen(Qt::NoPen);
+            for (int i = 0; i < 3; i++)
+            {
+                const int h = maxH * (i + 1) / 3;
+                painter->setBrush(i < level ? lit : unlit);
+                painter->drawRect(x0 + i * (barW + gap), baseY - h, barW, h);
+            }
+
+            if (wireless)
+            {
+                QFont f = opt.font;
+                f.setBold(true);
+                f.setPointSizeF(f.pointSizeF() + 1.0);
+                painter->setFont(f);
+                // Overlapping the top-right of the bars, with a 1px shadow so
+                // it stays readable over a lit bar in either theme.
+                const QRect exclR(x0 + 2 * (barW + gap), r.y(), 12, r.height());
+                painter->setPen(QColor(0, 0, 0, 140));
+                painter->drawText(exclR.translated(1, 1), Qt::AlignLeft | Qt::AlignVCenter, QStringLiteral("!"));
+                painter->setPen(QColor(0xf0, 0xa0, 0x30));
+                painter->drawText(exclR, Qt::AlignLeft | Qt::AlignVCenter, QStringLiteral("!"));
+            }
+            painter->restore();
         }
     };
 } // namespace
@@ -446,7 +552,7 @@ RollbackLobbyDialog::~RollbackLobbyDialog()
     // without a close event.
     QSettings s("RMG-K", "n02");
     if (m_playersTree)
-        s.setValue(QString("RollbackLobby/PlayersHeaderState.v2.c%1").arg(m_playersTree->columnCount()),
+        s.setValue(QString("RollbackLobby/PlayersHeaderState.v3.c%1").arg(m_playersTree->columnCount()),
                    m_playersTree->header()->saveState());
     if (m_roomsTree)
         s.setValue(QString("RollbackLobby/RoomsHeaderState.c%1").arg(m_roomsTree->columnCount()),
@@ -1305,13 +1411,15 @@ QWidget* RollbackLobbyDialog::buildPlayersColumn()
 
     m_playersTree = new QTreeWidget(card);
     m_playersTree->setObjectName("PlayersTree");
-    m_playersTree->setHeaderLabels({ "Player", "State", "Region" });
+    m_playersTree->setHeaderLabels({ "Player", "State", "Ping" });
     m_playersTree->setRootIsDecorated(false);
     m_playersTree->setSortingEnabled(true);
 	m_playersTree->sortItems(0, Qt::AscendingOrder);
     m_playersTree->setAlternatingRowColors(true);
     m_playersTree->setFrameShape(QFrame::NoFrame);
     m_playersTree->setUniformRowHeights(true);
+    // Right-edge flags in the name column + painted signal bars in Ping.
+    m_playersTree->setItemDelegate(new PlayersItemDelegate(m_playersTree));
     // Column sizing is hand-rolled in clampPlayersColumns rather than using a
     // Qt Stretch section. Qt resizes a column via the divider on its RIGHT
     // edge, so with three columns only two dividers physically exist: Player|
@@ -1332,31 +1440,31 @@ QWidget* RollbackLobbyDialog::buildPlayersColumn()
         const QFontMetrics fm(m_playersTree->header()->font());
         const int pad = 20; // section margins
         const int stateWidth  = fm.horizontalAdvance(QStringLiteral("Spectating")) + pad;
-        // Text width with a slightly tighter margin than State's — the sort
-        // indicator renders above the label in this header style, so nothing
-        // else needs the horizontal room.
-        const int regionWidth = fm.horizontalAdvance(QStringLiteral("Region")) + pad - 4;
+        // Wide enough for the painted bars + wireless "!" (≈36px) and the
+        // header label, whichever is larger; the sort indicator renders above
+        // the label in this header style, so nothing else needs the room.
+        const int pingWidth = std::max(fm.horizontalAdvance(QStringLiteral("Ping")) + pad - 4, 40);
         m_playersTree->setColumnWidth(1, stateWidth);
 
         // The column count is part of the key: restoring a state saved for a
         // different column layout half-applies and breaks the header (missing
-        // section dividers, wrong stretch section). v2: the v1 layout had no
-        // stretch section and a shrink-only clamp, so saved v1 states carry
-        // squeezed columns and a dead gap — leave them orphaned rather than
-        // restoring the broken shape into the fixed layout.
+        // section dividers, wrong stretch section). v3: column 2 changed
+        // meaning (Region flag → painted Ping bars), so v2 states carry a
+        // stale sort choice and width for a column that no longer exists —
+        // leave them orphaned rather than restoring them into the new shape.
         QSettings s("RMG-K", "n02");
-        const QString key = QString("RollbackLobby/PlayersHeaderState.v2.c%1").arg(m_playersTree->columnCount());
+        const QString key = QString("RollbackLobby/PlayersHeaderState.v3.c%1").arg(m_playersTree->columnCount());
         const QByteArray headerState = s.value(key).toByteArray();
         if (!headerState.isEmpty())
             m_playersTree->header()->restoreState(headerState);
         // restoreState can resurrect per-section modes and stale widths; re-pin
-        // ours AFTER it. Region's width is layout policy, not a user
+        // ours AFTER it. Ping's width is layout policy, not a user
         // preference — always the computed value, never the saved one. State's
         // saved width is the one thing that should survive the round trip;
         // Player is refit by the first viewport Resize regardless.
         m_playersTree->header()->setSectionResizeMode(QHeaderView::Interactive);
         m_playersTree->header()->setSectionResizeMode(2, QHeaderView::Fixed);
-        m_playersTree->setColumnWidth(2, regionWidth);
+        m_playersTree->setColumnWidth(2, pingWidth);
     }
     // The columns are clamped to the viewport (clampPlayersColumns), so a
     // horizontal scrollbar can never be needed — turning it off also stops Qt
@@ -2244,22 +2352,17 @@ void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyCli
     else
         item->setToolTip(1, QString());
 
-    // Region column: country flag only (Fightcade-style — the server geolocates
-    // the ISO country code, we render the bundled SVG). No text label: the
-    // region is a coarse server-side bucket that often disagrees with the
-    // geolocated country sitting right next to it, so printing both invited the
-    // reader to trust a mismatch. The full region still lives in the tooltip.
-    // Old servers don't send a country, so fall back to the region's emoji
-    // badge — still a glyph, not an abbreviation.
-    // U+2014 EM DASH — using QChar avoids any file-encoding ambiguity in
-    // the literal.
-    const QString dash = QString(QChar(0x2014));
+    // Country flag rides the right edge of the NAME cell (the delegate flips
+    // column 0's decorationPosition), Fightcade-style. The server geolocates
+    // the ISO country code; we render the bundled SVG. No flag for anonymous
+    // users — and deliberately no region-badge fallback for them either,
+    // that's the coarse location leak the option exists to prevent. Old
+    // servers that send no country just show no flag.
     const QString flagResource = QString(":/flags/%1.svg").arg(u.country.toLower());
     QString countryName;
-    if (!u.country.isEmpty() && QFile::exists(flagResource))
+    if (!u.anonymous && !u.country.isEmpty() && QFile::exists(flagResource))
     {
-        item->setIcon(2, QIcon(flagResource));
-        item->setText(2, QString());
+        item->setIcon(0, QIcon(flagResource));
         const QLocale::Territory territory = QLocale::codeToTerritory(u.country);
         countryName = (territory != QLocale::AnyTerritory)
             ? QLocale::territoryToString(territory)
@@ -2267,9 +2370,30 @@ void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyCli
     }
     else
     {
-        item->setIcon(2, QIcon());
-        item->setText(2, u.region.isEmpty() ? dash : LobbyRegions::flagFor(u.region));
+        item->setIcon(0, QIcon());
     }
+
+    // Ping column: roles only — PlayersItemDelegate paints the signal bars.
+    // A real measurement wins; the region estimate stands in translucently
+    // until one lands; -1 draws the empty skeleton. Self shows no bars. The
+    // wireless flag drives the "!" warning over the bars (wifi/cellular —
+    // where the frame spikes come from; anonymity doesn't hide it, since the
+    // whole point of surfacing it is match-quality risk).
+    const bool isSelf = (u.id == m_client->selfUserId());
+    const int measured = isSelf ? -1 : m_client->measuredPingMs(u.id);
+    const int estimate = LobbyRegions::estimatedRttMs(m_client->selfRegion(), u.region);
+    const int effective = isSelf ? -1
+        : measured >= 0 ? measured
+        : estimate > 0  ? estimate
+                        : -1;
+    item->setText(2, QString());
+    item->setIcon(2, QIcon());
+    item->setData(2, kShowPingRole, !isSelf);
+    item->setData(2, kPingMsRole, effective);
+    item->setData(2, kPingEstimateRole, measured < 0);
+    item->setData(2, kWirelessRole,
+                  u.connection == QLatin1String("wifi") ||
+                  u.connection == QLatin1String("cellular"));
 
     // Built as lines so an absent field just doesn't contribute, rather than
     // leaving a stray separator. The region is deliberately not among them: it's
@@ -2290,22 +2414,17 @@ void RollbackLobbyDialog::refreshPlayerRow(QTreeWidgetItem* item, const LobbyCli
         tipLines << QString("Connection: %1").arg(connLabel);
     if (!u.clientVersion.isEmpty())
         tipLines << QString("Build: %1").arg(u.clientVersion);
-    if (u.id != m_client->selfUserId())
+    if (!isSelf)
     {
-        const int measured = m_client->measuredPingMs(u.id);
+        // The bars give the tier; the tooltip gives the number. An estimate is
+        // hedged and only stands in until a real UDP probe lands — say what
+        // makes it real rather than implying a measurement is on its way.
         if (measured >= 0)
             tipLines << QString("Ping: %1 ms").arg(measured);
         else
-        {
-            // Still a region-derived number, but it's hedged as an estimate and
-            // only stands in until a real UDP probe lands — unlike a region
-            // label, it isn't asserting where the player is. Nothing probes
-            // lobby users in the background any more, so say what makes it real
-            // rather than implying a measurement is already on its way.
-            const int rtt = LobbyRegions::estimatedRttMs(m_client->selfRegion(), u.region);
-            tipLines << (rtt > 0 ? QString("Ping: ~%1 ms (estimate — click to measure)").arg(rtt)
-                                 : QStringLiteral("Ping: click to measure"));
-        }
+            tipLines << (estimate > 0
+                ? QString("Ping: ~%1 ms (estimate — click to measure)").arg(estimate)
+                : QStringLiteral("Ping: click to measure"));
     }
     const QString tip = tipLines.join(QChar('\n'));
     item->setToolTip(0, tip);

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -4059,7 +4059,21 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     }
     appendChatSystemLine(CHANNEL_ROOM, "Pre-match sync complete.");
 
-    m_client->releaseUdpAnchor();
+    // n02-style shared transport: lend the live anchor socket to GekkoNet
+    // instead of releasing the port for it to rebind. The port and every
+    // peer's NAT mapping to us survive the match; reclaim happens through the
+    // existing reopenUdpAnchor calls on the match-end paths. Falls back to
+    // the old release/rebind handoff if the descriptor can't be obtained.
+    const qintptr anchorFd = m_client->lendAnchorToMatch();
+    if (anchorFd != -1)
+    {
+        rmgk_gekko::set_external_socket(static_cast<uintptr_t>(anchorFd));
+    }
+    else
+    {
+        rmgk_gekko::clear_external_socket();
+        m_client->releaseUdpAnchor();
+    }
 
     {
         char buf[640];

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -171,6 +171,10 @@ private slots:
     // visible in the room rather than looking like a stalled Start button.
     void onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts);
     void onPingProbeFailed(quint64 userId);
+    // First consecutive miss on a peer we've measured before — treat as
+    // transient: drop any retry text and let the seat fall back to the last
+    // measurement instead of flashing unreachable.
+    void onPingProbeSoftFailed(quint64 userId);
     // Repaint one seat's right-hand meta cell (ping / retry / unreachable).
     void refreshSeatMeta(quint64 userId, const QString& statusHtml);
     void onPingMeasured(quint64 userId, int rttMs);

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -251,7 +251,14 @@ SettingsDialog::SettingsDialog(QWidget *parent, QString file) : QDialog(parent)
         "Write a detailed lobby_ping_*.log file (in the Logs folder) tracing lobby ping\n"
         "probes and NAT hole-punching. Only useful when debugging connection problems\n"
         "with another player. Applies the next time you connect to the lobby.");
+    this->rollbackHideLocationCheckBox = new QCheckBox("Hide my location from other players", rollbackTab);
+    this->rollbackHideLocationCheckBox->setToolTip(
+        "Your row in the netplay lobby shows no country flag, and no country in its\n"
+        "hover tooltip, for everyone on the server. Region-based ping estimates still\n"
+        "work. Players you actually play with still exchange connection addresses —\n"
+        "this hides the flag, not your traffic. Applies the next time you connect.");
     rollbackLayout->addWidget(this->rollbackEnableLocalTestingCheckBox);
+    rollbackLayout->addWidget(this->rollbackHideLocationCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackVerboseStatsCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackStallDiagnosticsCheckBox);
     rollbackLoggingLayout->addWidget(this->rollbackPacingTraceCheckBox);
@@ -1002,6 +1009,7 @@ void SettingsDialog::loadRollbackSettings(void)
     this->rollbackVerbosePifInputLoggingCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_VerbosePifInputLogging));
     this->rollbackVerboseGlideInputLoggingCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_VerboseGlideInputLogging));
     this->rollbackPingDiagnosticsCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_PingDiagnostics));
+    this->rollbackHideLocationCheckBox->setChecked(CoreSettingsGetBoolValue(SettingsID::Rollback_HideLocation));
 }
 
 void SettingsDialog::loadDefaultCoreSettings(void)
@@ -1221,6 +1229,7 @@ void SettingsDialog::loadDefaultRollbackSettings(void)
     this->rollbackVerbosePifInputLoggingCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_VerbosePifInputLogging));
     this->rollbackVerboseGlideInputLoggingCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_VerboseGlideInputLogging));
     this->rollbackPingDiagnosticsCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_PingDiagnostics));
+    this->rollbackHideLocationCheckBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Rollback_HideLocation));
 }
 
 void SettingsDialog::saveSettings(void)
@@ -1498,6 +1507,7 @@ void SettingsDialog::saveRollbackSettings(void)
     CoreSettingsSetValue(SettingsID::Rollback_VerbosePifInputLogging, this->rollbackVerbosePifInputLoggingCheckBox->isChecked());
     CoreSettingsSetValue(SettingsID::Rollback_VerboseGlideInputLogging, this->rollbackVerboseGlideInputLoggingCheckBox->isChecked());
     CoreSettingsSetValue(SettingsID::Rollback_PingDiagnostics, this->rollbackPingDiagnosticsCheckBox->isChecked());
+    CoreSettingsSetValue(SettingsID::Rollback_HideLocation, this->rollbackHideLocationCheckBox->isChecked());
 }
 
 void SettingsDialog::commonHotkeySettings(SettingsDialogAction action)

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
@@ -75,6 +75,7 @@ class SettingsDialog : public QDialog, private Ui::SettingsDialog
     QCheckBox* rollbackVerbosePifInputLoggingCheckBox = nullptr;
     QCheckBox* rollbackVerboseGlideInputLoggingCheckBox = nullptr;
     QCheckBox* rollbackPingDiagnosticsCheckBox = nullptr;
+    QCheckBox* rollbackHideLocationCheckBox = nullptr;
 
     std::vector<CorePlugin> pluginList;
 


### PR DESCRIPTION
## The transport model

Replaces the match-boundary socket handoff (lobby releases its UDP port, GekkoNet rebinds it) with n02-style lending: one socket serves lobby and game for the whole session, so the port and every peer's NAT mapping to it never change hands. Every transport bug of the past weeks lived inside the old handoff; this removes the handoff. Includes the pinned-port retry and passive-disconnect reset that led up to it.

Four follow-up fixes, all field-confirmed across multi-hour test sessions:
- close_session no longer wipes the just-lent descriptor (every lobby match failed to start with a bind error without this)
- the anchor socket keeps receiving after a match: unconditional reclaim drain + notifier-independent 100ms poll (Qt's read notification dies while the socket is lent and only a read revives it — the 50/50 'deaf until restart' coin-flip from field logs), plus SIO_UDP_CONNRESET so one departed peer can't poison receives
- no polling of an unbound socket (qWarning spam, visible on Linux)
- connect stages narrated to the log so a stalled connect names its stage

## Ping display

- Sticky seat pings: probes are cancelled silently when the socket is lent (they can't complete and were latching a false red 'unreachable' for entire matches), requestPingProbe no-ops during matches, and an established peer gets one free miss before 'unreachable' shows (two-strike rule). Field-confirmed: 77 RTTs / 0 failures across 8 lend cycles including an hour-long match.
- Searching players pin to the top of the player list regardless of sort column/direction.

## Features

- Fightcade-style player list: country flag on the right edge of the name cell, Region column replaced by painted ping signal bars (3/2/1 on the existing pingHex tiers, translucent while estimated), amber '!' over the bars for wifi/cellular peers.
- Connection-type detection actually works now, via QNetworkInterface on the connected socket's local address — QNetworkInformation's transport feature is compiled out of MinGW Qt and the AppImage never bundled its plugin, so the old path had never produced data on either shipped build.
- 'Hide my location from other players' (Rollback settings): HELLO carries an anonymous flag; server strips country and relays the flag. Client-side is inert until the rmgk-lobby anonymous-location branch deploys.
- Sparse seat rooms (P1+P2+P4) no longer black-screen: the GekkoNet session is sized by actor count, not highest seat — provably identical for contiguous rooms. All players in a sparse room must be on a build with this fix.

