### PR TITLE
Replace rollback lobby custom UDP punching with ICE and add per-player frame delay

### DIFF
--- a/GekkoNet-main/GekkoLib/src/backend.cpp
+++ b/GekkoNet-main/GekkoLib/src/backend.cpp
@@ -932,7 +932,10 @@ f32 Gekko::AdvantageHistory::GetAverageAdvantage()
 	f32 avg_local = sum_local / HISTORY_SIZE;
 	f32 avg_remote = sum_remote / HISTORY_SIZE;
 
-	// return the frames ahead (halved: each peer corrects its share of the gap)
+	// Return the signed error from the delay-balanced frame target (halved:
+	// each peer corrects its share). GameSession folds each side's local input
+	// delay into these samples, so zero may intentionally mean the peers are on
+	// different numeric simulation frames.
 	return (avg_local - avg_remote) / 2.f;
 }
 

--- a/GekkoNet-main/GekkoLib/src/game_session.cpp
+++ b/GekkoNet-main/GekkoLib/src/game_session.cpp
@@ -2,6 +2,27 @@
 
 #include <cassert>
 
+namespace {
+
+// Input frames already include the sender's delay. Adding the receiver's local
+// delay converts the raw simulation-frame gap into an error from the desired
+// delay-balanced timeline:
+//
+//     local_frame + local_delay == remote_frame + remote_delay
+//
+// Therefore a lower-delay peer runs numerically ahead by the delay difference.
+// If both peers are still on the same simulation frame, the lower-delay peer is
+// reported behind and the existing time-sync pacing advances it toward that
+// target. This makes each player's own delay determine how late remote input may
+// arrive at that player, rather than imposing their choice on their opponent.
+constexpr Frame DelayBalancedAdvantage(Frame current_frame, Frame remote_input_frame,
+                                       Frame local_delay)
+{
+    return current_frame - remote_input_frame + local_delay;
+}
+
+} // namespace
+
 Gekko::GameSession::GameSession()
 {
 	_host = nullptr;
@@ -483,7 +504,8 @@ void Gekko::GameSession::HandleReceivedInputs()
                     int current_idx = i - min_frame;
                     u8* input = input_q[current_idx].get();
                     _sync.AddRemoteInput(handle, input, i);
-                    const i8 local_adv = (i8)(current_frame - i - local_delay);
+                    const i8 local_adv =
+                        (i8)DelayBalancedAdvantage(current_frame, i, local_delay);
                     _msg.SendInputAck(handle, i, local_adv);
                 }
             }
@@ -510,7 +532,8 @@ void Gekko::GameSession::SendLocalInputs()
                 const Frame current_frame = _sync.GetCurrentFrame();
                 for (auto& remote : _msg.remotes) {
                     if (remote->GetStatus() == Connected) {
-                        const i8 local_adv = (i8)(current_frame - _sync.GetLastReceivedFrom(remote->handle) - (Frame)delay);
+                        const i8 local_adv = (i8)DelayBalancedAdvantage(
+                            current_frame, _sync.GetLastReceivedFrom(remote->handle), (Frame)delay);
                         remote->adv_history.SetLocalAdvantage(local_adv);
                         remote->adv_history.Update(frame);
                     }

--- a/Source/3rdParty/CMakeLists.txt
+++ b/Source/3rdParty/CMakeLists.txt
@@ -5,6 +5,12 @@ include(ExternalProject)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if (NETPLAY AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libjuice/CMakeLists.txt")
+    set(NO_SERVER ON CACHE BOOL "Disable the unused libjuice STUN/TURN server" FORCE)
+    set(NO_TESTS ON CACHE BOOL "Disable libjuice tests in the RMG build" FORCE)
+    add_subdirectory(libjuice EXCLUDE_FROM_ALL)
+endif()
+
 set(M64P_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/mupen64plus-core)
 if(WIN32)
     set(SO_EXT "dll")

--- a/Source/3rdParty/SDL_net/src/SDL_net.c
+++ b/Source/3rdParty/SDL_net/src/SDL_net.c
@@ -41,11 +41,11 @@ typedef SOCKET Socket;
 typedef int SockLen;
 typedef SOCKADDR_STORAGE AddressStorage;
 
-static int write(SOCKET s, const void *buf, size_t count) {
+static int SocketWrite(SOCKET s, const void *buf, size_t count) {
     return send(s, (const char *)buf, (int) count, 0);
 }
 
-static int read(SOCKET s, char *buf, size_t count) {
+static int SocketRead(SOCKET s, char *buf, size_t count) {
     WSABUF wsabuf;
     wsabuf.buf = buf;
     wsabuf.len = (ULONG) count;
@@ -191,6 +191,8 @@ static int WindowsPoll(struct pollfd *fds, unsigned int nfds, int timeout)
 typedef int Socket;
 typedef socklen_t SockLen;
 typedef struct sockaddr_storage AddressStorage;
+#define SocketWrite write
+#define SocketRead read
 #endif
 
 typedef enum NET_SocketType
@@ -1401,7 +1403,7 @@ static bool PumpStreamSocket(NET_StreamSocket *sock)
             return true;  // streams are reliable, so instead of packet loss, we introduce lag.
         }
 
-        const int bw = (int) write(sock->handle, sock->pending_output_buffer, sock->pending_output_len);
+        const int bw = (int) SocketWrite(sock->handle, sock->pending_output_buffer, sock->pending_output_len);
         if (bw < 0) {
             const int err = LastSocketError();
             return WouldBlock(err) ? true : SetSocketErrorBool("Failed to write to socket", err);
@@ -1431,7 +1433,7 @@ bool NET_WriteToStreamSocket(NET_StreamSocket *sock, const void *buf, int buflen
     if (sock->pending_output_len == 0) {  // nothing queued? See if we can just send this without queueing.
         // don't ever try to send directly if simulating packet loss; we'll always queue and mess with it then.
         if (sock->percent_loss == 0) {
-            const int bw = (int) write(sock->handle, buf, buflen);
+            const int bw = (int) SocketWrite(sock->handle, buf, buflen);
             if (bw < 0) {
                 const int err = LastSocketError();
                 if (!WouldBlock(err)) {
@@ -1529,7 +1531,7 @@ int NET_ReadFromStreamSocket(NET_StreamSocket *sock, void *buf, int buflen)
         return 0;  // nothing to do.
     }
 
-    const int br = (int) read(sock->handle, buf, buflen);
+    const int br = (int) SocketRead(sock->handle, buf, buflen);
     if (br == 0) {
         SDL_SetError("End of stream");
         return -1;

--- a/Source/3rdParty/libjuice/.clang-format
+++ b/Source/3rdParty/libjuice/.clang-format
@@ -1,0 +1,7 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+ColumnLimit: 100
+

--- a/Source/3rdParty/libjuice/.clang-tidy
+++ b/Source/3rdParty/libjuice/.clang-tidy
@@ -1,0 +1,44 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-security.insecureAPI.strcpy'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle:     none
+CheckOptions:
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           'false'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             cert-err33-c.CheckedFunctions
+    value:           '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           'false'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           'false'
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           'false'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+...
+

--- a/Source/3rdParty/libjuice/.editorconfig
+++ b/Source/3rdParty/libjuice/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+

--- a/Source/3rdParty/libjuice/CMakeLists.txt
+++ b/Source/3rdParty/libjuice/CMakeLists.txt
@@ -1,0 +1,260 @@
+cmake_minimum_required (VERSION 3.10)
+project (libjuice
+	VERSION 1.7.3
+	LANGUAGES C)
+set(PROJECT_DESCRIPTION "UDP Interactive Connectivity Establishment (ICE) library")
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(USE_NETTLE "Use Nettle for hash functions" OFF)
+option(NO_SERVER "Disable server support" OFF)
+option(NO_TESTS "Disable tests build" OFF)
+option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+option(FUZZER "Enable oss-fuzz fuzzing" OFF)
+option(CLANG_TIDY "Enable clang-tidy" OFF)
+
+# Mitigations
+option(DISABLE_CONSENT_FRESHNESS "Disable RFC 7675 Consent Freshness" OFF)
+option(ENABLE_LOCALHOST_ADDRESS "List localhost addresses in candidates" OFF)
+option(ENABLE_LOCAL_ADDRESS_TRANSLATION "Translate local addresses to localhost" OFF)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+
+include(GNUInstallDirs)
+
+if(WIN32)
+	add_definitions(-DWIN32_LEAN_AND_MEAN)
+	if (MSVC)
+		add_definitions(-DNOMINMAX)
+		add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+	endif()
+endif()
+
+if(CLANG_TIDY)
+	set(CMAKE_C_CLANG_TIDY clang-tidy)
+endif()
+
+set(LIBJUICE_SOURCES
+	${CMAKE_CURRENT_SOURCE_DIR}/src/addr.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/agent.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/crc32.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/const_time.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_poll.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_thread.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_mux.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/base64.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/hash.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/hmac.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/ice.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/juice.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/log.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/random.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/server.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/stun.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/timestamp.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/tcp.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/turn.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/udp.c
+)
+source_group("Source Files" FILES "${LIBJUICE_SOURCES}")
+
+set(LIBJUICE_HEADERS
+	${CMAKE_CURRENT_SOURCE_DIR}/include/juice/juice.h
+)
+source_group("Header Files" FILES "${LIBJUICE_HEADERS}")
+
+set(TESTS_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/main.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/crc32.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/base64.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-multiple.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-no-host.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-unhandle.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/gathering.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/turn.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/thread.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/mux.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/notrickle.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/server.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/conflict.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/bind.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/ufrag.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/tcp.c
+)
+source_group("Test Files" FILES "${TESTS_SOURCES}")
+
+set(FUZZER_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/fuzzer/fuzzer.c
+)
+source_group("Fuzzer Files" FILES "${FUZZER_SOURCES}")
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+add_library(juice ${LIBJUICE_SOURCES})
+set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+target_include_directories(juice PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+target_include_directories(juice PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
+target_include_directories(juice PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_compile_definitions(juice PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
+target_link_libraries(juice PRIVATE Threads::Threads)
+
+add_library(juice-static STATIC EXCLUDE_FROM_ALL ${LIBJUICE_SOURCES})
+set_target_properties(juice-static PROPERTIES VERSION ${PROJECT_VERSION})
+target_include_directories(juice-static PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
+target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_compile_definitions(juice-static PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
+target_link_libraries(juice-static PRIVATE Threads::Threads)
+
+if(WIN32)
+	target_link_libraries(juice PRIVATE
+		ws2_32 # winsock2
+		bcrypt)
+	target_link_libraries(juice-static PRIVATE
+		ws2_32 # winsock2
+		bcrypt)
+endif()
+
+if (USE_NETTLE)
+	find_package(Nettle REQUIRED)
+    target_compile_definitions(juice PRIVATE USE_NETTLE=1)
+    target_link_libraries(juice PRIVATE Nettle::Nettle)
+    target_compile_definitions(juice-static PRIVATE USE_NETTLE=1)
+    target_link_libraries(juice-static PRIVATE Nettle::Nettle)
+else()
+    target_compile_definitions(juice PRIVATE USE_NETTLE=0)
+    target_compile_definitions(juice-static PRIVATE USE_NETTLE=0)
+endif()
+
+if (NO_SERVER)
+	target_compile_definitions(juice PRIVATE NO_SERVER)
+	target_compile_definitions(juice-static PRIVATE NO_SERVER)
+endif()
+
+if(APPLE)
+	# This seems to be necessary on MacOS
+	target_include_directories(juice PRIVATE /usr/local/include)
+	target_include_directories(juice-static PRIVATE /usr/local/include)
+endif()
+
+set_target_properties(juice PROPERTIES EXPORT_NAME LibJuice)
+add_library(LibJuice::LibJuice ALIAS juice)
+
+set_target_properties(juice-static PROPERTIES EXPORT_NAME LibJuiceStatic)
+add_library(LibJuice::LibJuiceStatic ALIAS juice-static)
+
+install(TARGETS juice EXPORT LibJuiceTargets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(FILES ${LIBJUICE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/juice)
+
+# Export targets
+install(
+	EXPORT LibJuiceTargets
+	FILE LibJuiceTargets.cmake
+	NAMESPACE LibJuice::
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibJuiceConfig.cmake.in
+    ${CMAKE_BINARY_DIR}/LibJuiceConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+write_basic_package_version_file(
+    ${CMAKE_BINARY_DIR}/LibJuiceConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+# Export config and version files
+install(FILES
+	${CMAKE_BINARY_DIR}/LibJuiceConfig.cmake
+	${CMAKE_BINARY_DIR}/LibJuiceConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice)
+
+set_target_properties(juice PROPERTIES C_VISIBILITY_PRESET hidden)
+target_compile_definitions(juice PRIVATE JUICE_EXPORTS)
+if (NOT BUILD_SHARED_LIBS)
+	target_compile_definitions(juice PUBLIC JUICE_STATIC)
+endif()
+target_compile_definitions(juice-static PRIVATE JUICE_EXPORTS)
+target_compile_definitions(juice-static PUBLIC JUICE_STATIC)
+
+if(MSVC)
+	target_compile_options(juice PRIVATE /utf-8)
+	target_compile_options(juice-static PRIVATE /utf-8)
+else()
+	target_compile_options(juice PRIVATE -Wall -Wextra)
+	target_compile_options(juice-static PRIVATE -Wall -Wextra)
+endif()
+
+if(WARNINGS_AS_ERRORS)
+	if(MSVC)
+		target_compile_options(juice PRIVATE /WX)
+		target_compile_options(juice-static PRIVATE /WX)
+	else()
+		target_compile_options(juice PRIVATE -Werror)
+		target_compile_options(juice-static PRIVATE -Werror)
+	endif()
+endif()
+
+if(DISABLE_CONSENT_FRESHNESS)
+	target_compile_definitions(juice PRIVATE JUICE_DISABLE_CONSENT_FRESHNESS=1)
+	target_compile_definitions(juice-static PRIVATE JUICE_DISABLE_CONSENT_FRESHNESS=1)
+endif()
+
+if(ENABLE_LOCALHOST_ADDRESS)
+	target_compile_definitions(juice PRIVATE JUICE_ENABLE_LOCALHOST_ADDRESS=1)
+	target_compile_definitions(juice-static PRIVATE JUICE_ENABLE_LOCALHOST_ADDRESS=1)
+endif()
+
+if(ENABLE_LOCAL_ADDRESS_TRANSLATION)
+	target_compile_definitions(juice PRIVATE JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION=1)
+	target_compile_definitions(juice-static PRIVATE JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION=1)
+endif()
+
+# Tests
+if(NOT NO_TESTS)
+	add_executable(juice-tests ${TESTS_SOURCES})
+	target_include_directories(juice-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+	target_include_directories(juice-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
+
+	set_target_properties(juice-tests PROPERTIES
+		VERSION ${PROJECT_VERSION}
+		OUTPUT_NAME tests)
+
+	set_target_properties(juice-tests PROPERTIES
+		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libjuice.tests)
+
+	target_link_libraries(juice-tests juice Threads::Threads)
+
+	if(WIN32)
+		target_link_libraries(juice-tests ws2_32)
+	endif()
+endif()
+
+# Fuzzer
+if(FUZZER)
+	add_executable(stun-fuzzer ${FUZZER_SOURCES})
+	target_include_directories(stun-fuzzer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+	target_include_directories(stun-fuzzer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
+
+	set_target_properties(stun-fuzzer PROPERTIES OUTPUT_NAME fuzzer)
+	target_link_libraries(stun-fuzzer juice-static ${LIB_FUZZING_ENGINE})
+endif()

--- a/Source/3rdParty/libjuice/LICENSE
+++ b/Source/3rdParty/libjuice/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/Source/3rdParty/libjuice/README.md
+++ b/Source/3rdParty/libjuice/README.md
@@ -1,0 +1,109 @@
+# libjuice - UDP Interactive Connectivity Establishment
+
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-blue.svg)](https://www.mozilla.org/en-US/MPL/2.0/)
+[![Build and test](https://github.com/paullouisageneau/libjuice/actions/workflows/build.yml/badge.svg)](https://github.com/paullouisageneau/libjuice/actions/workflows/build.yml)
+[![Packaging status](https://repology.org/badge/tiny-repos/libjuice.svg)](https://repology.org/project/libjuice/versions)
+[![Latest packaged version](https://repology.org/badge/latest-versions/libjuice.svg)](https://repology.org/project/libjuice/versions)
+[![Gitter](https://badges.gitter.im/libjuice/community.svg)](https://gitter.im/libjuice/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Discord](https://img.shields.io/discord/903257095539925006?logo=discord)](https://discord.gg/jXAP8jp3Nn)
+
+libjuice :lemon::sweat_drops: (_JUICE is a UDP Interactive Connectivity Establishment library_) allows to open bidirectionnal User Datagram Protocol (UDP) streams with Network Address Translator (NAT) traversal.
+
+The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol, client-side and server-side, written in C without dependencies for multiple platforms, including GNU/Linux, Android, FreeBSD, Apple macOS, iOS, and Microsoft Windows. The client supports only a single component over UDP per session in a standard single-gateway network topology, as this should be sufficient for the majority of use cases nowadays.
+
+libjuice is licensed under MPL 2.0, see [LICENSE](https://github.com/paullouisageneau/libjuice/blob/master/LICENSE).
+
+libjuice is available on [AUR](https://aur.archlinux.org/packages/libjuice-git) and [vcpkg](https://vcpkg.io/en/getting-started). Bindings are available for [Rust](https://github.com/VollmondT/juice-rs).
+
+For a STUN/TURN server application based on libjuice, see [Violet](https://github.com/paullouisageneau/violet).
+
+## Compatibility
+
+The library implements a simplified full ICE agent ([RFC5245](https://www.rfc-editor.org/rfc/rfc5245.html) then [RFC8445](https://www.rfc-editor.org/rfc/rfc8445.html)) featuring:
+- STUN protocol ([RFC5389](https://www.rfc-editor.org/rfc/rfc5389.html) then [RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html))
+- TURN relaying ([RFC5766](https://www.rfc-editor.org/rfc/rfc5766.html) then [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html))
+- TCP candidates ([RFC6544](https://www.rfc-editor.org/rfc/rfc6544.html))
+- ICE Consent freshness ([RFC7675](https://www.rfc-editor.org/rfc/rfc7675.html))
+- ICE Patiently Awaiting Connectivity ([RFC 8863](https://www.rfc-editor.org/rfc/rfc8863.html))
+- SDP-based interface ([RFC8839](https://www.rfc-editor.org/rfc/rfc8839.html))
+- IPv4 and IPv6 dual-stack support
+- Optional multiplexing on a single UDP port
+
+The limitations compared to a fully-featured ICE agent are:
+- Only UDP is supported as transport protocol and other protocols are ignored.
+- Only one component is supported, which is sufficient for WebRTC Data Channels and multiplexed RTP+RTCP.
+- Only [RFC8828](https://www.rfc-editor.org/rfc/rfc8828) mode 2 is supported (default route + all local addresses).
+
+It also implements a lightweight STUN/TURN server ([RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html) and [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html)). The server can be disabled at compile-time with the `NO_SERVER` flag.
+
+## Dependencies
+
+None!
+
+Optionally, [Nettle](https://www.lysator.liu.se/~nisse/nettle/) can provide SHA1 and SHA256 algorithms instead of the internal implementation.
+
+## Building
+
+### Clone repository
+
+```bash
+$ git clone https://github.com/paullouisageneau/libjuice.git
+$ cd libjuice
+```
+
+### Build with CMake
+
+The CMake library targets `libjuice` and `libjuice-static` respectively correspond to the shared and static libraries. The default target will build the library and tests. It exports the targets with namespace `LibJuice::LibJuice` and `LibJuice::LibJuiceStatic` to link the library from another CMake project.
+
+#### POSIX-compliant operating systems (including Linux and Apple macOS)
+
+```bash
+$ cmake -B build
+$ cd build
+$ make -j2
+```
+
+The option `USE_NETTLE` allows to use the Nettle library instead of the internal implementation for HMAC-SHA1:
+```bash
+$ cmake -B build -DUSE_NETTLE=1
+$ cd build
+$ make -j2
+```
+
+#### Microsoft Windows with MinGW cross-compilation
+
+```bash
+$ cmake -B build -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-x86_64-w64-mingw32.cmake # replace with your toolchain file
+$ cd build
+$ make -j2
+```
+
+#### Microsoft Windows with Microsoft Visual C++
+
+```bash
+$ cmake -B build -G "NMake Makefiles"
+$ cd build
+$ nmake
+```
+
+### Build directly with Make (Linux only)
+
+```bash
+$ make
+```
+
+The option `USE_NETTLE` allows to use the Nettle library instead of the internal implementation for HMAC-SHA1:
+```bash
+$ make USE_NETTLE=1
+```
+
+## Example
+
+See [test/connectivity.c](https://github.com/paullouisageneau/libjuice/blob/master/test/connectivity.c) for a complete local connection example.
+
+See [test/server.c](https://github.com/paullouisageneau/libjuice/blob/master/test/server.c) for a server example.
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/paullouisageneau/libjuice/blob/master/CONTRIBUTING.md) for contribution guidelines.
+

--- a/Source/3rdParty/libjuice/cmake/LibJuiceConfig.cmake.in
+++ b/Source/3rdParty/libjuice/cmake/LibJuiceConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/LibJuiceTargets.cmake")
+

--- a/Source/3rdParty/libjuice/cmake/Modules/FindNettle.cmake
+++ b/Source/3rdParty/libjuice/cmake/Modules/FindNettle.cmake
@@ -1,0 +1,142 @@
+# Copyright (C) 2020 Dieter Baron and Thomas Klausner
+#
+# The authors can be contacted at <libzip@nih.at>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# 3. The names of the authors may not be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindNettle
+-------
+
+Finds the Nettle library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``Nettle::Nettle``
+  The Nettle library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``Nettle_FOUND``
+  True if the system has the Nettle library.
+``Nettle_VERSION``
+  The version of the Nettle library which was found.
+``Nettle_INCLUDE_DIRS``
+  Include directories needed to use Nettle.
+``Nettle_LIBRARIES``
+  Libraries needed to link to Nettle.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Nettle_INCLUDE_DIR``
+  The directory containing ``nettle/aes.h``.
+``Nettle_LIBRARY``
+  The path to the Nettle library.
+
+#]=======================================================================]
+
+find_package(PkgConfig)
+pkg_check_modules(PC_Nettle QUIET nettle)
+
+find_path(Nettle_INCLUDE_DIR
+  NAMES nettle/aes.h nettle/md5.h nettle/pbkdf2.h nettle/ripemd160.h nettle/sha.h
+  PATHS ${PC_Nettle_INCLUDE_DIRS}
+)
+find_library(Nettle_LIBRARY
+  NAMES nettle
+  PATHS ${PC_Nettle_LIBRARY_DIRS}
+)
+
+# Extract version information from the header file
+if(Nettle_INCLUDE_DIR)
+  # This file only exists in nettle>=3.0
+  if(EXISTS ${Nettle_INCLUDE_DIR}/nettle/version.h)
+    file(STRINGS ${Nettle_INCLUDE_DIR}/nettle/version.h _ver_major_line
+         REGEX "^#define NETTLE_VERSION_MAJOR  *[0-9]+"
+         LIMIT_COUNT 1)
+    string(REGEX MATCH "[0-9]+"
+           Nettle_MAJOR_VERSION "${_ver_major_line}")
+    file(STRINGS ${Nettle_INCLUDE_DIR}/nettle/version.h _ver_minor_line
+         REGEX "^#define NETTLE_VERSION_MINOR  *[0-9]+"
+         LIMIT_COUNT 1)
+    string(REGEX MATCH "[0-9]+"
+           Nettle_MINOR_VERSION "${_ver_minor_line}")
+    set(Nettle_VERSION "${Nettle_MAJOR_VERSION}.${Nettle_MINOR_VERSION}")
+    unset(_ver_major_line)
+    unset(_ver_minor_line)
+  else()
+    if(PC_Nettle_VERSION)
+      set(Nettle_VERSION ${PC_Nettle_VERSION})
+    else()
+      set(Nettle_VERSION "1.0")
+    endif()
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Nettle
+  FOUND_VAR Nettle_FOUND
+  REQUIRED_VARS
+    Nettle_LIBRARY
+    Nettle_INCLUDE_DIR
+  VERSION_VAR Nettle_VERSION
+)
+
+if(Nettle_FOUND)
+  set(Nettle_LIBRARIES ${Nettle_LIBRARY})
+  set(Nettle_INCLUDE_DIRS ${Nettle_INCLUDE_DIR})
+  set(Nettle_DEFINITIONS ${PC_Nettle_CFLAGS_OTHER})
+endif()
+
+if(Nettle_FOUND AND NOT TARGET Nettle::Nettle)
+  add_library(Nettle::Nettle UNKNOWN IMPORTED)
+  set_target_properties(Nettle::Nettle PROPERTIES
+    IMPORTED_LOCATION "${Nettle_LIBRARY}"
+    INTERFACE_COMPILE_OPTIONS "${PC_Nettle_CFLAGS_OTHER}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Nettle_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(
+  Nettle_INCLUDE_DIR
+  Nettle_LIBRARY
+)
+
+# compatibility variables
+set(Nettle_VERSION_STRING ${Nettle_VERSION})
+

--- a/Source/3rdParty/libjuice/include/juice/juice.h
+++ b/Source/3rdParty/libjuice/include/juice/juice.h
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2020-2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_H
+#define JUICE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef JUICE_STATIC // dynamic library
+#  ifdef _WIN32
+#    ifdef JUICE_EXPORTS
+#      define JUICE_EXPORT __declspec(dllexport) // building the library
+#    else
+#      define JUICE_EXPORT __declspec(dllimport) // using the library
+#    endif
+#  else // not WIN32
+#    if defined(__has_attribute)
+#      if __has_attribute(visibility)
+#        define JUICE_EXPORT __attribute__((visibility("default")))
+#      endif
+#    endif
+#  endif
+#endif
+#ifndef JUICE_EXPORT
+#  define JUICE_EXPORT
+#endif
+
+#define JUICE_ERR_SUCCESS 0
+#define JUICE_ERR_INVALID -1   // invalid argument
+#define JUICE_ERR_FAILED -2    // runtime error
+#define JUICE_ERR_NOT_AVAIL -3 // element not available
+#define JUICE_ERR_IGNORED -4   // ignored
+#define JUICE_ERR_AGAIN -5     // buffer full
+#define JUICE_ERR_TOO_LARGE -6 // datagram too large
+
+// ICE Agent
+
+#define JUICE_MAX_ADDRESS_STRING_LEN 64
+#define JUICE_MAX_CANDIDATE_SDP_STRING_LEN 256
+#define JUICE_MAX_SDP_STRING_LEN 4096
+
+typedef struct juice_agent juice_agent_t;
+
+typedef enum juice_state {
+	JUICE_STATE_DISCONNECTED = 0,
+	JUICE_STATE_GATHERING,
+	JUICE_STATE_CONNECTING,
+	JUICE_STATE_CONNECTED,
+	JUICE_STATE_COMPLETED,
+	JUICE_STATE_FAILED
+} juice_state_t;
+
+typedef void (*juice_cb_state_changed_t)(juice_agent_t *agent, juice_state_t state, void *user_ptr);
+typedef void (*juice_cb_candidate_t)(juice_agent_t *agent, const char *sdp, void *user_ptr);
+typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
+typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t size,
+                                void *user_ptr);
+
+typedef struct juice_mux_binding_request {
+	const char *local_ufrag;
+	const char *remote_ufrag;
+
+	const char *address;
+	uint16_t port;
+} juice_mux_binding_request_t;
+
+typedef void (*juice_cb_mux_incoming_t)(const juice_mux_binding_request_t *info, void *user_ptr);
+
+typedef struct juice_turn_server {
+	const char *host;
+	const char *username;
+	const char *password;
+	uint16_t port;
+} juice_turn_server_t;
+
+typedef enum juice_concurrency_mode {
+	JUICE_CONCURRENCY_MODE_POLL = 0, // Connections share a single thread
+	JUICE_CONCURRENCY_MODE_MUX,      // Connections are multiplexed on a single UDP socket
+	JUICE_CONCURRENCY_MODE_THREAD,   // Each connection runs in its own thread
+} juice_concurrency_mode_t;
+
+typedef enum juice_ice_tcp_mode {
+	JUICE_ICE_TCP_MODE_NONE = 0, // ICE-TCP is disabled
+	JUICE_ICE_TCP_MODE_ACTIVE,   // ICE-TCP will operate as a client
+} juice_ice_tcp_mode_t;
+
+typedef struct juice_config {
+	juice_concurrency_mode_t concurrency_mode;
+
+	const char *stun_server_host;
+	uint16_t stun_server_port;
+
+	juice_turn_server_t *turn_servers;
+	int turn_servers_count;
+
+	const char *bind_address;
+
+	uint16_t local_port_range_begin;
+	uint16_t local_port_range_end;
+
+	juice_cb_state_changed_t cb_state_changed;
+	juice_cb_candidate_t cb_candidate;
+	juice_cb_gathering_done_t cb_gathering_done;
+	juice_cb_recv_t cb_recv;
+
+	void *user_ptr;
+
+} juice_config_t;
+
+JUICE_EXPORT juice_agent_t *juice_create(const juice_config_t *config);
+JUICE_EXPORT void juice_destroy(juice_agent_t *agent);
+
+JUICE_EXPORT int juice_gather_candidates(juice_agent_t *agent);
+JUICE_EXPORT int juice_get_local_description(juice_agent_t *agent, char *buffer, size_t size);
+JUICE_EXPORT int juice_set_remote_description(juice_agent_t *agent, const char *sdp);
+JUICE_EXPORT int juice_add_remote_candidate(juice_agent_t *agent, const char *sdp);
+JUICE_EXPORT int juice_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server);
+JUICE_EXPORT int juice_set_remote_gathering_done(juice_agent_t *agent);
+JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size);
+JUICE_EXPORT int juice_send_diffserv(juice_agent_t *agent, const char *data, size_t size, int ds);
+JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent);
+JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,
+                                               char *remote, size_t remote_size);
+JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,
+                                              char *remote, size_t remote_size);
+JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
+JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
+JUICE_EXPORT int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr);
+JUICE_EXPORT int juice_set_ice_tcp_mode(juice_agent_t *agent, juice_ice_tcp_mode_t ice_tcp_mode);
+
+// ICE server
+
+typedef struct juice_server juice_server_t;
+
+typedef struct juice_server_credentials {
+	const char *username;
+	const char *password;
+	int allocations_quota;
+} juice_server_credentials_t;
+
+typedef struct juice_server_config {
+	juice_server_credentials_t *credentials;
+	int credentials_count;
+
+	int max_allocations;
+	int max_peers;
+
+	const char *bind_address;
+	const char *external_address;
+	uint16_t port;
+
+	uint16_t relay_port_range_begin;
+	uint16_t relay_port_range_end;
+
+	const char *realm;
+
+} juice_server_config_t;
+
+JUICE_EXPORT juice_server_t *juice_server_create(const juice_server_config_t *config);
+JUICE_EXPORT void juice_server_destroy(juice_server_t *server);
+
+JUICE_EXPORT uint16_t juice_server_get_port(juice_server_t *server);
+JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
+                                              const juice_server_credentials_t *credentials,
+                                              unsigned long lifetime_ms);
+
+// Logging
+
+typedef enum juice_log_level {
+	JUICE_LOG_LEVEL_VERBOSE = 0,
+	JUICE_LOG_LEVEL_DEBUG,
+	JUICE_LOG_LEVEL_INFO,
+	JUICE_LOG_LEVEL_WARN,
+	JUICE_LOG_LEVEL_ERROR,
+	JUICE_LOG_LEVEL_FATAL,
+	JUICE_LOG_LEVEL_NONE
+} juice_log_level_t;
+
+typedef void (*juice_log_cb_t)(juice_log_level_t level, const char *message);
+
+JUICE_EXPORT void juice_set_log_level(juice_log_level_t level);
+JUICE_EXPORT void juice_set_log_handler(juice_log_cb_t cb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Source/3rdParty/libjuice/src/addr.c
+++ b/Source/3rdParty/libjuice/src/addr.c
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "addr.h"
+#include "log.h"
+
+#include <stdio.h>
+#include <string.h>
+
+socklen_t addr_get_len(const struct sockaddr *sa) {
+	switch (sa->sa_family) {
+	case AF_INET:
+		return sizeof(struct sockaddr_in);
+	case AF_INET6:
+		return sizeof(struct sockaddr_in6);
+	default:
+		JLOG_WARN("Unknown address family %hu", sa->sa_family);
+		return 0;
+	}
+}
+
+uint16_t addr_get_port(const struct sockaddr *sa) {
+	switch (sa->sa_family) {
+	case AF_INET:
+		return ntohs(((struct sockaddr_in *)sa)->sin_port);
+	case AF_INET6:
+		return ntohs(((struct sockaddr_in6 *)sa)->sin6_port);
+	default:
+		JLOG_WARN("Unknown address family %hu", sa->sa_family);
+		return 0;
+	}
+}
+
+int addr_set_port(struct sockaddr *sa, uint16_t port) {
+	switch (sa->sa_family) {
+	case AF_INET:
+		((struct sockaddr_in *)sa)->sin_port = htons(port);
+		return 0;
+	case AF_INET6:
+		((struct sockaddr_in6 *)sa)->sin6_port = htons(port);
+		return 0;
+	default:
+		JLOG_WARN("Unknown address family %hu", sa->sa_family);
+		return -1;
+	}
+}
+
+bool addr_is_any(const struct sockaddr *sa) {
+	switch (sa->sa_family) {
+	case AF_INET: {
+		const struct sockaddr_in *sin = (const struct sockaddr_in *)sa;
+		const uint8_t *b = (const uint8_t *)&sin->sin_addr;
+		for (int i = 0; i < 4; ++i)
+			if (b[i] != 0)
+				return false;
+
+		return true;
+	}
+	case AF_INET6: {
+		const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sa;
+		if (IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
+			const uint8_t *b = (const uint8_t *)&sin6->sin6_addr + 12;
+			for (int i = 0; i < 4; ++i)
+				if (b[i] != 0)
+					return false;
+		} else {
+			const uint8_t *b = (const uint8_t *)&sin6->sin6_addr;
+			for (int i = 0; i < 16; ++i)
+				if (b[i] != 0)
+					return false;
+		}
+		return true;
+	}
+	default:
+		return false;
+	}
+}
+
+bool addr_is_local(const struct sockaddr *sa) {
+	switch (sa->sa_family) {
+	case AF_INET: {
+		const struct sockaddr_in *sin = (const struct sockaddr_in *)sa;
+		const uint8_t *b = (const uint8_t *)&sin->sin_addr;
+		if (b[0] == 127) // loopback
+			return true;
+		if (b[0] == 169 && b[1] == 254) // link-local
+			return true;
+		return false;
+	}
+	case AF_INET6: {
+		const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sa;
+		if (IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr)) {
+			return true;
+		}
+		if (IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr)) {
+			return true;
+		}
+		if (IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
+			const uint8_t *b = (const uint8_t *)&sin6->sin6_addr + 12;
+			if (b[0] == 127) // loopback
+				return true;
+			if (b[0] == 169 && b[1] == 254) // link-local
+				return true;
+			return false;
+		}
+		return false;
+	}
+	default:
+		return false;
+	}
+}
+
+bool addr_unmap_inet6_v4mapped(struct sockaddr *sa, socklen_t *len) {
+	if (sa->sa_family != AF_INET6)
+		return false;
+
+	const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sa;
+	if (!IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr))
+		return false;
+
+	struct sockaddr_in6 copy = *sin6;
+	sin6 = &copy;
+
+	struct sockaddr_in *sin = (struct sockaddr_in *)sa;
+	memset(sin, 0, sizeof(*sin));
+	sin->sin_family = AF_INET;
+	sin->sin_port = sin6->sin6_port;
+	memcpy(&sin->sin_addr, ((const uint8_t *)&sin6->sin6_addr) + 12, 4);
+	*len = sizeof(*sin);
+	return true;
+}
+
+bool addr_map_inet6_v4mapped(struct sockaddr_storage *ss, socklen_t *len) {
+	if (ss->ss_family != AF_INET)
+		return false;
+
+	const struct sockaddr_in *sin = (const struct sockaddr_in *)ss;
+	struct sockaddr_in copy = *sin;
+	sin = &copy;
+
+	struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)ss;
+	memset(sin6, 0, sizeof(*sin6));
+	sin6->sin6_family = AF_INET6;
+	sin6->sin6_port = sin->sin_port;
+	uint8_t *b = (uint8_t *)&sin6->sin6_addr;
+	memset(b, 0, 10);
+	memset(b + 10, 0xFF, 2);
+	memcpy(b + 12, (const uint8_t *)&sin->sin_addr, 4);
+	*len = sizeof(*sin6);
+	return true;
+}
+
+bool addr_is_equal(const struct sockaddr *a, const struct sockaddr *b, bool compare_ports) {
+	if (a->sa_family != b->sa_family)
+		return false;
+
+	switch (a->sa_family) {
+	case AF_INET: {
+		const struct sockaddr_in *ain = (const struct sockaddr_in *)a;
+		const struct sockaddr_in *bin = (const struct sockaddr_in *)b;
+		if (memcmp(&ain->sin_addr, &bin->sin_addr, 4) != 0)
+			return false;
+		if (compare_ports && ain->sin_port != bin->sin_port)
+			return false;
+		break;
+	}
+	case AF_INET6: {
+		const struct sockaddr_in6 *ain6 = (const struct sockaddr_in6 *)a;
+		const struct sockaddr_in6 *bin6 = (const struct sockaddr_in6 *)b;
+		if (memcmp(&ain6->sin6_addr, &bin6->sin6_addr, 16) != 0)
+			return false;
+		if (compare_ports && ain6->sin6_port != bin6->sin6_port)
+			return false;
+		break;
+	}
+	default:
+		return false;
+	}
+
+	return true;
+}
+
+int addr_to_string(const struct sockaddr *sa, char *buffer, size_t size) {
+	socklen_t salen = addr_get_len(sa);
+	if (salen == 0)
+		goto error;
+
+	char host[ADDR_MAX_NUMERICHOST_LEN];
+	char service[ADDR_MAX_NUMERICSERV_LEN];
+	if (getnameinfo(sa, salen, host, ADDR_MAX_NUMERICHOST_LEN, service, ADDR_MAX_NUMERICSERV_LEN,
+	                NI_NUMERICHOST | NI_NUMERICSERV | NI_DGRAM)) {
+		JLOG_ERROR("getnameinfo failed, errno=%d", sockerrno);
+		goto error;
+	}
+
+	int len = snprintf(buffer, size, "%s:%s", host, service);
+	if (len < 0 || (size_t)len >= size)
+		goto error;
+
+	return len;
+
+error:
+	// Make sure we still write a valid null-terminated string
+	snprintf(buffer, size, "?");
+	return -1;
+}
+
+// djb2 hash function
+#define DJB2_INIT 5381
+static void djb2(unsigned long *hash, int i) {
+	*hash = ((*hash << 5) + *hash) + i; // hash * 33 + i
+}
+
+unsigned long addr_hash(const struct sockaddr *sa, bool with_port) {
+	unsigned long hash = DJB2_INIT;
+
+	djb2(&hash, sa->sa_family);
+	switch (sa->sa_family) {
+	case AF_INET: {
+		const struct sockaddr_in *sin = (const struct sockaddr_in *)sa;
+		const uint8_t *b = (const uint8_t *)&sin->sin_addr;
+		for (int i = 0; i < 4; ++i)
+			djb2(&hash, b[i]);
+		if (with_port) {
+			djb2(&hash, sin->sin_port >> 8);
+			djb2(&hash, sin->sin_port & 0xFF);
+		}
+		break;
+	}
+	case AF_INET6: {
+		const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sa;
+		const uint8_t *b = (const uint8_t *)&sin6->sin6_addr;
+		for (int i = 0; i < 16; ++i)
+			djb2(&hash, b[i]);
+		if (with_port) {
+			djb2(&hash, sin6->sin6_port >> 8);
+			djb2(&hash, sin6->sin6_port & 0xFF);
+		}
+		break;
+	}
+	default:
+		break;
+	}
+
+	return hash;
+}
+
+int addr_resolve(const char *hostname, const char *service, int socktype, addr_record_t *records,
+                 size_t count) {
+	addr_record_t *end = records + count;
+
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = socktype;
+	hints.ai_protocol = socktype == SOCK_STREAM ? IPPROTO_TCP : IPPROTO_UDP;
+#ifdef AI_ADDRCONFIG
+	hints.ai_flags = AI_ADDRCONFIG;
+#endif
+	struct addrinfo *ai_list = NULL;
+	if (getaddrinfo(hostname, service, &hints, &ai_list)) {
+		JLOG_WARN("Address resolution failed for %s:%s", hostname, service);
+		return -1;
+	}
+
+	int ret = 0;
+	for (struct addrinfo *ai = ai_list; ai; ai = ai->ai_next) {
+		if (ai->ai_family == AF_INET || ai->ai_family == AF_INET6) {
+			++ret;
+			if (records != end) {
+				memcpy(&records->addr, ai->ai_addr, ai->ai_addrlen);
+				records->len = (socklen_t)ai->ai_addrlen;
+				records->socktype = socktype;
+				++records;
+			}
+		}
+	}
+
+	freeaddrinfo(ai_list);
+	return ret;
+}
+
+bool addr_is_numeric_hostname(const char *hostname) {
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_DGRAM;
+	hints.ai_protocol = IPPROTO_UDP;
+	hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+	struct addrinfo *ai_list = NULL;
+	if (getaddrinfo(hostname, "9", &hints, &ai_list))
+		return false;
+
+	freeaddrinfo(ai_list);
+	return true;
+}
+
+bool addr_record_is_equal(const addr_record_t *a, const addr_record_t *b, bool compare_ports) {
+	return addr_is_equal((const struct sockaddr *)&a->addr, (const struct sockaddr *)&b->addr,
+	                     compare_ports) &&
+	       a->socktype == b->socktype;
+}
+
+int addr_record_to_string(const addr_record_t *record, char *buffer, size_t size) {
+	return addr_to_string((const struct sockaddr *)&record->addr, buffer, size);
+}
+
+unsigned long addr_record_hash(const addr_record_t *record, bool with_port) {
+	return addr_hash((const struct sockaddr *)&record->addr, with_port) +
+	       (record->socktype == SOCK_DGRAM ? 0 : 1);
+}

--- a/Source/3rdParty/libjuice/src/addr.h
+++ b/Source/3rdParty/libjuice/src/addr.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_ADDR_H
+#define JUICE_ADDR_H
+
+#include "socket.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// IPv6 max representation length is 45 plus 4 for potential zone index
+#define ADDR_MAX_NUMERICHOST_LEN 56 // 45 + 4 + 1 rounded up
+#define ADDR_MAX_NUMERICSERV_LEN 8 // 5 + 1 rounded up
+#define ADDR_MAX_STRING_LEN 64
+
+socklen_t addr_get_len(const struct sockaddr *sa);
+uint16_t addr_get_port(const struct sockaddr *sa);
+int addr_set_port(struct sockaddr *sa, uint16_t port);
+bool addr_is_any(const struct sockaddr *sa);
+bool addr_is_local(const struct sockaddr *sa);
+bool addr_unmap_inet6_v4mapped(struct sockaddr *sa, socklen_t *len);
+bool addr_map_inet6_v4mapped(struct sockaddr_storage *ss, socklen_t *len);
+bool addr_is_equal(const struct sockaddr *a, const struct sockaddr *b, bool compare_ports);
+int addr_to_string(const struct sockaddr *sa, char *buffer, size_t size);
+unsigned long addr_hash(const struct sockaddr *sa, bool with_port);
+
+typedef struct addr_record {
+	struct sockaddr_storage addr;
+	socklen_t len;
+	int socktype;
+} addr_record_t;
+
+int addr_resolve(const char *hostname, const char *service, int socktype, addr_record_t *records, size_t count);
+bool addr_is_numeric_hostname(const char *hostname);
+
+bool addr_record_is_equal(const addr_record_t *a, const addr_record_t *b, bool compare_ports);
+int addr_record_to_string(const addr_record_t *record, char *buffer, size_t size);
+unsigned long addr_record_hash(const addr_record_t *record, bool with_port);
+
+#endif // JUICE_ADDR_H

--- a/Source/3rdParty/libjuice/src/agent.c
+++ b/Source/3rdParty/libjuice/src/agent.c
@@ -1,0 +1,2799 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "agent.h"
+#include "ice.h"
+#include "juice.h"
+#include "log.h"
+#include "random.h"
+#include "stun.h"
+#include "turn.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+// RFC 8656: The Permission Lifetime MUST be 300 seconds (= 5 minutes)
+#define PERMISSION_LIFETIME 300000 // ms
+
+// RFC 8656: Channel bindings last for 10 minutes unless refreshed
+#define BIND_LIFETIME 600000 // ms
+
+#define BUFFER_SIZE 4096
+#define DEFAULT_MAX_RECORDS_COUNT 8
+
+static char *alloc_string_copy(const char *orig, bool *alloc_failed) {
+	if (!orig)
+		return NULL;
+
+	char *copy = malloc(strlen(orig) + 1);
+	if (!copy) {
+		if (alloc_failed)
+			*alloc_failed = true;
+
+		return NULL;
+	}
+	strcpy(copy, orig);
+	return copy;
+}
+
+static int copy_turn_server(juice_turn_server_t *dst, const juice_turn_server_t *src) {
+	bool alloc_failed = false;
+	dst->host = alloc_string_copy(src->host, &alloc_failed);
+	dst->username = alloc_string_copy(src->username, &alloc_failed);
+	dst->password = alloc_string_copy(src->password, &alloc_failed);
+	dst->port = src->port;
+
+	if (alloc_failed) {
+		JLOG_FATAL("Memory allocation for TURN server configuration copy failed");
+		free((void *)dst->host);
+		free((void *)dst->username);
+		free((void *)dst->password);
+		dst->host = NULL;
+		dst->username = NULL;
+		dst->password = NULL;
+		return -1;
+	}
+
+	return 0;
+}
+
+static bool entry_is_tcp(agent_stun_entry_t *entry) {
+	return (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP);
+}
+
+juice_agent_t *agent_create(const juice_config_t *config) {
+	JLOG_VERBOSE("Creating agent");
+
+#ifdef _WIN32
+	WSADATA wsaData;
+	if (WSAStartup(MAKEWORD(2, 2), &wsaData)) {
+		JLOG_FATAL("WSAStartup failed");
+		return NULL;
+	}
+#endif
+
+	juice_agent_t *agent = calloc(1, sizeof(juice_agent_t));
+	if (!agent) {
+		JLOG_FATAL("Memory allocation for agent failed");
+		return NULL;
+	}
+
+	bool alloc_failed = false;
+	agent->ice_tcp_mode = JUICE_ICE_TCP_MODE_NONE;
+	agent->config.concurrency_mode = config->concurrency_mode;
+	agent->config.stun_server_host = alloc_string_copy(config->stun_server_host, &alloc_failed);
+	agent->config.stun_server_port = config->stun_server_port;
+	agent->config.bind_address = alloc_string_copy(config->bind_address, &alloc_failed);
+	agent->config.local_port_range_begin = config->local_port_range_begin;
+	agent->config.local_port_range_end = config->local_port_range_end;
+	agent->config.cb_state_changed = config->cb_state_changed;
+	agent->config.cb_candidate = config->cb_candidate;
+	agent->config.cb_gathering_done = config->cb_gathering_done;
+	agent->config.cb_recv = config->cb_recv;
+	agent->config.user_ptr = config->user_ptr;
+	if (alloc_failed) {
+		JLOG_FATAL("Memory allocation for configuration copy failed");
+		goto error;
+	}
+
+	if (config->turn_servers_count <= 0) {
+		agent->config.turn_servers = NULL;
+		agent->config.turn_servers_count = 0;
+	} else {
+		agent->config.turn_servers =
+		    calloc(config->turn_servers_count, sizeof(juice_turn_server_t));
+		if (!agent->config.turn_servers) {
+			JLOG_FATAL("Memory allocation for TURN servers copy failed");
+			goto error;
+		}
+		agent->config.turn_servers_count = config->turn_servers_count;
+		for (int i = 0; i < config->turn_servers_count; ++i) {
+			if (copy_turn_server(agent->config.turn_servers + i, config->turn_servers + i) < 0) {
+				goto error;
+			}
+		}
+	}
+
+	agent->state = JUICE_STATE_DISCONNECTED;
+	agent->mode = AGENT_MODE_UNKNOWN;
+	agent->selected_entry = NULL;
+
+	agent->conn_index = -1;
+	agent->conn_impl = NULL;
+
+	ice_create_local_description(&agent->local);
+
+	// RFC 8445: 16.1. Attributes
+	// The content of the [ICE-CONTROLLED/ICE-CONTROLLING] attribute is a 64-bit
+	// unsigned integer in network byte order, which contains a random number.
+	// The number is used for solving role conflicts, when it is referred to as
+	// the "tiebreaker value".  An ICE agent MUST use the same number for
+	// all Binding requests, for all streams, within an ICE session, unless
+	// it has received a 487 response, in which case it MUST change the
+	// number.
+	juice_random(&agent->ice_tiebreaker, sizeof(agent->ice_tiebreaker));
+
+	return agent;
+
+error:
+	agent_destroy(agent);
+	return NULL;
+}
+
+void agent_destroy(juice_agent_t *agent) {
+	JLOG_DEBUG("Destroying agent");
+
+	if (agent->resolver_thread_started) {
+		JLOG_VERBOSE("Waiting for resolver thread");
+		thread_join(agent->resolver_thread, NULL);
+	}
+
+	if (agent->conn_impl) {
+		conn_destroy(agent);
+	}
+
+	// Free credentials in entries
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry->turn) {
+			turn_destroy_map(&entry->turn->map);
+			free(entry->turn);
+		}
+	}
+
+	// Free strings in config
+	free((void *)agent->config.stun_server_host);
+	for (int i = 0; i < agent->config.turn_servers_count; ++i) {
+		juice_turn_server_t *turn_server = agent->config.turn_servers + i;
+		free((void *)turn_server->host);
+		free((void *)turn_server->username);
+		free((void *)turn_server->password);
+	}
+	free(agent->config.turn_servers);
+	free((void *)agent->config.bind_address);
+	free(agent);
+
+#ifdef _WIN32
+	WSACleanup();
+#endif
+
+	JLOG_VERBOSE("Destroyed agent");
+}
+
+static bool has_nonnumeric_server_hostnames(const juice_config_t *config) {
+	if (config->stun_server_host && !addr_is_numeric_hostname(config->stun_server_host))
+		return true;
+
+	for (int i = 0; i < config->turn_servers_count; ++i) {
+		juice_turn_server_t *turn_server = config->turn_servers + i;
+		if (turn_server->host && !addr_is_numeric_hostname(turn_server->host))
+			return true;
+	}
+
+	return false;
+}
+
+static thread_return_t THREAD_CALL resolver_thread_entry(void *arg) {
+	thread_set_name_self("juice resolver");
+	agent_resolve_servers((juice_agent_t *)arg);
+	return (thread_return_t)0;
+}
+
+int agent_gather_candidates(juice_agent_t *agent) {
+	JLOG_VERBOSE("Gathering candidates");
+	if (agent->conn_impl) {
+		JLOG_WARN("Candidates gathering already started");
+		return 0;
+	}
+
+	if (agent->mode == AGENT_MODE_UNKNOWN) {
+		JLOG_DEBUG("Assuming controlling mode");
+		agent->mode = AGENT_MODE_CONTROLLING;
+	}
+
+	agent_change_state(agent, JUICE_STATE_GATHERING);
+
+	udp_socket_config_t socket_config;
+	memset(&socket_config, 0, sizeof(socket_config));
+	socket_config.bind_address = agent->config.bind_address;
+	socket_config.port_begin = agent->config.local_port_range_begin;
+	socket_config.port_end = agent->config.local_port_range_end;
+
+	if (conn_create(agent, &socket_config)) {
+		JLOG_FATAL("Connection creation for agent failed");
+		return -1;
+	}
+
+	addr_record_t records[ICE_MAX_CANDIDATES_COUNT - 1];
+	int records_count = conn_get_addrs(agent, records, ICE_MAX_CANDIDATES_COUNT - 1);
+	if (records_count < 0) {
+		JLOG_ERROR("Failed to gather local host candidates");
+		records_count = 0;
+	} else if (records_count == 0) {
+		JLOG_WARN("No local host candidates gathered");
+	} else if (records_count > ICE_MAX_CANDIDATES_COUNT - 1)
+		records_count = ICE_MAX_CANDIDATES_COUNT - 1;
+
+	conn_lock(agent);
+
+	JLOG_VERBOSE("Adding %d local host candidates", records_count);
+	for (int i = 0; i < records_count; ++i) {
+		ice_candidate_t candidate;
+		if (ice_create_local_candidate(ICE_CANDIDATE_TYPE_HOST, 1, agent->local.candidates_count,
+		                               records + i, &candidate, ICE_CANDIDATE_TRANSPORT_UDP)) {
+			JLOG_ERROR("Failed to create host candidate");
+			continue;
+		}
+		if (agent->local.candidates_count >= MAX_HOST_CANDIDATES_COUNT) {
+			JLOG_WARN("Local description already has the maximum number of host candidates");
+			break;
+		}
+		if (ice_add_candidate(&candidate, &agent->local)) {
+			JLOG_ERROR("Failed to add candidate to local description");
+			continue;
+		}
+	}
+
+	if (agent->ice_tcp_mode == JUICE_ICE_TCP_MODE_ACTIVE) {
+		if (records_count > 0) {
+			// RFC 6544: The connection-address encoded into the candidate-attribute for
+			// active candidates MUST be set to the IP address that will be used for the
+			// attempt, but the port(s) MUST be set to 9 (i.e., Discard).
+			// Add only two TCP candidates, one for IPv6 and one for IPv4
+			const int families[2] = {AF_INET6, AF_INET};
+			for (int i = 0; i < 2; ++i) {
+				int family = families[i];
+				for (int j = 0; j < records_count; ++j) {
+					addr_record_t *record = records + j;
+					if (record->addr.ss_family == family) {
+						addr_record_t tcp_record;
+						memcpy(&tcp_record, record, sizeof(addr_record_t));
+						tcp_record.socktype = SOCK_STREAM;
+						addr_set_port((struct sockaddr *)&tcp_record.addr, 9);
+						agent_add_local_tcp_active_candidate(agent, &tcp_record);
+						break;
+					}
+				}
+			}
+		} else {
+			JLOG_WARN("No local host candidates gathered, unable to add TCP candidates");
+		}
+	}
+
+	ice_sort_candidates(&agent->local);
+
+	for (int i = 0; i < agent->entries_count; ++i)
+		agent_translate_host_candidate_entry(agent, agent->entries + i);
+
+	char buffer[BUFFER_SIZE];
+	for (int i = 0; i < agent->local.candidates_count; ++i) {
+		ice_candidate_t *candidate = agent->local.candidates + i;
+		if (candidate->type != ICE_CANDIDATE_TYPE_HOST)
+			continue;
+
+		if (ice_generate_candidate_sdp(candidate, buffer, BUFFER_SIZE) < 0) {
+			JLOG_ERROR("Failed to generate SDP for local candidate");
+			continue;
+		}
+
+		JLOG_DEBUG("Gathered host candidate: %s", buffer);
+
+		if (agent->config.cb_candidate)
+			agent->config.cb_candidate(agent, buffer, agent->config.user_ptr);
+	}
+
+	agent_change_state(agent, JUICE_STATE_CONNECTING);
+	conn_unlock(agent);
+	conn_interrupt(agent);
+
+	if (has_nonnumeric_server_hostnames(&agent->config)) {
+		// Resolve server hostnames in a separate thread as it may block
+		JLOG_DEBUG("Starting resolver thread for servers");
+		int ret = thread_init(&agent->resolver_thread, resolver_thread_entry, agent);
+		if (ret) {
+			JLOG_FATAL("Thread creation failed, error=%d", ret);
+			agent_update_gathering_done(agent);
+			return -1;
+		}
+		agent->resolver_thread_started = true;
+	} else {
+		JLOG_DEBUG("Resolving servers synchronously");
+		if (agent_resolve_servers(agent) < 0)
+			return -1;
+	}
+
+	return 0;
+}
+
+int agent_resolve_servers(juice_agent_t *agent) {
+	conn_lock(agent);
+
+	// TURN server resolution
+	juice_concurrency_mode_t mode = agent->config.concurrency_mode;
+	if (mode == JUICE_CONCURRENCY_MODE_MUX) {
+		if (agent->config.turn_servers_count > 0)
+			JLOG_WARN("TURN servers are not supported in mux mode");
+
+	} else if (agent->config.turn_servers_count > 0) {
+		int count = 0;
+		for (int i = 0; i < agent->config.turn_servers_count; ++i) {
+			if (count >= MAX_RELAY_ENTRIES_COUNT)
+				break;
+
+			juice_turn_server_t *turn_server = agent->config.turn_servers + i;
+			if (!turn_server->host)
+				continue;
+
+			if (!turn_server->port)
+				turn_server->port = 3478; // default TURN port
+
+			char hostname[256];
+			char service[8];
+			snprintf(hostname, 256, "%s", turn_server->host);
+			snprintf(service, 8, "%hu", turn_server->port);
+
+			conn_unlock(agent);
+
+			addr_record_t records[DEFAULT_MAX_RECORDS_COUNT];
+			int records_count =
+			    addr_resolve(hostname, service, SOCK_DGRAM, records, DEFAULT_MAX_RECORDS_COUNT);
+
+			conn_lock(agent);
+
+			if (records_count > 0) {
+				if (records_count > DEFAULT_MAX_RECORDS_COUNT)
+					records_count = DEFAULT_MAX_RECORDS_COUNT;
+
+				JLOG_INFO("Using TURN server %s:%s", hostname, service);
+
+				addr_record_t *record = NULL;
+				for (int j = 0; j < records_count; ++j) {
+					int family = records[j].addr.ss_family;
+					// Prefer IPv4 for TURN
+					if (family == AF_INET) {
+						record = records + j;
+						break;
+					}
+					if (family == AF_INET6 && !record)
+						record = records + j;
+				}
+				if (record) {
+					// Ignore duplicate TURN servers as they will cause conflicts
+					bool is_duplicate = false;
+					for (int i = 0; i < agent->entries_count; ++i) {
+						agent_stun_entry_t *entry = agent->entries + i;
+						if (entry->type == AGENT_STUN_ENTRY_TYPE_RELAY &&
+						    addr_record_is_equal(&entry->record, record, true)) {
+							is_duplicate = true;
+							break;
+						}
+					}
+					if (is_duplicate) {
+						JLOG_INFO("Duplicate TURN server, ignoring");
+						continue;
+					}
+
+					JLOG_VERBOSE("Registering STUN entry %d for relay request",
+					             agent->entries_count);
+					agent_stun_entry_t *entry = agent->entries + agent->entries_count;
+					entry->type = AGENT_STUN_ENTRY_TYPE_RELAY;
+					entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+					entry->pair = NULL;
+					entry->record = *record;
+					entry->turn_redirections = 0;
+					entry->turn = calloc(1, sizeof(agent_turn_state_t));
+					if (!entry->turn) {
+						JLOG_ERROR("Memory allocation for TURN state failed");
+						break;
+					}
+					if (turn_init_map(&entry->turn->map, AGENT_TURN_MAP_SIZE) < 0) {
+						free(entry->turn);
+						break;
+					}
+					snprintf(entry->turn->credentials.username, STUN_MAX_USERNAME_LEN, "%s",
+					         turn_server->username);
+					entry->turn->password = turn_server->password;
+					juice_random(entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+					entry->transaction_id_expired = false;
+					++agent->entries_count;
+
+					agent_arm_transmission(agent, entry, STUN_PACING_TIME * i);
+
+					++count;
+				}
+			} else {
+				JLOG_ERROR("TURN address resolution failed");
+			}
+		}
+	}
+
+	// STUN server resolution
+	// The entry is added after so the TURN server address will be matched in priority
+	if (agent->config.stun_server_host) {
+		if (!agent->config.stun_server_port)
+			agent->config.stun_server_port = 3478; // default STUN port
+
+		char hostname[256];
+		char service[8];
+		snprintf(hostname, 256, "%s", agent->config.stun_server_host);
+		snprintf(service, 8, "%hu", agent->config.stun_server_port);
+
+		conn_unlock(agent);
+
+		addr_record_t records[MAX_STUN_SERVER_RECORDS_COUNT];
+		int records_count =
+		    addr_resolve(hostname, service, SOCK_DGRAM, records, MAX_STUN_SERVER_RECORDS_COUNT);
+
+		conn_lock(agent);
+
+		if (records_count > 0) {
+			if (records_count > MAX_STUN_SERVER_RECORDS_COUNT)
+				records_count = MAX_STUN_SERVER_RECORDS_COUNT;
+
+			JLOG_INFO("Using STUN server %s:%s", agent->config.stun_server_host, service);
+
+			for (int i = 0; i < records_count; ++i) {
+				if (i >= MAX_SERVER_ENTRIES_COUNT)
+					break;
+				JLOG_VERBOSE("Registering STUN entry %d for server request", agent->entries_count);
+				agent_stun_entry_t *entry = agent->entries + agent->entries_count;
+				entry->type = AGENT_STUN_ENTRY_TYPE_SERVER;
+				entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+				entry->pair = NULL;
+				entry->record = records[i];
+				juice_random(entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+				entry->transaction_id_expired = false;
+				++agent->entries_count;
+
+				agent_arm_transmission(agent, entry, STUN_PACING_TIME * i);
+			}
+		} else {
+			JLOG_ERROR("STUN server address resolution failed");
+		}
+	}
+
+	agent_update_gathering_done(agent);
+	conn_unlock(agent);
+	conn_interrupt(agent);
+	return 0;
+}
+
+int agent_get_local_description(juice_agent_t *agent, char *buffer, size_t size) {
+	conn_lock(agent);
+	if (ice_generate_sdp(&agent->local, buffer, size) < 0) {
+		JLOG_ERROR("Failed to generate local SDP description");
+		conn_unlock(agent);
+		return -1;
+	}
+	JLOG_VERBOSE("Generated local SDP description: %s", buffer);
+
+	if (agent->mode == AGENT_MODE_UNKNOWN) {
+		JLOG_DEBUG("Assuming controlling mode");
+		agent->mode = AGENT_MODE_CONTROLLING;
+	}
+
+	conn_unlock(agent);
+	return 0;
+}
+
+int agent_set_remote_description(juice_agent_t *agent, const char *sdp) {
+	conn_lock(agent);
+	JLOG_VERBOSE("Setting remote SDP description: %s", sdp);
+
+	ice_description_t remote;
+	int ret = ice_parse_sdp(sdp, &remote);
+	if (ret < 0) {
+		switch (ret) {
+		case ICE_PARSE_MISSING_UFRAG:
+			JLOG_ERROR("Missing ICE user fragment in remote description");
+			break;
+		case ICE_PARSE_MISSING_PWD:
+			JLOG_ERROR("Missing ICE password in remote description");
+			break;
+		default:
+			JLOG_ERROR("Failed to parse remote SDP description");
+			break;
+		}
+		conn_unlock(agent);
+		return JUICE_ERR_INVALID;
+	}
+
+	if (*agent->remote.ice_ufrag) {
+		// There is already a remote description
+		if (strcmp(agent->remote.ice_ufrag, remote.ice_ufrag) == 0 &&
+		    strcmp(agent->remote.ice_pwd, remote.ice_pwd) == 0) {
+			JLOG_DEBUG("Remote description is already set, ignoring");
+			conn_unlock(agent);
+			return JUICE_ERR_SUCCESS;
+		}
+
+		JLOG_WARN("ICE restart is not supported");
+		conn_unlock(agent);
+		return JUICE_ERR_FAILED;
+	}
+
+	agent->remote = remote;
+
+	agent_update_pac_timer(agent);
+
+	if (agent->remote.ice_lite && agent->mode != AGENT_MODE_CONTROLLING) {
+		// RFC 8445 6.1.1. Determining Role:
+		// The full agent MUST take the controlling role, and the lite agent MUST take the
+		// controlled role.
+		JLOG_DEBUG("Remote ICE agent is lite, assuming controlling mode");
+		agent->mode = AGENT_MODE_CONTROLLING;
+	} else if (agent->mode == AGENT_MODE_UNKNOWN) {
+		JLOG_DEBUG("Assuming controlled mode");
+		agent->mode = AGENT_MODE_CONTROLLED;
+	}
+
+	// There is only one component, therefore we can unfreeze already existing pairs now
+	JLOG_DEBUG("Unfreezing %d existing candidate pairs", (int)agent->candidate_pairs_count);
+	for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+		agent_unfreeze_candidate_pair(agent, agent->candidate_pairs + i);
+	}
+	JLOG_DEBUG("Adding %d candidates from remote description", (int)agent->remote.candidates_count);
+	for (int i = 0; i < agent->remote.candidates_count; ++i) {
+		ice_candidate_t *remote = agent->remote.candidates + i;
+		if (agent_add_candidate_pairs_for_remote(agent, remote))
+			JLOG_WARN("Failed to add candidate pair");
+	}
+
+	conn_unlock(agent);
+	conn_interrupt(agent);
+	return JUICE_ERR_SUCCESS;
+}
+
+int agent_add_remote_candidate(juice_agent_t *agent, const char *sdp) {
+	conn_lock(agent);
+	JLOG_VERBOSE("Adding remote candidate: %s", sdp);
+	if (agent->remote.finished) {
+		JLOG_ERROR("Remote candidate added after remote gathering done");
+		conn_unlock(agent);
+		return JUICE_ERR_FAILED;
+	}
+	ice_candidate_t candidate;
+	int ret = ice_parse_candidate_sdp(sdp, &candidate);
+	if (ret < 0) {
+		if (ret == ICE_PARSE_IGNORED) {
+			JLOG_DEBUG("Ignored SDP candidate: %s", sdp);
+			conn_unlock(agent);
+			return JUICE_ERR_IGNORED;
+		}
+
+		JLOG_ERROR("Failed to parse remote SDP candidate: %s", sdp);
+		conn_unlock(agent);
+		return JUICE_ERR_INVALID;
+	}
+	if (ice_add_candidate(&candidate, &agent->remote)) {
+		JLOG_ERROR("Failed to add candidate to remote description");
+		conn_unlock(agent);
+		return JUICE_ERR_FAILED;
+	}
+	ice_candidate_t *remote = agent->remote.candidates + agent->remote.candidates_count - 1;
+	if (agent_add_candidate_pairs_for_remote(agent, remote)) {
+		JLOG_WARN("Failed to add candidate pair");
+		conn_unlock(agent);
+		return JUICE_ERR_FAILED;
+	}
+
+	conn_unlock(agent);
+	conn_interrupt(agent);
+	return JUICE_ERR_SUCCESS;
+}
+
+int agent_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd) {
+	if (agent->conn_impl) {
+		JLOG_WARN("Unable to set ICE attributes, candidates gathering already started");
+		return JUICE_ERR_FAILED;
+	}
+
+	if (strlen(ufrag) < 4 || strlen(pwd) < 22 || !ice_is_valid_string(ufrag) ||
+	    !ice_is_valid_string(pwd)) {
+		JLOG_ERROR("Invalid ICE attributes");
+		return JUICE_ERR_INVALID;
+	}
+
+	snprintf(agent->local.ice_ufrag, sizeof(agent->local.ice_ufrag), "%s", ufrag);
+	snprintf(agent->local.ice_pwd, sizeof(agent->local.ice_pwd), "%s", pwd);
+	return JUICE_ERR_SUCCESS;
+}
+
+int agent_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server) {
+	if (agent->conn_impl) {
+		// The array must no be reallocated anymore after gathering started
+		JLOG_WARN("Unable to add TURN server, candidates gathering already started");
+		return -1;
+	}
+
+	juice_turn_server_t *new_turn_servers =
+	    realloc(agent->config.turn_servers,
+	            (agent->config.turn_servers_count + 1) * sizeof(juice_turn_server_t));
+	if (!new_turn_servers) {
+		JLOG_FATAL("Memory allocation for TURN servers failed");
+		return -1;
+	}
+	memset(new_turn_servers + agent->config.turn_servers_count, 0, sizeof(juice_turn_server_t));
+	agent->config.turn_servers = new_turn_servers;
+	if (copy_turn_server(new_turn_servers + agent->config.turn_servers_count, turn_server) < 0) {
+		return -1;
+	}
+	agent->config.turn_servers_count++;
+	return 0;
+}
+
+int agent_set_remote_gathering_done(juice_agent_t *agent) {
+	conn_lock(agent);
+	agent->remote.finished = true;
+	conn_unlock(agent);
+	conn_interrupt(agent);
+	return 0;
+}
+
+int agent_send(juice_agent_t *agent, const char *data, size_t size, int ds) {
+	// Try not to lock in the send path
+	agent_stun_entry_t *selected_entry = atomic_load(&agent->selected_entry);
+	if (!selected_entry) {
+		JLOG_ERROR("Send while ICE is not connected");
+		return -1;
+	}
+
+	if (selected_entry->relay_entry) {
+		// The datagram should be sent through the relay, use a channel to minimize overhead
+		conn_lock(agent); // We have to lock
+		int ret = agent_channel_send(agent, selected_entry->relay_entry, &selected_entry->record,
+		                             data, size, ds);
+		conn_unlock(agent);
+		return ret;
+	}
+
+	return agent_direct_send(agent, &selected_entry->record, data, size, ds);
+}
+
+int agent_direct_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                      int ds) {
+	return conn_send(agent, dst, data, size, ds);
+}
+
+int agent_relay_send(juice_agent_t *agent, agent_stun_entry_t *entry, const addr_record_t *dst,
+                     const char *data, size_t size, int ds) {
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+
+	JLOG_VERBOSE("Sending datagram via TURN Send Indication, size=%d", size);
+
+	// Send CreatePermission if necessary
+	if (!turn_has_permission(&entry->turn->map, dst))
+		if (agent_send_turn_create_permission_request(agent, entry, dst, ds))
+			return -1;
+
+	// Send the data in a TURN Send indication
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_INDICATION;
+	msg.msg_method = STUN_METHOD_SEND;
+	juice_random(msg.transaction_id, STUN_TRANSACTION_ID_SIZE);
+	msg.peers_size = 1;
+	msg.peers[0] = *dst;
+	msg.data = data;
+	msg.data_size = size;
+
+	char buffer[BUFFER_SIZE];
+	size = stun_write(buffer, BUFFER_SIZE, &msg, NULL); // no password
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+
+	return agent_direct_send(agent, &entry->record, buffer, size, ds);
+}
+
+int agent_channel_send(juice_agent_t *agent, agent_stun_entry_t *entry, const addr_record_t *record,
+                       const char *data, size_t size, int ds) {
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+
+	// Send ChannelBind if necessary
+	uint16_t channel;
+	if (!turn_get_bound_channel(&entry->turn->map, record, &channel))
+		if (agent_send_turn_channel_bind_request(agent, entry, record, ds, &channel) < 0)
+			return -1;
+
+	JLOG_VERBOSE("Sending datagram via TURN ChannelData, channel=0x%hX, size=%d", channel, size);
+
+	// Send the data wrapped as ChannelData
+	char buffer[BUFFER_SIZE];
+	int len = turn_wrap_channel_data(buffer, BUFFER_SIZE, data, size, channel);
+	if (len <= 0) {
+		JLOG_ERROR("TURN ChannelData wrapping failed");
+		return -1;
+	}
+
+	return agent_direct_send(agent, &entry->record, buffer, len, ds);
+}
+
+juice_state_t agent_get_state(juice_agent_t *agent) {
+	conn_lock(agent);
+	juice_state_t state = agent->state;
+	conn_unlock(agent);
+	return state;
+}
+
+int agent_get_selected_candidate_pair(juice_agent_t *agent, ice_candidate_t *local,
+                                      ice_candidate_t *remote) {
+	conn_lock(agent);
+	ice_candidate_pair_t *pair = agent->selected_pair;
+	if (!pair) {
+		conn_unlock(agent);
+		return -1;
+	}
+
+	if (local)
+		*local = pair->local ? *pair->local : agent->local.candidates[0];
+	if (remote)
+		*remote = *pair->remote;
+
+	conn_unlock(agent);
+	return 0;
+}
+
+int agent_conn_update(juice_agent_t *agent, timestamp_t *next_timestamp) {
+	return agent_bookkeeping(agent, next_timestamp);
+}
+
+int agent_conn_recv(juice_agent_t *agent, char *buf, size_t len, const addr_record_t *src) {
+	agent_input(agent, buf, len, src, NULL);
+	return 0; // ignore errors
+}
+
+int agent_conn_fail(juice_agent_t *agent) {
+	agent_change_state(agent, JUICE_STATE_FAILED);
+	atomic_store(&agent->selected_entry, NULL); // disallow sending
+	return 0;
+}
+
+int agent_input(juice_agent_t *agent, char *buf, size_t len, const addr_record_t *src,
+                const addr_record_t *relayed) {
+	JLOG_VERBOSE("Received datagram, size=%d", len);
+
+	if (agent->state == JUICE_STATE_DISCONNECTED || agent->state == JUICE_STATE_GATHERING)
+		return 0;
+
+	if (is_stun_datagram(buf, len)) {
+		if (JLOG_DEBUG_ENABLED) {
+			char src_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+			if (relayed) {
+				char relayed_str[ADDR_MAX_STRING_LEN];
+				addr_record_to_string(relayed, relayed_str, ADDR_MAX_STRING_LEN);
+				JLOG_DEBUG("Received STUN datagram from %s relayed via %s", src_str, relayed_str);
+			} else {
+				JLOG_DEBUG("Received STUN datagram from %s", src_str);
+			}
+		}
+		stun_message_t msg;
+		if (stun_read(buf, len, &msg) < 0) {
+			JLOG_ERROR("STUN message reading failed");
+			return -1;
+		}
+		return agent_dispatch_stun(agent, buf, len, &msg, src, relayed);
+	}
+
+	if (JLOG_DEBUG_ENABLED) {
+		char src_str[ADDR_MAX_STRING_LEN];
+		addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+		if (relayed) {
+			char relayed_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(relayed, relayed_str, ADDR_MAX_STRING_LEN);
+			JLOG_DEBUG("Received non-STUN datagram from %s relayed via %s", src_str, relayed_str);
+		} else {
+			JLOG_DEBUG("Received non-STUN datagram from %s", src_str);
+		}
+	}
+	agent_stun_entry_t *entry = agent_find_entry_from_record(agent, src, relayed);
+	if (!entry) {
+		JLOG_WARN("Received a datagram from unknown address, ignoring");
+		return -1;
+	}
+	switch (entry->type) {
+	case AGENT_STUN_ENTRY_TYPE_RELAY:
+		if (is_channel_data(buf, len)) {
+			JLOG_DEBUG("Received ChannelData datagram");
+			return agent_process_channel_data(agent, entry, buf, len);
+		}
+		break;
+
+	case AGENT_STUN_ENTRY_TYPE_CHECK:
+		JLOG_DEBUG("Received application datagram");
+		if (agent->config.cb_recv)
+			agent->config.cb_recv(agent, buf, len, agent->config.user_ptr);
+		return 0;
+
+	default:
+		break;
+	}
+
+	JLOG_WARN("Received unexpected non-STUN datagram, ignoring");
+	return -1;
+}
+
+void agent_register_entry_for_candidate_pair(juice_agent_t *agent, ice_candidate_pair_t *pair,
+                                             agent_stun_entry_t *relay_entry) {
+	JLOG_VERBOSE("Registering STUN entry %d for candidate pair checking", agent->entries_count);
+	agent_stun_entry_t *entry = agent->entries + agent->entries_count;
+	entry->type = AGENT_STUN_ENTRY_TYPE_CHECK;
+	entry->state = AGENT_STUN_ENTRY_STATE_IDLE;
+	entry->mode = AGENT_MODE_UNKNOWN;
+	entry->pair = pair;
+	entry->record = pair->remote->resolved;
+	entry->relay_entry = relay_entry;
+	juice_random(entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+	entry->transaction_id_expired = false;
+	++agent->entries_count;
+
+	if (pair->remote->type == ICE_CANDIDATE_TYPE_HOST)
+		agent_translate_host_candidate_entry(agent, entry);
+}
+
+int agent_conn_tcp_state(juice_agent_t *agent, const addr_record_t *dst, tcp_state_t state) {
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry_is_tcp(entry) && addr_record_is_equal(&entry->record, dst, true)) {
+			entry->tcp_state = state;
+			switch (state) {
+			case TCP_STATE_CONNECTED:
+				agent_arm_transmission(agent, entry, 0); // transmit now
+				break;
+			case TCP_STATE_DISCONNECTED:
+			case TCP_STATE_FAILED:
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				entry->next_transmission = 0;
+
+				if(entry->pair)
+					entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+
+				conn_interrupt(agent);
+				break;
+			default:
+				break;
+			}
+			return 0;
+		}
+	}
+
+	JLOG_WARN("No entry found for TCP address");
+	return -1;
+}
+
+int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
+	JLOG_VERBOSE("Bookkeeping...");
+
+	timestamp_t now = current_timestamp();
+	*next_timestamp = now + 6000000;
+
+	if (agent->state == JUICE_STATE_DISCONNECTED || agent->state == JUICE_STATE_GATHERING)
+		return 0;
+
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+
+		if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) { // STUN transmission or retransmission
+			if (entry->next_transmission > now)
+				continue;
+
+			if (entry_is_tcp(entry)) {
+			    if (entry->tcp_state == TCP_STATE_DISCONNECTED)
+					conn_tcp_connect(agent, &entry->record); // First attempt a TCP connection
+
+				if(entry->tcp_state != TCP_STATE_CONNECTED)
+					continue;
+			}
+
+			if (entry->retransmissions >= 0) {
+				if (JLOG_DEBUG_ENABLED) {
+					char record_str[ADDR_MAX_STRING_LEN];
+					addr_record_to_string(&entry->record, record_str, ADDR_MAX_STRING_LEN);
+					if (entry->retransmissions == 0) {
+						JLOG_DEBUG("STUN entry %d: Sending request to %s (no retransmission)", i,
+						           record_str);
+					} else if (entry->retransmissions == 1) {
+						JLOG_DEBUG("STUN entry %d: Sending request to %s (1 retransmission left)",
+						           i, record_str);
+					} else {
+						JLOG_DEBUG("STUN entry %d: Sending request to %s (%d retransmissions left)",
+						           i, record_str, entry->retransmissions);
+					}
+				}
+				if (entry->transaction_id_expired) {
+					juice_random(entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+					entry->transaction_id_expired = false;
+				}
+				int ret;
+				switch (entry->type) {
+				case AGENT_STUN_ENTRY_TYPE_RELAY:
+					ret = agent_send_turn_allocate_request(agent, entry, STUN_METHOD_ALLOCATE);
+					break;
+
+				default:
+					ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
+					break;
+				}
+
+				if (ret >= 0) {
+					--entry->retransmissions;
+					if (entry->retransmissions < 0) {
+						entry->next_transmission = now + LAST_STUN_RETRANSMISSION_TIMEOUT;
+					} else {
+						entry->next_transmission = now + entry->retransmission_timeout;
+						entry->retransmission_timeout *= 2;
+					}
+					continue;
+				}
+			}
+
+			// Failure sending or end of retransmissions
+			JLOG_DEBUG("STUN entry %d: Failed", i);
+			entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+			entry->next_transmission = 0;
+
+			switch (entry->type) {
+			case AGENT_STUN_ENTRY_TYPE_RELAY:
+				JLOG_INFO("TURN allocation failed");
+				agent_update_gathering_done(agent);
+				break;
+
+			case AGENT_STUN_ENTRY_TYPE_SERVER:
+				JLOG_INFO("STUN server binding failed");
+				agent_update_gathering_done(agent);
+				break;
+
+			default:
+				if (entry->pair) {
+					JLOG_DEBUG("Candidate pair check failed");
+					entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+				}
+				break;
+			}
+		}
+		// STUN keepalives
+		else if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+			// No expiration
+#else
+			// Consent freshness expiration
+			if (entry->pair && entry->pair->consent_expiry <= now) {
+				JLOG_INFO("STUN entry %d: Consent expired for candidate pair", i);
+				entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				entry->next_transmission = 0;
+				continue;
+			}
+#endif
+
+			if (entry->next_transmission > now)
+				continue;
+
+			JLOG_DEBUG("STUN entry %d: Sending keepalive", i);
+
+			juice_random(entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+			entry->transaction_id_expired = false;
+
+			int ret;
+			switch (entry->type) {
+			case AGENT_STUN_ENTRY_TYPE_RELAY:
+				// RFC 8445 5.1.1.4. Keeping Candidates Alive:
+				// Refreshes for allocations are done using the Refresh transaction, as described in
+				// [RFC5766]
+				ret = agent_send_turn_allocate_request(agent, entry, STUN_METHOD_REFRESH);
+				break;
+			case AGENT_STUN_ENTRY_TYPE_SERVER:
+				// RFC 8445 5.1.1.4. Keeping Candidates Alive:
+				// For server-reflexive candidates learned through a Binding request, the bindings
+				// MUST be kept alive by additional Binding requests to the server.
+				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
+				break;
+			default:
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+				// RFC 8445 11. Keepalives:
+				// All endpoints MUST send keepalives for each data session. [...] STUN keepalives
+				// MUST be used when an ICE agent is a full ICE implementation and is communicating
+				// with a peer that supports ICE (lite or full). [...] When STUN is being used for
+				// keepalives, a STUN Binding Indication is used [RFC5389].
+				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_INDICATION, 0, NULL, NULL);
+#else
+				// RFC 7675 4. Design Considerations:
+				// STUN binding requests sent for consent freshness also serve the keepalive purpose
+				// (i.e., to keep NAT bindings alive). Because of that, dedicated keepalives (e.g.,
+				// STUN Binding Indications) are not sent on candidate pairs where consent requests
+				// are sent, in accordance with Section 20.2.3 of [RFC5245].
+				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
+#endif
+				break;
+			}
+
+			if (ret < 0) {
+				JLOG_WARN("Sending keepalive failed");
+				agent_arm_transmission(agent, entry, STUN_KEEPALIVE_PERIOD);
+				continue;
+			}
+
+			agent_arm_keepalive(agent, entry);
+
+		} else {
+			// Entry does not transmit, unset next transmission
+			entry->next_transmission = 0;
+		}
+	}
+
+	int pending_count = 0;
+	ice_candidate_pair_t *nominated_pair = NULL;
+	ice_candidate_pair_t *selected_pair = NULL;
+	for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+		ice_candidate_pair_t *pair = agent->ordered_pairs[i];
+		if (pair->nominated) {
+			// RFC 8445 8.1.1. Nominating Pairs:
+			// If more than one candidate pair is nominated by the controlling agent, and if the
+			// controlled agent accepts multiple nominations requests, the agents MUST produce the
+			// selected pairs and use the pairs with the highest priority.
+			if (!nominated_pair) {
+				nominated_pair = pair;
+				selected_pair = pair;
+			}
+		} else if (pair->state == ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
+			if (!selected_pair)
+				selected_pair = pair;
+		} else if (pair->state == ICE_CANDIDATE_PAIR_STATE_PENDING) {
+			if (agent->mode == AGENT_MODE_CONTROLLING && selected_pair) {
+				// A higher-priority pair will be used, we can stop checking.
+				// Entries will be synchronized after the current loop.
+				JLOG_VERBOSE("Cancelling check for lower-priority pair");
+				pair->state = ICE_CANDIDATE_PAIR_STATE_FROZEN;
+			} else {
+				++pending_count;
+			}
+		}
+	}
+
+	if (agent->mode == AGENT_MODE_CONTROLLING && nominated_pair) {
+		// RFC 8445 8.1.1. Nominating Pairs:
+		// Once the controlling agent has successfully nominated a candidate pair, the agent MUST
+		// NOT nominate another pair for same component of the data stream within the ICE session.
+		for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+			ice_candidate_pair_t *pair = agent->ordered_pairs[i];
+			if (pair != nominated_pair && pair->state == ICE_CANDIDATE_PAIR_STATE_PENDING) {
+				// Entries will be synchronized after the current loop.
+				JLOG_VERBOSE("Cancelling check for non-nominated pair");
+				pair->state = ICE_CANDIDATE_PAIR_STATE_FROZEN;
+			}
+		}
+		pending_count = 0;
+	}
+
+	// Cancel entries of frozen pairs
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry->pair && entry->pair->state == ICE_CANDIDATE_PAIR_STATE_FROZEN &&
+		    entry->state != AGENT_STUN_ENTRY_STATE_IDLE &&
+		    entry->state != AGENT_STUN_ENTRY_STATE_CANCELLED) {
+			JLOG_DEBUG("STUN entry %d: Cancelled", i);
+			entry->state = AGENT_STUN_ENTRY_STATE_CANCELLED;
+			entry->next_transmission = 0;
+		}
+	}
+
+	if (nominated_pair && nominated_pair->state == ICE_CANDIDATE_PAIR_STATE_FAILED) {
+		JLOG_WARN("Lost connectivity");
+		agent_change_state(agent, JUICE_STATE_FAILED);
+		atomic_store(&agent->selected_entry, NULL); // disallow sending
+		return 0;
+	}
+
+	if (selected_pair) {
+		// Change selected entry if this is a new selected pair
+		if (agent->selected_pair != selected_pair) {
+			JLOG_DEBUG(selected_pair->nominated ? "New selected and nominated pair"
+			                                    : "New selected pair");
+			agent->selected_pair = selected_pair;
+
+			// Start nomination timer if controlling
+			if (agent->mode == AGENT_MODE_CONTROLLING)
+				agent->nomination_timestamp = now + NOMINATION_TIMEOUT;
+
+			for (int i = 0; i < agent->entries_count; ++i) {
+				agent_stun_entry_t *entry = agent->entries + i;
+				if (entry->pair == selected_pair) {
+					atomic_store(&agent->selected_entry, entry);
+					break;
+				}
+			}
+		}
+
+		if (nominated_pair) {
+			// Completed
+			// Do not allow direct transition from connecting to completed
+			if (agent->state == JUICE_STATE_CONNECTING)
+				agent_change_state(agent, JUICE_STATE_CONNECTED);
+
+			agent_change_state(agent, JUICE_STATE_COMPLETED);
+
+			agent_stun_entry_t *nominated_entry = NULL;
+			agent_stun_entry_t *relay_entry = NULL;
+			for (int i = 0; i < agent->entries_count; ++i) {
+				agent_stun_entry_t *entry = agent->entries + i;
+				if (entry->pair && entry->pair == nominated_pair) {
+					nominated_entry = entry;
+					relay_entry = nominated_entry->relay_entry;
+					break;
+				}
+			}
+
+			// Enable keepalive for the entry of the nominated pair
+			if (nominated_entry &&
+			    nominated_entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+				nominated_entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
+				agent_arm_keepalive(agent, nominated_entry);
+				atomic_store(&agent->selected_entry, nominated_entry); // for consistency
+			}
+
+			// If the entry of the nominated candidate is relayed locally, we need also to
+			// refresh the corresponding TURN session regularly
+			if (relay_entry && relay_entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+				relay_entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
+				agent_arm_keepalive(agent, relay_entry);
+			}
+
+			// Disable keepalives for other entries
+			for (int i = 0; i < agent->entries_count; ++i) {
+				agent_stun_entry_t *entry = agent->entries + i;
+				if (entry != nominated_entry && entry != relay_entry &&
+				    entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE)
+					entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+			}
+
+		} else {
+			// Connected
+			agent_change_state(agent, JUICE_STATE_CONNECTED);
+
+			if (agent->mode == AGENT_MODE_CONTROLLING && !selected_pair->nomination_requested) {
+				if (pending_count == 0 ||
+				    (agent->nomination_timestamp && now >= agent->nomination_timestamp)) {
+					// Nominate selected
+					JLOG_DEBUG("Requesting pair nomination (controlling)");
+					selected_pair->nomination_requested = true;
+					for (int i = 0; i < agent->entries_count; ++i) {
+						agent_stun_entry_t *entry = agent->entries + i;
+						if (entry->pair && entry->pair == selected_pair) {
+							entry->state =
+							    AGENT_STUN_ENTRY_STATE_PENDING;      // we don't want keepalives
+							entry->transaction_id_expired = true;    // this is a new request
+							agent_arm_transmission(agent, entry, 0); // transmit now
+							break;
+						}
+					}
+				} else if (agent->nomination_timestamp &&
+				           *next_timestamp > agent->nomination_timestamp) {
+					*next_timestamp = agent->nomination_timestamp;
+				}
+			}
+		}
+
+	} else if (pending_count == 0 && agent->pac_timestamp) {
+		// RFC 8863: While the timer is still running, the ICE agent MUST NOT update a checklist
+		// state from Running to Failed, even if there are no pairs left in the checklist to check.
+		if (now >= agent->pac_timestamp) {
+			JLOG_INFO("Connectivity timer expired");
+			agent_change_state(agent, JUICE_STATE_FAILED);
+			atomic_store(&agent->selected_entry, NULL); // disallow sending
+			return 0;
+		} else if (*next_timestamp > agent->pac_timestamp) {
+			*next_timestamp = agent->pac_timestamp;
+		}
+	}
+
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry->next_transmission && *next_timestamp > entry->next_transmission)
+			*next_timestamp = entry->next_transmission;
+
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+		// No expiration
+#else
+		if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE && entry->pair &&
+		    *next_timestamp > entry->pair->consent_expiry)
+			*next_timestamp = selected_pair->consent_expiry;
+#endif
+	}
+
+	return 0;
+}
+
+void agent_change_state(juice_agent_t *agent, juice_state_t state) {
+	if (state != agent->state) {
+		JLOG_INFO("Changing state to %s", juice_state_to_string(state));
+		agent->state = state;
+		if (agent->config.cb_state_changed)
+			agent->config.cb_state_changed(agent, state, agent->config.user_ptr);
+	}
+}
+
+int agent_verify_stun_binding(juice_agent_t *agent, void *buf, size_t size,
+                              const stun_message_t *msg) {
+	if (msg->msg_method != STUN_METHOD_BINDING)
+		return -1;
+
+	if (msg->msg_class == STUN_CLASS_INDICATION || msg->msg_class == STUN_CLASS_RESP_ERROR)
+		return 0;
+
+	if (!msg->has_integrity) {
+		JLOG_WARN("Missing integrity in STUN message");
+		return -1;
+	}
+
+	// Check username (The USERNAME attribute is not present in responses)
+	if (msg->msg_class == STUN_CLASS_REQUEST) {
+		char username[STUN_MAX_USERNAME_LEN];
+		strcpy(username, msg->credentials.username);
+		char *separator = strchr(username, ':');
+		if (!separator) {
+			JLOG_WARN("STUN username invalid, username=\"%s\"", username);
+			return -1;
+		}
+		*separator = '\0';
+		const char *local_ufrag = username;
+		const char *remote_ufrag = separator + 1;
+		if (strcmp(local_ufrag, agent->local.ice_ufrag) != 0) {
+			JLOG_WARN("STUN local ufrag check failed, expected=\"%s\", actual=\"%s\"",
+			          agent->local.ice_ufrag, local_ufrag);
+			return -1;
+		}
+		// RFC 8445 7.3. STUN Server Procedures:
+		// It is possible (and in fact very likely) that the initiating agent will receive a Binding
+		// request prior to receiving the candidates from its peer.  If this happens, the agent MUST
+		// immediately generate a response.
+		if (*agent->remote.ice_ufrag != '\0' &&
+		    strcmp(remote_ufrag, agent->remote.ice_ufrag) != 0) {
+			JLOG_WARN("STUN remote ufrag check failed, expected=\"%s\", actual=\"%s\"",
+			          agent->remote.ice_ufrag, remote_ufrag);
+			return -1;
+		}
+	}
+	// Check password
+	const char *password =
+	    msg->msg_class == STUN_CLASS_REQUEST ? agent->local.ice_pwd : agent->remote.ice_pwd;
+	if (*password == '\0') {
+		JLOG_WARN("STUN integrity check failed, unknown password");
+		return -1;
+	}
+	if (!stun_check_integrity(buf, size, msg, password)) {
+		JLOG_WARN("STUN integrity check failed, password=\"%s\"", password);
+		return -1;
+	}
+	return 0;
+}
+
+int agent_verify_credentials(juice_agent_t *agent, const agent_stun_entry_t *entry, void *buf,
+                             size_t size, stun_message_t *msg) {
+	(void)agent;
+
+	// RFC 8489: If the response is an error response with an error code of 400 (Bad Request) and
+	// does not contain either the MESSAGE-INTEGRITY or MESSAGE-INTEGRITY-SHA256 attribute, then the
+	// response MUST be discarded, as if it were never received.  This means that retransmits, if
+	// applicable, will continue.
+	if (msg->msg_class == STUN_CLASS_INDICATION ||
+	    (msg->msg_class == STUN_CLASS_RESP_ERROR && msg->error_code != 400))
+		return 0;
+
+	if (!msg->has_integrity) {
+		JLOG_WARN("Missing integrity in STUN message");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_WARN("No credentials for entry");
+		return -1;
+	}
+	stun_credentials_t *credentials = &entry->turn->credentials;
+	const char *password = entry->turn->password;
+
+	// Prepare credentials
+	strcpy(msg->credentials.realm, credentials->realm);
+	strcpy(msg->credentials.nonce, credentials->nonce);
+	strcpy(msg->credentials.username, credentials->username);
+
+	// Check credentials
+	if (!stun_check_integrity(buf, size, msg, password)) {
+		JLOG_WARN("STUN integrity check failed");
+		return -1;
+	}
+	return 0;
+}
+
+int agent_dispatch_stun(juice_agent_t *agent, void *buf, size_t size, stun_message_t *msg,
+                        const addr_record_t *src, const addr_record_t *relayed) {
+	if (msg->msg_method == STUN_METHOD_BINDING && msg->has_integrity) {
+		JLOG_VERBOSE("STUN message is from the remote peer");
+		// Verify the message now
+		if (agent_verify_stun_binding(agent, buf, size, msg)) {
+			JLOG_WARN("STUN message verification failed");
+			return -1;
+		}
+		if (agent_add_remote_reflexive_candidate(agent, ICE_CANDIDATE_TYPE_PEER_REFLEXIVE,
+		                                         msg->priority, src)) {
+			JLOG_WARN("Failed to add remote peer reflexive candidate from STUN message");
+		}
+	}
+
+	agent_stun_entry_t *entry = NULL;
+	if (STUN_IS_RESPONSE(msg->msg_class)) {
+		JLOG_VERBOSE("STUN message is a response, looking for transaction ID");
+		entry = agent_find_entry_from_transaction_id(agent, msg->transaction_id);
+		if (!entry) {
+			JLOG_DEBUG("No STUN entry matching transaction ID, ignoring");
+			return -1;
+		}
+	} else {
+		JLOG_VERBOSE("STUN message is a request or indication, looking for remote address");
+		entry = agent_find_entry_from_record(agent, src, relayed);
+		if (entry) {
+			JLOG_VERBOSE("Found STUN entry matching remote address");
+		} else {
+			// This may happen normally, for instance when there is no space left for reflexive
+			// candidates
+			JLOG_DEBUG("No STUN entry matching remote address, ignoring");
+			return 0;
+		}
+	}
+
+	switch (msg->msg_method) {
+	case STUN_METHOD_BINDING:
+		// Message was verified earlier, no need to re-verify
+		if (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK && !msg->has_integrity &&
+		    (msg->msg_class == STUN_CLASS_REQUEST || msg->msg_class == STUN_CLASS_RESP_SUCCESS)) {
+			JLOG_WARN("Missing integrity in STUN Binding message from remote peer, ignoring");
+			return -1;
+		}
+		return agent_process_stun_binding(agent, msg, entry, src, relayed);
+
+	case STUN_METHOD_ALLOCATE:
+	case STUN_METHOD_REFRESH:
+		if (agent_verify_credentials(agent, entry, buf, size, msg)) {
+			JLOG_WARN("Ignoring TURN Allocate message with invalid credentials (Is server "
+			          "authentication disabled?)");
+			return -1;
+		}
+		return agent_process_turn_allocate(agent, msg, entry);
+
+	case STUN_METHOD_CREATE_PERMISSION:
+		if (agent_verify_credentials(agent, entry, buf, size, msg)) {
+			JLOG_WARN("Ignoring TURN CreatePermission message with invalid credentials");
+			return -1;
+		}
+		return agent_process_turn_create_permission(agent, msg, entry);
+
+	case STUN_METHOD_CHANNEL_BIND:
+		if (agent_verify_credentials(agent, entry, buf, size, msg)) {
+			JLOG_WARN("Ignoring TURN ChannelBind message with invalid credentials");
+			return -1;
+		}
+		return agent_process_turn_channel_bind(agent, msg, entry);
+
+	case STUN_METHOD_DATA:
+		return agent_process_turn_data(agent, msg, entry);
+
+	default:
+		JLOG_WARN("Unknown STUN method 0x%X, ignoring", msg->msg_method);
+		return -1;
+	}
+}
+
+int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
+                               agent_stun_entry_t *entry, const addr_record_t *src,
+                               const addr_record_t *relayed) {
+
+	switch (msg->msg_class) {
+	case STUN_CLASS_REQUEST: {
+		JLOG_DEBUG("Received STUN Binding request");
+		if (entry->type != AGENT_STUN_ENTRY_TYPE_CHECK)
+			return -1;
+
+		ice_candidate_pair_t *pair = entry->pair;
+		if (msg->ice_controlling == msg->ice_controlled) {
+			JLOG_WARN("Controlling and controlled attributes mismatch in request");
+			agent_send_stun_binding(agent, entry, STUN_CLASS_RESP_ERROR, 400, msg->transaction_id,
+			                        NULL);
+			return -1;
+		}
+		// RFC8445 7.3.1.1. Detecting and Repairing Role Conflicts:
+		// If the agent is in the controlling role, and the ICE-CONTROLLING attribute is present in
+		// the request:
+		//  * If the agent's tiebreaker value is larger than or equal to the contents of the
+		//  ICE-CONTROLLING attribute, the agent generates a Binding error response and includes an
+		//  ERROR-CODE attribute with a value of 487 (Role Conflict) but retains its role.
+		//  * If the agent's tiebreaker value is less than the contents of the ICE-CONTROLLING
+		//  attribute, the agent switches to the controlled role.
+		if (agent->mode == AGENT_MODE_CONTROLLING && msg->ice_controlling) {
+			JLOG_WARN("ICE role conflict (both controlling)");
+			if (agent->ice_tiebreaker >= msg->ice_controlling) {
+				JLOG_DEBUG("Asking remote peer to switch roles");
+				agent_send_stun_binding(agent, entry, STUN_CLASS_RESP_ERROR, 487,
+				                        msg->transaction_id, NULL);
+			} else {
+				JLOG_DEBUG("Switching to controlled role");
+				agent->mode = AGENT_MODE_CONTROLLED;
+				agent_update_candidate_pairs(agent);
+			}
+			break;
+		}
+		// If the agent is in the controlled role, and the ICE-CONTROLLED attribute is present in
+		// the request:
+		//  * If the agent's tiebreaker value is larger than or equal to the contents of the
+		//  ICE-CONTROLLED attribute, the agent switches to the controlling role.
+		//  * If the agent's tiebreaker value is less than the contents of the ICE-CONTROLLED
+		//  attribute, the agent generates a Binding error response and includes an ERROR-CODE
+		//  attribute with a value of 487 (Role Conflict) but retains its role.
+		if (agent->mode == AGENT_MODE_CONTROLLED && msg->ice_controlled) {
+			JLOG_WARN("ICE role conflict (both controlled)");
+			if (agent->ice_tiebreaker >= msg->ice_controlling) {
+				JLOG_DEBUG("Switching to controlling role");
+				agent->mode = AGENT_MODE_CONTROLLING;
+				agent_update_candidate_pairs(agent);
+			} else {
+				JLOG_DEBUG("Asking remote peer to switch roles");
+				agent_send_stun_binding(agent, entry, STUN_CLASS_RESP_ERROR, 487,
+				                        msg->transaction_id, NULL);
+			}
+			break;
+		}
+		if (msg->use_candidate) {
+			if (!msg->ice_controlling) {
+				JLOG_WARN("STUN message use_candidate missing ice_controlling attribute");
+				agent_send_stun_binding(agent, entry, STUN_CLASS_RESP_ERROR, 400,
+				                        msg->transaction_id, NULL);
+				return -1;
+			}
+			// RFC 8445 7.3.1.5. Updating the Nominated Flag:
+			// If the state of this pair is Succeeded, it means that the check previously sent by
+			// this pair produced a successful response and generated a valid pair. The agent sets
+			// the nominated flag value of the valid pair to true.
+			if (pair->state == ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
+				JLOG_DEBUG("Got a nominated pair (controlled)");
+				pair->nominated = true;
+			} else if (!pair->nomination_requested) {
+				JLOG_DEBUG("Pair nomination requested (controlled)");
+				pair->nomination_requested = true;
+			}
+		}
+		// Response
+		if (agent_send_stun_binding(agent, entry, STUN_CLASS_RESP_SUCCESS, 0, msg->transaction_id,
+		                            src)) {
+			JLOG_ERROR("Failed to send STUN Binding response");
+			return -1;
+		}
+		// Triggered check
+		// RFC 8445: If the state of that pair is Succeeded, nothing further is done. If the state
+		// of that pair is In-Progress, [...] the agent MUST [...] trigger a new connectivity check
+		// of the pair. [...] If the state of that pair is Waiting, Frozen, or Failed, the agent
+		// MUST [...] trigger a new connectivity check of the pair.
+		if (pair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED && *agent->remote.ice_ufrag != '\0') {
+			JLOG_DEBUG("Triggered pair check");
+			pair->state = ICE_CANDIDATE_PAIR_STATE_PENDING;
+			entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+			agent_arm_transmission(agent, entry, STUN_PACING_TIME);
+		}
+		break;
+	}
+	case STUN_CLASS_RESP_SUCCESS: {
+		JLOG_DEBUG("Received STUN Binding success response from %s",
+		           entry->type == AGENT_STUN_ENTRY_TYPE_CHECK ? "peer" : "server");
+
+		if (entry->type == AGENT_STUN_ENTRY_TYPE_SERVER)
+			JLOG_INFO("STUN server binding successful");
+
+		if (entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+			entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+			entry->next_transmission = 0;
+		}
+
+		if (!agent->selected_pair || !agent->selected_pair->nominated) {
+			// We want to send keepalives now
+			entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
+			agent_arm_keepalive(agent, entry);
+		}
+
+		if (msg->mapped.len && !relayed) {
+			JLOG_VERBOSE("Response has mapped address");
+
+			if (JLOG_INFO_ENABLED && entry->type != AGENT_STUN_ENTRY_TYPE_CHECK) {
+				char mapped_str[ADDR_MAX_STRING_LEN];
+				addr_record_to_string(&msg->mapped, mapped_str, ADDR_MAX_STRING_LEN);
+				JLOG_INFO("Got STUN mapped address %s from server", mapped_str);
+			}
+
+			ice_candidate_type_t type = (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK)
+			                                ? ICE_CANDIDATE_TYPE_PEER_REFLEXIVE
+			                                : ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE;
+			if (agent_add_local_reflexive_candidate(agent, type, &msg->mapped)) {
+				JLOG_WARN("Failed to add local peer reflexive candidate from STUN mapped address");
+			}
+		}
+
+		if (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK) {
+			ice_candidate_pair_t *pair = entry->pair;
+			if (!pair) {
+				JLOG_ERROR("STUN entry for candidate pair checking has no candidate pair");
+				return -1;
+			}
+
+			if (pair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
+				// 7.2.5.2.1. Non-Symmetric Transport Addresses:
+				// The ICE agent MUST check that the source and destination transport addresses in
+				// the Binding request and response are symmetric. [...] If the addresses are not
+				// symmetric, the agent MUST set the candidate pair state to Failed.
+				if (!addr_record_is_equal(src, &entry->record, true)) {
+					JLOG_DEBUG(
+					    "Candidate pair check failed (non-symmetric source address in response)");
+					entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+					entry->next_transmission = 0;
+					pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+					break;
+				}
+
+				JLOG_DEBUG("Candidate pair check succeeded");
+				pair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
+			}
+
+			if (!pair->local && msg->mapped.len)
+				pair->local = ice_find_candidate_from_addr(&agent->local, &msg->mapped,
+				                                           ICE_CANDIDATE_TYPE_UNKNOWN);
+
+			// Update consent timestamp
+			pair->consent_expiry = current_timestamp() + CONSENT_TIMEOUT;
+
+			// RFC 8445 7.3.1.5. Updating the Nominated Flag:
+			// [...] once the check is sent and if it generates a successful response, and
+			// generates a valid pair, the agent sets the nominated flag of the pair to true.
+			if (pair->nomination_requested) {
+				JLOG_DEBUG("Got a nominated pair (%s)",
+				           agent->mode == AGENT_MODE_CONTROLLING ? "controlling" : "controlled");
+				pair->nominated = true;
+			}
+		} else if (entry->type == AGENT_STUN_ENTRY_TYPE_SERVER) {
+			agent_update_gathering_done(agent);
+		}
+		break;
+	}
+	case STUN_CLASS_RESP_ERROR: {
+		if (msg->error_code != STUN_ERROR_INTERNAL_VALIDATION_FAILED) {
+			if (msg->error_code == 487)
+				JLOG_DEBUG("Got STUN Binding error response, code=%u",
+				           (unsigned int)msg->error_code);
+			else
+				JLOG_WARN("Got STUN Binding error response, code=%u",
+				          (unsigned int)msg->error_code);
+		}
+
+		if (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK) {
+			if (msg->error_code == 487) {
+				if (entry->mode == agent->mode) {
+					// RFC 8445 7.2.5.1. Role Conflict:
+					// If the Binding request generates a 487 (Role Conflict) error response, and if
+					// the ICE agent included an ICE-CONTROLLED attribute in the request, the agent
+					// MUST switch to the controlling role. If the agent included an ICE-CONTROLLING
+					// attribute in the request, the agent MUST switch to the controlled role. Once
+					// the agent has switched its role, the agent MUST [...] set the candidate pair
+					// state to Waiting [and] change the tiebreaker value.
+					JLOG_WARN("ICE role conflict");
+					JLOG_DEBUG("Switching roles to %s as requested",
+					           entry->mode == AGENT_MODE_CONTROLLING ? "controlled"
+					                                                 : "controlling");
+					agent->mode = entry->mode == AGENT_MODE_CONTROLLING ? AGENT_MODE_CONTROLLED
+					                                                    : AGENT_MODE_CONTROLLING;
+					juice_random(&agent->ice_tiebreaker, sizeof(agent->ice_tiebreaker));
+					agent_update_candidate_pairs(agent); // expires transaction IDs
+
+					if (entry->state != AGENT_STUN_ENTRY_STATE_IDLE) { // Check might not be started
+						entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+						agent_arm_transmission(agent, entry, 0);
+					}
+				} else {
+					JLOG_DEBUG("Already switched roles to %s as requested",
+					           agent->mode == AGENT_MODE_CONTROLLING ? "controlling"
+					                                                 : "controlled");
+				}
+			} else {
+				// 7.2.5.2.4. Unrecoverable STUN Response:
+				// If the Binding request generates a STUN error response that is unrecoverable
+				// [RFC5389], the ICE agent SHOULD set the candidate pair state to Failed.
+				JLOG_DEBUG("Chandidate pair check failed (unrecoverable error)");
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				entry->next_transmission = 0;
+				if (entry->pair)
+					entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+			}
+		} else if (entry->type == AGENT_STUN_ENTRY_TYPE_SERVER) {
+			JLOG_INFO("STUN server binding failed (unrecoverable error)");
+			entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+			agent_update_gathering_done(agent);
+		}
+		break;
+	}
+	case STUN_CLASS_INDICATION: {
+		JLOG_VERBOSE("Received STUN Binding indication");
+		break;
+	}
+	default: {
+		JLOG_WARN("Got STUN unexpected binding message, class=%u", (unsigned int)msg->msg_class);
+		return -1;
+	}
+	}
+	return 0;
+}
+
+int agent_send_stun_binding(juice_agent_t *agent, agent_stun_entry_t *entry, stun_class_t msg_class,
+                            unsigned int error_code, const uint8_t *transaction_id,
+                            const addr_record_t *mapped) {
+	// Send STUN Binding
+	JLOG_DEBUG("Sending STUN Binding %s",
+	           msg_class == STUN_CLASS_REQUEST
+	               ? "request"
+	               : (msg_class == STUN_CLASS_INDICATION ? "indication" : "response"));
+
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = msg_class;
+	msg.msg_method = STUN_METHOD_BINDING;
+
+	if ((msg_class == STUN_CLASS_RESP_SUCCESS || msg_class == STUN_CLASS_RESP_ERROR) &&
+	    !transaction_id) {
+		JLOG_ERROR("No transaction ID specified for STUN response");
+		return -1;
+	}
+
+	if (transaction_id)
+		memcpy(msg.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+	else if (msg_class == STUN_CLASS_INDICATION)
+		juice_random(msg.transaction_id, STUN_TRANSACTION_ID_SIZE);
+	else
+		memcpy(msg.transaction_id, entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	const char *password = NULL;
+	if (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK) {
+		// RFC 8445 7.2.2. Forming Credentials:
+		// A connectivity-check Binding request MUST utilize the STUN short-term credential
+		// mechanism. The username for the credential is formed by concatenating the username
+		// fragment provided by the peer with the username fragment of the ICE agent sending the
+		// request, separated by a colon (":"). The password is equal to the password provided by
+		// the peer.
+		switch (msg_class) {
+		case STUN_CLASS_REQUEST: {
+			if (*agent->remote.ice_ufrag == '\0' || *agent->remote.ice_pwd == '\0') {
+				JLOG_DEBUG("Missing remote ICE credentials, dropping STUN binding request");
+				return 0;
+			}
+			snprintf(msg.credentials.username, STUN_MAX_USERNAME_LEN, "%s:%s",
+			         agent->remote.ice_ufrag, agent->local.ice_ufrag);
+			password = agent->remote.ice_pwd;
+			msg.ice_controlling = agent->mode == AGENT_MODE_CONTROLLING ? agent->ice_tiebreaker : 0;
+			msg.ice_controlled = agent->mode == AGENT_MODE_CONTROLLED ? agent->ice_tiebreaker : 0;
+
+			// RFC 8445 7.1.1. PRIORITY
+			// The PRIORITY attribute MUST be included in a Binding request and be set to the value
+			// computed by the algorithm in Section 5.1.2 for the local candidate, but with the
+			// candidate type preference of peer-reflexive candidates.
+			int family = entry->record.addr.ss_family;
+			int index = entry->pair && entry->pair->local
+			                ? (int)(entry->pair->local - agent->local.candidates)
+			                : 0;
+			msg.priority =
+			    ice_compute_priority(ICE_CANDIDATE_TYPE_PEER_REFLEXIVE, family, 1, index, false);
+
+			// RFC 8445 8.1.1. Nominating Pairs:
+			// Once the controlling agent has picked a valid pair for nomination, it repeats the
+			// connectivity check that produced this valid pair [...], this time with the
+			// USE-CANDIDATE attribute.
+			msg.use_candidate = agent->mode == AGENT_MODE_CONTROLLING && entry->pair &&
+			                    entry->pair->nomination_requested && !entry->pair->nominated;
+
+			entry->mode = agent->mode; // save current mode in case of conflict
+			break;
+		}
+		case STUN_CLASS_RESP_SUCCESS:
+		case STUN_CLASS_RESP_ERROR: {
+			password = agent->local.ice_pwd;
+			msg.error_code = error_code;
+			if (mapped)
+				msg.mapped = *mapped;
+
+			break;
+		}
+		case STUN_CLASS_INDICATION: {
+			// RFC8445 11. Keepalives:
+			// When STUN is being used for keepalives, a STUN Binding Indication is used. The
+			// Indication MUST NOT utilize any authentication mechanism. It SHOULD contain the
+			// FINGERPRINT attribute to aid in demultiplexing, but it SHOULD NOT contain any other
+			// attributes.
+		}
+		}
+	}
+
+	char buffer[BUFFER_SIZE];
+	int size = stun_write(buffer, BUFFER_SIZE, &msg, password);
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+
+	if (entry->relay_entry) {
+		// The datagram must be sent through the relay
+		JLOG_DEBUG("Sending STUN message via relay");
+		int ret;
+		if (entry->pair && entry->pair->nominated)
+			ret = agent_channel_send(agent, entry->relay_entry, &entry->record, buffer, size, 0);
+		else
+			ret = agent_relay_send(agent, entry->relay_entry, &entry->record, buffer, size, 0);
+
+		if (ret < 0) {
+			JLOG_WARN("STUN message send via relay failed");
+			return -1;
+		}
+		return 0;
+	}
+
+	// Direct send
+	int ret = agent_direct_send(agent, &entry->record, buffer, size, 0);
+	if (ret < 0) {
+		if (ret == -SENETUNREACH)
+			JLOG_INFO("STUN binding failed: Network unreachable");
+		else
+			JLOG_WARN("STUN message send failed");
+
+		return -1;
+	}
+	return 0;
+}
+
+int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
+                                agent_stun_entry_t *entry) {
+	if (msg->msg_method != STUN_METHOD_ALLOCATE && msg->msg_method != STUN_METHOD_REFRESH)
+		return -1;
+
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_WARN("Received TURN %s message for a non-relay entry, ignoring",
+		          msg->msg_method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+
+	switch (msg->msg_class) {
+	case STUN_CLASS_RESP_SUCCESS: {
+		JLOG_DEBUG("Received TURN %s success response",
+		           msg->msg_method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh");
+
+		if (msg->msg_method == STUN_METHOD_REFRESH) {
+			JLOG_DEBUG("TURN refresh successful");
+			// There is nothing to do
+			break;
+		}
+
+		JLOG_DEBUG("TURN allocate successful");
+
+		if (!msg->relayed.len) {
+			JLOG_ERROR("Expected relayed address in TURN Allocate response");
+			entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+			return -1;
+		}
+
+		if (entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+			entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+			entry->next_transmission = 0;
+		}
+
+		if (!agent->selected_pair || !agent->selected_pair->nominated) {
+			// We want to send refresh requests for keepalive now
+			entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
+			agent_arm_keepalive(agent, entry);
+		}
+
+		if (msg->mapped.len) {
+			JLOG_VERBOSE("Response has mapped address");
+
+			if (JLOG_INFO_ENABLED) {
+				char mapped_str[ADDR_MAX_STRING_LEN];
+				addr_record_to_string(&msg->mapped, mapped_str, ADDR_MAX_STRING_LEN);
+				JLOG_INFO("Got STUN mapped address %s from TURN server", mapped_str);
+			}
+
+			if (agent_add_local_reflexive_candidate(agent, ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE,
+			                                        &msg->mapped)) {
+				JLOG_WARN("Failed to add local peer reflexive candidate from TURN mapped address");
+			}
+		}
+
+		entry->relayed = msg->relayed;
+		if (agent_add_local_relayed_candidate(agent, &msg->relayed)) {
+			JLOG_WARN("Failed to add local relayed candidate from TURN relayed address");
+			return -1;
+		}
+
+		if (JLOG_INFO_ENABLED) {
+			char relayed_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(&entry->relayed, relayed_str, ADDR_MAX_STRING_LEN);
+			JLOG_INFO("Allocated TURN relayed address %s", relayed_str);
+		}
+
+		agent_update_gathering_done(agent);
+		break;
+	}
+	case STUN_CLASS_RESP_ERROR: {
+		if (msg->error_code == 401) { // Unauthorized
+			JLOG_DEBUG("Got TURN %s Unauthorized response",
+			           msg->msg_method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh");
+			if (*entry->turn->credentials.realm != '\0') {
+				JLOG_ERROR("TURN authentication failed");
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				agent_update_gathering_done(agent);
+				return -1;
+			}
+			if (*msg->credentials.realm == '\0' || *msg->credentials.nonce == '\0') {
+				JLOG_ERROR("Expected realm and nonce in TURN error response");
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				agent_update_gathering_done(agent);
+				return -1;
+			}
+
+			stun_process_credentials(&msg->credentials, &entry->turn->credentials);
+
+			// Resend request when possible
+			agent_arm_transmission(agent, entry, 0);
+
+		} else if (msg->error_code == 438) { // Stale Nonce
+			JLOG_DEBUG("Got TURN %s Stale Nonce response",
+			           msg->msg_method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh");
+			if (*msg->credentials.realm == '\0' || *msg->credentials.nonce == '\0') {
+				JLOG_ERROR("Expected realm and nonce in TURN error response");
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				agent_update_gathering_done(agent);
+				return -1;
+			}
+
+			stun_process_credentials(&msg->credentials, &entry->turn->credentials);
+
+			// Resend request when possible
+			agent_arm_transmission(agent, entry, 0);
+
+		} else if (msg->msg_method == STUN_METHOD_ALLOCATE &&
+		           msg->error_code == 300) { // Try Alternate
+			// RFC 8489 10. ALTERNATE-SERVER Mechanism:
+			// A client using this extension handles a 300 (Try Alternate) error code as follows.
+			// The client looks for an ALTERNATE-SERVER attribute in the error response. If one is
+			// found, then the client considers the current transaction as failed and reattempts the
+			// request with the server specified in the attribute, using the same transport protocol
+			// used for the previous request.
+			if (!msg->alternate_server.len ||
+			    addr_record_is_equal(&msg->alternate_server, &entry->record, true)) {
+				JLOG_ERROR("Expected alternate server in TURN Allocate 300 Try Alternate response");
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				agent_update_gathering_done(agent);
+				return -1;
+			}
+			// Prevent infinite redirection loop
+			if (entry->turn_redirections >= MAX_TURN_REDIRECTIONS) {
+				JLOG_ERROR("Too many redirections for TURN Allocate");
+				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+				agent_update_gathering_done(agent);
+				return -1;
+			}
+
+			if (JLOG_INFO_ENABLED) {
+				char alternate_server_str[ADDR_MAX_STRING_LEN];
+				addr_record_to_string(&msg->alternate_server, alternate_server_str,
+				                      ADDR_MAX_STRING_LEN);
+				JLOG_INFO("Trying alternate TURN server %s", alternate_server_str);
+			}
+
+			// Change record and resend request when possible
+			++entry->turn_redirections;
+			entry->record = msg->alternate_server;
+			agent_arm_transmission(agent, entry, 0);
+
+		} else {
+			if (msg->error_code != STUN_ERROR_INTERNAL_VALIDATION_FAILED)
+				JLOG_WARN("Got TURN %s error response, code=%u",
+				          msg->msg_method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh",
+				          (unsigned int)msg->error_code);
+
+			JLOG_INFO("TURN allocation failed");
+			entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+			agent_update_gathering_done(agent);
+		}
+		break;
+	}
+	default: {
+		JLOG_WARN("Got unexpected TURN %s message, class=%u",
+		          msg->msg_method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh",
+		          (unsigned int)msg->msg_class);
+		return -1;
+	}
+	}
+	return 0;
+}
+
+int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entry_t *entry,
+                                     stun_method_t method) {
+	if (method != STUN_METHOD_ALLOCATE && method != STUN_METHOD_REFRESH)
+		return -1;
+
+	JLOG_DEBUG("Sending TURN %s request", method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh");
+
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_ERROR("Attempted to send a TURN %s request for a non-relay entry",
+		           method == STUN_METHOD_ALLOCATE ? "Allocate" : "Refresh");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_REQUEST;
+	msg.msg_method = method;
+	memcpy(msg.transaction_id, entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	msg.lifetime = TURN_LIFETIME / 1000; // seconds
+
+	// Include allocation attributes in Allocate request only
+	if (method == STUN_METHOD_ALLOCATE) {
+		msg.requested_transport = true;
+	}
+
+	const char *password = NULL;
+	if (*entry->turn->credentials.nonce != '\0') {
+		msg.credentials = entry->turn->credentials;
+		password = entry->turn->password;
+	}
+
+	char buffer[BUFFER_SIZE];
+	int size = stun_write(buffer, BUFFER_SIZE, &msg, password);
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+	if (agent_direct_send(agent, &entry->record, buffer, size, 0) < 0) {
+		JLOG_WARN("STUN message send failed");
+		return -1;
+	}
+	return 0;
+}
+
+int agent_process_turn_create_permission(juice_agent_t *agent, const stun_message_t *msg,
+                                         agent_stun_entry_t *entry) {
+	(void)(agent);
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_WARN("Received TURN CreatePermission message for a non-relay entry, ignoring");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+
+	switch (msg->msg_class) {
+	case STUN_CLASS_RESP_SUCCESS: {
+		JLOG_DEBUG("Received TURN CreatePermission success response");
+		if (!turn_set_permission(&entry->turn->map, msg->transaction_id, NULL,
+		                         PERMISSION_LIFETIME / 2))
+			JLOG_WARN("Transaction ID from TURN CreatePermission response does not match");
+		break;
+	}
+	case STUN_CLASS_RESP_ERROR: {
+		if (msg->error_code == 438) { // Stale Nonce
+			JLOG_DEBUG("Got TURN CreatePermission Stale Nonce response");
+			if (*msg->credentials.realm == '\0' || *msg->credentials.nonce == '\0') {
+				JLOG_ERROR("Expected realm and nonce in TURN error response");
+				return -1;
+			}
+
+			stun_process_credentials(&msg->credentials, &entry->turn->credentials);
+
+			// Resend
+			addr_record_t record;
+			if (turn_retrieve_transaction_id(&entry->turn->map, msg->transaction_id, &record))
+				agent_send_turn_create_permission_request(agent, entry, &record, 0);
+
+		} else if (msg->error_code != STUN_ERROR_INTERNAL_VALIDATION_FAILED) {
+			JLOG_WARN("Got TURN CreatePermission error response, code=%u",
+			          (unsigned int)msg->error_code);
+		}
+		break;
+	}
+	default: {
+		JLOG_WARN("Got unexpected TURN CreatePermission message, class=%u",
+		          (unsigned int)msg->msg_class);
+		return -1;
+	}
+	}
+	return 0;
+}
+
+int agent_send_turn_create_permission_request(juice_agent_t *agent, agent_stun_entry_t *entry,
+                                              const addr_record_t *record, int ds) {
+	if (JLOG_DEBUG_ENABLED) {
+		char record_str[ADDR_MAX_STRING_LEN];
+		addr_record_to_string(record, record_str, ADDR_MAX_STRING_LEN);
+		JLOG_DEBUG("Sending TURN CreatePermission request for %s", record_str);
+	}
+
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_ERROR("Attempted to send a TURN CreatePermission request for a non-relay entry");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+	const stun_credentials_t *credentials = &entry->turn->credentials;
+
+	if (*credentials->realm == '\0' || *credentials->nonce == '\0') {
+		JLOG_ERROR("Missing realm and nonce to send TURN CreatePermission request");
+		return -1;
+	}
+
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_REQUEST;
+	msg.msg_method = STUN_METHOD_CREATE_PERMISSION;
+	if (!turn_set_random_permission_transaction_id(&entry->turn->map, record, msg.transaction_id))
+		return -1;
+
+	msg.credentials = entry->turn->credentials;
+	msg.peers_size = 1;
+	msg.peers[0] = *record;
+
+	char buffer[BUFFER_SIZE];
+	int size = stun_write(buffer, BUFFER_SIZE, &msg, entry->turn->password);
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+	if (agent_direct_send(agent, &entry->record, buffer, size, ds) < 0) {
+		JLOG_WARN("STUN message send failed");
+		return -1;
+	}
+	return 0;
+}
+
+int agent_process_turn_channel_bind(juice_agent_t *agent, const stun_message_t *msg,
+                                    agent_stun_entry_t *entry) {
+	(void)agent;
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_WARN("Received TURN ChannelBind message for a non-relay entry, ignoring");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+
+	switch (msg->msg_class) {
+	case STUN_CLASS_RESP_SUCCESS: {
+		JLOG_DEBUG("Received TURN ChannelBind success response");
+		if (!turn_bind_current_channel(&entry->turn->map, msg->transaction_id, NULL,
+		                               BIND_LIFETIME / 2))
+			JLOG_WARN("Transaction ID from TURN ChannelBind response does not match");
+		break;
+	}
+	case STUN_CLASS_RESP_ERROR: {
+		if (msg->error_code == 438) { // Stale Nonce
+			JLOG_DEBUG("Got TURN ChannelBind Stale Nonce response");
+			if (*msg->credentials.realm == '\0' || *msg->credentials.nonce == '\0') {
+				JLOG_ERROR("Expected realm and nonce in TURN error response");
+				return -1;
+			}
+
+			stun_process_credentials(&msg->credentials, &entry->turn->credentials);
+
+			// Resend
+			addr_record_t record;
+			if (turn_retrieve_transaction_id(&entry->turn->map, msg->transaction_id, &record))
+				agent_send_turn_channel_bind_request(agent, entry, &record, 0, NULL);
+
+		} else if (msg->error_code != STUN_ERROR_INTERNAL_VALIDATION_FAILED) {
+			JLOG_WARN("Got TURN ChannelBind error response, code=%u",
+			          (unsigned int)msg->error_code);
+		}
+		break;
+	}
+	default: {
+		JLOG_WARN("Got STUN unexpected ChannelBind message, class=%u",
+		          (unsigned int)msg->msg_class);
+		return -1;
+	}
+	}
+	return 0;
+}
+
+int agent_send_turn_channel_bind_request(juice_agent_t *agent, agent_stun_entry_t *entry,
+                                         const addr_record_t *record, int ds,
+                                         uint16_t *out_channel) {
+	if (JLOG_DEBUG_ENABLED) {
+		char record_str[ADDR_MAX_STRING_LEN];
+		addr_record_to_string(record, record_str, ADDR_MAX_STRING_LEN);
+		JLOG_DEBUG("Sending TURN ChannelBind request for %s", record_str);
+	}
+
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_ERROR("Attempted to send a TURN ChannelBind request for a non-relay entry");
+		return -1;
+	}
+	if (!entry->turn) {
+		JLOG_ERROR("Missing TURN state on relay entry");
+		return -1;
+	}
+	const stun_credentials_t *credentials = &entry->turn->credentials;
+	const char *password = entry->turn->password;
+
+	if (*credentials->realm == '\0' || *credentials->nonce == '\0') {
+		JLOG_ERROR("Missing realm and nonce to send TURN ChannelBind request");
+		return -1;
+	}
+
+	uint16_t channel;
+	if (!turn_get_channel(&entry->turn->map, record, &channel))
+		if (!turn_bind_random_channel(&entry->turn->map, record, &channel, 0))
+			return -1;
+
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_REQUEST;
+	msg.msg_method = STUN_METHOD_CHANNEL_BIND;
+	if (!turn_set_random_channel_transaction_id(&entry->turn->map, record, msg.transaction_id))
+		return -1;
+
+	msg.credentials = entry->turn->credentials;
+	msg.channel_number = channel;
+	msg.peers_size = 1;
+	msg.peers[0] = *record;
+
+	if (out_channel)
+		*out_channel = channel;
+
+	char buffer[BUFFER_SIZE];
+	int size = stun_write(buffer, BUFFER_SIZE, &msg, password);
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+	if (agent_direct_send(agent, &entry->record, buffer, size, ds) < 0) {
+		JLOG_WARN("STUN message send failed");
+		return -1;
+	}
+	return 0;
+}
+
+int agent_process_turn_data(juice_agent_t *agent, const stun_message_t *msg,
+                            agent_stun_entry_t *entry) {
+	if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY) {
+		JLOG_WARN("Received TURN Data message for a non-relay entry, ignoring");
+		return -1;
+	}
+	if (msg->msg_class != STUN_CLASS_INDICATION) {
+		JLOG_WARN("Received non-indication TURN Data message, ignoring");
+		return -1;
+	}
+
+	JLOG_DEBUG("Received TURN Data indication");
+	if (!msg->data) {
+		JLOG_WARN("Missing data in TURN Data indication");
+		return -1;
+	}
+	if (!msg->peers_size) {
+		JLOG_WARN("Missing peer address in TURN Data indication");
+		return -1;
+	}
+	const addr_record_t *peer = msg->peers;
+	return agent_input(agent, (char *)msg->data, msg->data_size, peer, &entry->relayed);
+}
+
+int agent_process_channel_data(juice_agent_t *agent, agent_stun_entry_t *entry, char *buf,
+                               size_t len) {
+	if (len < sizeof(struct channel_data_header)) {
+		JLOG_WARN("ChannelData is too short");
+		return -1;
+	}
+
+	const struct channel_data_header *header = (const struct channel_data_header *)buf;
+	buf += sizeof(struct channel_data_header);
+	len -= sizeof(struct channel_data_header);
+	uint16_t channel = ntohs(header->channel_number);
+	uint16_t length = ntohs(header->length);
+	JLOG_VERBOSE("Received ChannelData, channel=0x%hX, length=%hu", channel, length);
+	if (length > len) {
+		JLOG_WARN("ChannelData has invalid length");
+		return -1;
+	}
+
+	addr_record_t src;
+	if (!turn_find_channel(&entry->turn->map, channel, &src)) {
+		JLOG_WARN("Channel not found");
+		return -1;
+	}
+
+	return agent_input(agent, buf, length, &src, &entry->relayed);
+}
+
+int agent_add_local_relayed_candidate(juice_agent_t *agent, const addr_record_t *record) {
+	if (ice_find_candidate_from_addr(&agent->local, record, ICE_CANDIDATE_TYPE_RELAYED)) {
+		JLOG_VERBOSE("The relayed local candidate already exists");
+		return 0;
+	}
+	ice_candidate_t candidate;
+	if (ice_create_local_candidate(ICE_CANDIDATE_TYPE_RELAYED, 1, agent->local.candidates_count,
+	                               record, &candidate, ICE_CANDIDATE_TRANSPORT_UDP)) {
+		JLOG_ERROR("Failed to create relayed candidate");
+		return -1;
+	}
+	if (ice_add_candidate(&candidate, &agent->local)) {
+		JLOG_ERROR("Failed to add candidate to local description");
+		return -1;
+	}
+
+	char buffer[BUFFER_SIZE];
+	if (ice_generate_candidate_sdp(&candidate, buffer, BUFFER_SIZE) < 0) {
+		JLOG_ERROR("Failed to generate SDP for local candidate");
+		return -1;
+	}
+	JLOG_DEBUG("Gathered relayed candidate: %s", buffer);
+
+	// Relayed candidates must be differenciated, so match them with already known remote candidates
+	ice_candidate_t *local = agent->local.candidates + agent->local.candidates_count - 1;
+	for (int i = 0; i < agent->remote.candidates_count; ++i) {
+		ice_candidate_t *remote = agent->remote.candidates + i;
+		if (local->resolved.addr.ss_family == remote->resolved.addr.ss_family)
+			agent_add_candidate_pair(agent, local, remote);
+	}
+
+	if (agent->config.cb_candidate)
+		agent->config.cb_candidate(agent, buffer, agent->config.user_ptr);
+
+	return 0;
+}
+
+int agent_add_local_reflexive_candidate(juice_agent_t *agent, ice_candidate_type_t type,
+                                        const addr_record_t *record) {
+	if (type != ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE && type != ICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
+		JLOG_ERROR("Invalid type for local reflexive candidate");
+		return -1;
+	}
+	int family = record->addr.ss_family;
+	if (ice_find_candidate_from_addr(&agent->local, record,
+	                                 family == AF_INET6 ? ICE_CANDIDATE_TYPE_UNKNOWN : type)) {
+		JLOG_VERBOSE("A local candidate exists for the mapped address");
+		return 0;
+	}
+	ice_candidate_t candidate;
+	if (ice_create_local_candidate(type, 1, agent->local.candidates_count, record, &candidate,
+	                               ICE_CANDIDATE_TRANSPORT_UDP)) {
+		JLOG_ERROR("Failed to create reflexive candidate");
+		return -1;
+	}
+	if (candidate.type == ICE_CANDIDATE_TYPE_PEER_REFLEXIVE &&
+	    ice_candidates_count(&agent->local, ICE_CANDIDATE_TYPE_PEER_REFLEXIVE) >=
+	        MAX_PEER_REFLEXIVE_CANDIDATES_COUNT) {
+		JLOG_INFO(
+		    "Local description has the maximum number of peer reflexive candidates, ignoring");
+		return 0;
+	}
+	if (ice_add_candidate(&candidate, &agent->local)) {
+		JLOG_ERROR("Failed to add candidate to local description");
+		return -1;
+	}
+
+	char buffer[BUFFER_SIZE];
+	if (ice_generate_candidate_sdp(&candidate, buffer, BUFFER_SIZE) < 0) {
+		JLOG_ERROR("Failed to generate SDP for local candidate");
+		return -1;
+	}
+	JLOG_DEBUG("Gathered reflexive candidate: %s", buffer);
+
+	if (type != ICE_CANDIDATE_TYPE_PEER_REFLEXIVE && agent->config.cb_candidate)
+		agent->config.cb_candidate(agent, buffer, agent->config.user_ptr);
+
+	return 0;
+}
+
+int agent_add_remote_reflexive_candidate(juice_agent_t *agent, ice_candidate_type_t type,
+                                         uint32_t priority, const addr_record_t *record) {
+	if (type != ICE_CANDIDATE_TYPE_PEER_REFLEXIVE) {
+		JLOG_ERROR("Invalid type for remote reflexive candidate");
+		return -1;
+	}
+	if (ice_find_candidate_from_addr(&agent->remote, record, ICE_CANDIDATE_TYPE_UNKNOWN)) {
+		JLOG_VERBOSE("A remote candidate exists for the remote address");
+		return 0;
+	}
+	ice_candidate_t candidate;
+	if (ice_create_local_candidate(type, 1, agent->local.candidates_count, record, &candidate,
+	                               ICE_CANDIDATE_TRANSPORT_UDP)) {
+		JLOG_ERROR("Failed to create reflexive candidate");
+		return -1;
+	}
+	if (ice_candidates_count(&agent->remote, ICE_CANDIDATE_TYPE_PEER_REFLEXIVE) >=
+	    MAX_PEER_REFLEXIVE_CANDIDATES_COUNT) {
+		JLOG_INFO(
+		    "Remote description has the maximum number of peer reflexive candidates, ignoring");
+		return 0;
+	}
+	if (ice_add_candidate(&candidate, &agent->remote)) {
+		JLOG_ERROR("Failed to add candidate to remote description");
+		return -1;
+	}
+
+	JLOG_DEBUG("Obtained a new remote reflexive candidate, priority=%lu", (unsigned long)priority);
+
+	ice_candidate_t *remote = agent->remote.candidates + agent->remote.candidates_count - 1;
+	remote->priority = priority;
+
+	return agent_add_candidate_pairs_for_remote(agent, remote);
+}
+
+int agent_add_local_tcp_active_candidate(juice_agent_t *agent, addr_record_t *record) {
+	ice_candidate_t candidate;
+	if (ice_create_local_candidate(ICE_CANDIDATE_TYPE_HOST, 1, agent->local.candidates_count,
+	                               record, &candidate, ICE_CANDIDATE_TRANSPORT_TCP_TYPE_ACTIVE)) {
+		JLOG_ERROR("Failed to create TCP candidate");
+		return -1;
+	}
+	if (ice_add_candidate(&candidate, &agent->local)) {
+		JLOG_ERROR("Failed to add TCP candidate to local description");
+		return -1;
+	}
+
+	return 0;
+}
+
+int agent_add_candidate_pair(juice_agent_t *agent, ice_candidate_t *local, // local may be NULL
+                             ice_candidate_t *remote) {
+	ice_candidate_pair_t pair;
+	bool is_controlling = agent->mode == AGENT_MODE_CONTROLLING;
+	if (ice_create_candidate_pair(local, remote, is_controlling, &pair)) {
+		JLOG_ERROR("Failed to create candidate pair");
+		return -1;
+	}
+
+	if (agent->candidate_pairs_count >= MAX_CANDIDATE_PAIRS_COUNT) {
+		JLOG_WARN("Session already has the maximum number of candidate pairs");
+		return -1;
+	}
+
+	if (remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
+		if (agent->ice_tcp_mode != JUICE_ICE_TCP_MODE_ACTIVE) {
+			JLOG_WARN("ICE-TCP is disabled, ignoring TCP candidate");
+			return 0;
+		}
+
+		if (remote->transport != ICE_CANDIDATE_TRANSPORT_TCP_TYPE_PASSIVE &&
+		    remote->transport != ICE_CANDIDATE_TRANSPORT_TCP_TYPE_SO) {
+			JLOG_INFO("TCP candidate is not passive or simultaneous open, ignoring");
+			return 0;
+		}
+
+		for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+			ice_candidate_pair_t *pair = &agent->candidate_pairs[i];
+			if (pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP &&
+			    pair->remote->resolved.addr.ss_family == remote->resolved.addr.ss_family) {
+				JLOG_INFO("Only one remote TCP candidate is supported, ignoring");
+				return 0;
+			}
+		}
+	}
+
+	JLOG_VERBOSE("Adding new candidate pair, priority=%" PRIu64, pair.priority);
+
+	// Add pair
+	ice_candidate_pair_t *pos = agent->candidate_pairs + agent->candidate_pairs_count;
+	*pos = pair;
+	++agent->candidate_pairs_count;
+
+	agent_update_ordered_pairs(agent);
+
+	if (agent->entries_count == MAX_STUN_ENTRIES_COUNT) {
+		JLOG_WARN("No free STUN entry left for candidate pair checking");
+		return -1;
+	}
+
+	agent_stun_entry_t *relay_entry = NULL;
+	if (local && local->type == ICE_CANDIDATE_TYPE_RELAYED) {
+		for (int i = 0; i < agent->entries_count; ++i) {
+			agent_stun_entry_t *other_entry = agent->entries + i;
+			if (other_entry->type == AGENT_STUN_ENTRY_TYPE_RELAY &&
+			    addr_record_is_equal(&other_entry->relayed, &local->resolved, true)) {
+				relay_entry = other_entry;
+				break;
+			}
+		}
+		if (!relay_entry) {
+			JLOG_ERROR("Relay entry not found");
+			return -1;
+		}
+	}
+
+	agent_register_entry_for_candidate_pair(agent, pos, relay_entry);
+
+	if (agent->mode == AGENT_MODE_CONTROLLING) {
+		for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+			ice_candidate_pair_t *ordered_pair = agent->ordered_pairs[i];
+			if (ordered_pair == pos) {
+				JLOG_VERBOSE("Candidate pair has priority");
+				break;
+			}
+			if (ordered_pair->state == ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
+				// We found a succeeded pair with higher priority, ignore this one
+				JLOG_VERBOSE("Candidate pair doesn't have priority, keeping it frozen");
+				return 0;
+			}
+		}
+	}
+
+	// There is only one component, therefore we can unfreeze if no pair is nominated
+	if (*agent->remote.ice_ufrag != '\0' &&
+	    (!agent->selected_pair || !agent->selected_pair->nominated)) {
+		JLOG_VERBOSE("Unfreezing the new candidate pair");
+		agent_unfreeze_candidate_pair(agent, pos);
+	}
+
+	return 0;
+}
+
+int agent_add_candidate_pairs_for_remote(juice_agent_t *agent, ice_candidate_t *remote) {
+	// Here is the trick: local non-relayed candidates are undifferentiated for sending.
+	// Therefore, we don't need to match remote candidates with local ones.
+	if (agent_add_candidate_pair(agent, NULL, remote))
+		return -1;
+
+	// However, we need still to differenciate local relayed candidates
+	for (int i = 0; i < agent->local.candidates_count; ++i) {
+		ice_candidate_t *local = agent->local.candidates + i;
+		if (local->type == ICE_CANDIDATE_TYPE_RELAYED &&
+		    local->resolved.addr.ss_family == remote->resolved.addr.ss_family)
+			if (agent_add_candidate_pair(agent, local, remote))
+				return -1;
+	}
+
+	return 0;
+}
+
+int agent_unfreeze_candidate_pair(juice_agent_t *agent, ice_candidate_pair_t *pair) {
+	if (pair->state != ICE_CANDIDATE_PAIR_STATE_FROZEN)
+		return 0;
+
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry->pair == pair) {
+			pair->state = ICE_CANDIDATE_PAIR_STATE_PENDING;
+			entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+			agent_arm_transmission(agent, entry, 0); // transmit now
+			return 0;
+		}
+	}
+
+	JLOG_WARN("Unable to unfreeze the pair: no matching entry");
+	return -1;
+}
+
+void agent_arm_keepalive(juice_agent_t *agent, agent_stun_entry_t *entry) {
+	if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED)
+		entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
+
+	if (entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE)
+		return;
+
+	timediff_t period;
+	switch (entry->type) {
+	case AGENT_STUN_ENTRY_TYPE_RELAY:
+		period = agent->remote.candidates_count > 0 ? TURN_REFRESH_PERIOD : STUN_KEEPALIVE_PERIOD;
+		break;
+	case AGENT_STUN_ENTRY_TYPE_SERVER:
+		period = STUN_KEEPALIVE_PERIOD;
+		break;
+	default:
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+		period = STUN_KEEPALIVE_PERIOD;
+#else
+		period = MIN_CONSENT_CHECK_PERIOD +
+		         juice_rand32() % (MAX_CONSENT_CHECK_PERIOD - MIN_CONSENT_CHECK_PERIOD + 1);
+#endif
+		break;
+	}
+
+	entry->transaction_id_expired = true;
+	agent_arm_transmission(agent, entry, period);
+}
+
+void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, timediff_t delay) {
+	if (entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE)
+		entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+
+	// Arm transmission
+	entry->next_transmission = current_timestamp() + delay;
+
+	if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
+		if (entry_is_tcp(entry)) {
+			entry->retransmission_timeout = STUN_TCP_TIMEOUT;
+			entry->retransmissions = 0; // do not retransmit
+		} else {
+			entry->retransmission_timeout = MIN_STUN_RETRANSMISSION_TIMEOUT;
+			entry->retransmissions = entry->type == AGENT_STUN_ENTRY_TYPE_CHECK
+			                             ? MAX_STUN_CHECK_RETRANSMISSION_COUNT
+			                             : MAX_STUN_SERVER_RETRANSMISSION_COUNT;
+		}
+	}
+
+	// Find a time slot
+	agent_stun_entry_t *other = agent->entries;
+	while (other != agent->entries + agent->entries_count) {
+		if (other != entry) {
+			timestamp_t other_transmission = other->next_transmission;
+			timediff_t timediff = entry->next_transmission - other_transmission;
+			if (other_transmission && abs((int)timediff) < STUN_PACING_TIME) {
+				entry->next_transmission = other_transmission + STUN_PACING_TIME;
+				other = agent->entries;
+				continue;
+			}
+		}
+		++other;
+	}
+}
+
+void agent_update_pac_timer(juice_agent_t *agent) {
+	if (agent->pac_timestamp)
+		return;
+
+	// RFC 8863: The ICE agent will start its timer once it believes ICE connectivity checks are
+	// starting. This occurs when the agent has sent the values needed to perform connectivity
+	// checks (e.g., the Username Fragment and Password [...]) and has received some indication that
+	// the remote side is ready to start connectivity checks, typically via receipt of the values
+	// mentioned above.
+	if (*agent->remote.ice_ufrag != '\0' && agent->gathering_done) {
+		JLOG_INFO("Connectivity timer started");
+		agent->pac_timestamp = current_timestamp() + ICE_PAC_TIMEOUT;
+	}
+}
+
+void agent_update_gathering_done(juice_agent_t *agent) {
+	JLOG_VERBOSE("Updating gathering status");
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry->type != AGENT_STUN_ENTRY_TYPE_CHECK &&
+		    entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
+			JLOG_VERBOSE("STUN server or relay entry %d is still pending", i);
+			return;
+		}
+	}
+	if (!agent->gathering_done) {
+		JLOG_INFO("Candidate gathering done");
+		agent->local.finished = true;
+		agent->gathering_done = true;
+
+		agent_update_pac_timer(agent);
+
+		if (agent->config.cb_gathering_done)
+			agent->config.cb_gathering_done(agent, agent->config.user_ptr);
+	}
+}
+
+void agent_update_candidate_pairs(juice_agent_t *agent) {
+	bool is_controlling = agent->mode == AGENT_MODE_CONTROLLING;
+	for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+		ice_candidate_pair_t *pair = agent->candidate_pairs + i;
+		ice_update_candidate_pair(pair, is_controlling);
+	}
+	agent_update_ordered_pairs(agent);
+
+	// Expire all transaction IDs for checks
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK) {
+			entry->transaction_id_expired = true;
+		}
+	}
+}
+
+void agent_update_ordered_pairs(juice_agent_t *agent) {
+	JLOG_VERBOSE("Updating ordered candidate pairs");
+	for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+		ice_candidate_pair_t **begin = agent->ordered_pairs;
+		ice_candidate_pair_t **end = begin + i;
+		ice_candidate_pair_t **prev = end;
+		uint64_t priority = agent->candidate_pairs[i].priority;
+		while (--prev >= begin && (*prev)->priority < priority)
+			*(prev + 1) = *prev;
+
+		*(prev + 1) = agent->candidate_pairs + i;
+	}
+}
+
+static inline bool pair_is_relayed(const ice_candidate_pair_t *pair) {
+	return pair->local && pair->local->type == ICE_CANDIDATE_TYPE_RELAYED;
+}
+
+static inline bool entry_is_relayed(const agent_stun_entry_t *entry) {
+	return entry->pair && pair_is_relayed(entry->pair);
+}
+
+agent_stun_entry_t *agent_find_entry_from_transaction_id(juice_agent_t *agent,
+                                                         const uint8_t *transaction_id) {
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (memcmp(transaction_id, entry->transaction_id, STUN_TRANSACTION_ID_SIZE) == 0) {
+			JLOG_VERBOSE("STUN entry %d matching incoming transaction ID", i);
+			return entry;
+		}
+		if (entry->turn) {
+			if (turn_retrieve_transaction_id(&entry->turn->map, transaction_id, NULL)) {
+				JLOG_VERBOSE("STUN entry %d matching incoming transaction ID (TURN)", i);
+				return entry;
+			}
+		}
+	}
+	return NULL;
+}
+
+agent_stun_entry_t *agent_find_entry_from_record(juice_agent_t *agent, const addr_record_t *record,
+                                                 const addr_record_t *relayed) {
+	agent_stun_entry_t *selected_entry = atomic_load(&agent->selected_entry);
+
+	if (selected_entry && selected_entry->pair && selected_entry->pair->nominated) {
+		// As an optimization, try to match the nominated entry first
+		if (relayed) {
+			if (entry_is_relayed(selected_entry) &&
+			    addr_record_is_equal(&selected_entry->pair->local->resolved, relayed, true) &&
+			    addr_record_is_equal(&selected_entry->record, record, true)) {
+				JLOG_DEBUG("STUN selected entry matching incoming relayed address");
+				return selected_entry;
+			}
+		} else {
+			if (!entry_is_relayed(selected_entry) &&
+			    addr_record_is_equal(&selected_entry->record, record, true)) {
+				JLOG_DEBUG("STUN selected entry matching incoming address");
+				return selected_entry;
+			}
+		}
+	}
+
+	if (relayed) {
+		for (int i = 0; i < agent->entries_count; ++i) {
+			agent_stun_entry_t *entry = agent->entries + i;
+			if (entry_is_relayed(entry) &&
+			    addr_record_is_equal(&entry->pair->local->resolved, relayed, true) &&
+			    addr_record_is_equal(&entry->record, record, true)) {
+				JLOG_DEBUG("STUN entry %d matching incoming relayed address", i);
+				return entry;
+			}
+		}
+	} else {
+		// Try to match pairs by priority first
+		ice_candidate_pair_t *matching_pair = NULL;
+		for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+			ice_candidate_pair_t *pair = agent->ordered_pairs[i];
+			if (!pair_is_relayed(pair) &&
+			    addr_record_is_equal(&pair->remote->resolved, record, true)) {
+				matching_pair = pair;
+				break;
+			}
+		}
+
+		if (matching_pair) {
+			// Just find the corresponding entry
+			for (int i = 0; i < agent->entries_count; ++i) {
+				agent_stun_entry_t *entry = agent->entries + i;
+				if (entry->pair == matching_pair) {
+					JLOG_DEBUG("STUN entry %d pair matching incoming address", i);
+					return entry;
+				}
+			}
+		}
+
+		// Try to match entries directly
+		for (int i = 0; i < agent->entries_count; ++i) {
+			agent_stun_entry_t *entry = agent->entries + i;
+			if (!entry_is_relayed(entry) && addr_record_is_equal(&entry->record, record, true)) {
+				JLOG_DEBUG("STUN entry %d matching incoming address", i);
+				return entry;
+			}
+		}
+	}
+	return NULL;
+}
+
+int agent_set_ice_tcp_mode(juice_agent_t *agent, juice_ice_tcp_mode_t ice_tcp_mode) {
+	if (agent->conn_impl) {
+		JLOG_WARN("Unable to set ICE attributes, candidates gathering already started");
+		return JUICE_ERR_FAILED;
+	}
+
+	agent->ice_tcp_mode = ice_tcp_mode;
+	return JUICE_ERR_SUCCESS;
+}
+
+void agent_translate_host_candidate_entry(juice_agent_t *agent, agent_stun_entry_t *entry) {
+	if (!entry->pair || entry->pair->remote->type != ICE_CANDIDATE_TYPE_HOST)
+		return;
+
+#if defined(JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION) && JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION
+	for (int i = 0; i < agent->local.candidates_count; ++i) {
+		ice_candidate_t *candidate = agent->local.candidates + i;
+		if (candidate->type != ICE_CANDIDATE_TYPE_HOST)
+			continue;
+
+		if (addr_record_is_equal(&candidate->resolved, &entry->record, false)) {
+			JLOG_DEBUG("Entry remote address matches local candidate, translating to localhost");
+			struct sockaddr_storage *addr = &entry->record.addr;
+			switch (addr->ss_family) {
+			case AF_INET6: {
+				struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)addr;
+				memset(&sin6->sin6_addr, 0, 16);
+				*((uint8_t *)&sin6->sin6_addr + 15) = 0x01;
+				break;
+			}
+			case AF_INET: {
+				struct sockaddr_in *sin = (struct sockaddr_in *)addr;
+				const uint8_t localhost[4] = {127, 0, 0, 1};
+				memcpy(&sin->sin_addr, localhost, 4);
+				break;
+			}
+			default:
+				// Ignore
+				break;
+			}
+			break;
+		}
+	}
+#else
+	(void)agent;
+#endif
+}

--- a/Source/3rdParty/libjuice/src/agent.h
+++ b/Source/3rdParty/libjuice/src/agent.h
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_AGENT_H
+#define JUICE_AGENT_H
+
+#include "addr.h"
+#include "conn.h"
+#include "ice.h"
+#include "juice.h"
+#include "stun.h"
+#include "tcp.h"
+#include "thread.h"
+#include "timestamp.h"
+#include "turn.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// RFC 8445: Agents MUST NOT use an RTO value smaller than 500 ms.
+#define MIN_STUN_RETRANSMISSION_TIMEOUT 500 // msecs
+#define LAST_STUN_RETRANSMISSION_TIMEOUT (MIN_STUN_RETRANSMISSION_TIMEOUT * 16)
+#define MAX_STUN_CHECK_RETRANSMISSION_COUNT 6  // exponential backoff, total 39500ms
+#define MAX_STUN_SERVER_RETRANSMISSION_COUNT 5 // total 23500ms
+#define STUN_TCP_TIMEOUT LAST_STUN_RETRANSMISSION_TIMEOUT
+
+// RFC 8445: ICE agents SHOULD use a default Ta value, 50 ms, but MAY use another value based on the
+// characteristics of the associated data.
+#define STUN_PACING_TIME 50 // msecs
+
+// RFC 8445: Agents SHOULD use a Tr value of 15 seconds. Agents MAY use a bigger value but MUST NOT
+// use a value smaller than 15 seconds.
+#define STUN_KEEPALIVE_PERIOD 15000 // msecs
+
+// ICE Patiently Awaiting Connectivity timer
+// RFC 8863: The RECOMMENDED duration for the PAC timer is equal to the agent's connectivity check
+// transaction timeout, including all retransmissions.
+#define ICE_PAC_TIMEOUT 39500 // msecs
+
+// Consent freshness
+// RFC 7675: Consent expires after 30 seconds.
+#define CONSENT_TIMEOUT 30000 // msecs
+
+// RFC 7675: To prevent synchronization of consent checks, each interval MUST be randomized from
+// between 0.8 and 1.2 times the basic period. Implementations SHOULD set a default interval of 5
+// seconds, resulting in a period between checks of 4 to 6 seconds. Implementations MUST NOT set the
+// period between checks to less than 4 seconds.
+#define MIN_CONSENT_CHECK_PERIOD 4000 // msecs
+#define MAX_CONSENT_CHECK_PERIOD 6000 // msecs
+
+// Nomination timeout for the controlling agent to settle for the selected pair
+#define NOMINATION_TIMEOUT 2000
+
+// TURN refresh period
+#define TURN_LIFETIME 600000                        // msecs (10 min)
+#define TURN_REFRESH_PERIOD (TURN_LIFETIME - 60000) // msecs (lifetime - 1 min)
+
+// Max STUN and TURN server entries
+#define MAX_SERVER_ENTRIES_COUNT 2 // max STUN server entries
+#define MAX_RELAY_ENTRIES_COUNT 2  // max TURN server entries
+
+// Max TURN redirections for ALTERNATE-SERVER mechanism
+#define MAX_TURN_REDIRECTIONS 1
+
+// Compute max candidates and entries count
+#define MAX_STUN_SERVER_RECORDS_COUNT MAX_SERVER_ENTRIES_COUNT
+#define MAX_HOST_CANDIDATES_COUNT ((ICE_MAX_CANDIDATES_COUNT - MAX_STUN_SERVER_RECORDS_COUNT) / 2)
+#define MAX_PEER_REFLEXIVE_CANDIDATES_COUNT MAX_HOST_CANDIDATES_COUNT
+#define MAX_CANDIDATE_PAIRS_COUNT (ICE_MAX_CANDIDATES_COUNT * (1 + MAX_RELAY_ENTRIES_COUNT))
+#define MAX_STUN_ENTRIES_COUNT (MAX_CANDIDATE_PAIRS_COUNT + MAX_STUN_SERVER_RECORDS_COUNT)
+
+#define AGENT_TURN_MAP_SIZE ICE_MAX_CANDIDATES_COUNT
+
+typedef enum agent_mode {
+	AGENT_MODE_UNKNOWN,
+	AGENT_MODE_CONTROLLED,
+	AGENT_MODE_CONTROLLING
+} agent_mode_t;
+
+typedef enum agent_stun_entry_type {
+	AGENT_STUN_ENTRY_TYPE_EMPTY,
+	AGENT_STUN_ENTRY_TYPE_SERVER,
+	AGENT_STUN_ENTRY_TYPE_RELAY,
+	AGENT_STUN_ENTRY_TYPE_CHECK
+} agent_stun_entry_type_t;
+
+typedef enum agent_stun_entry_state {
+	AGENT_STUN_ENTRY_STATE_PENDING,
+	AGENT_STUN_ENTRY_STATE_CANCELLED,
+	AGENT_STUN_ENTRY_STATE_FAILED,
+	AGENT_STUN_ENTRY_STATE_SUCCEEDED,
+	AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE,
+	AGENT_STUN_ENTRY_STATE_IDLE
+} agent_stun_entry_state_t;
+
+typedef struct agent_turn_state {
+	turn_map_t map;
+	stun_credentials_t credentials;
+	const char *password;
+} agent_turn_state_t;
+
+typedef struct agent_stun_entry {
+	agent_stun_entry_type_t type;
+	agent_stun_entry_state_t state;
+	agent_mode_t mode;
+	ice_candidate_pair_t *pair;
+	addr_record_t record;
+	addr_record_t relayed;
+	uint8_t transaction_id[STUN_TRANSACTION_ID_SIZE];
+	timestamp_t next_transmission;
+	timediff_t retransmission_timeout;
+	int retransmissions;
+	bool transaction_id_expired;
+	tcp_state_t tcp_state;
+
+	// TURN
+	agent_turn_state_t *turn;
+	unsigned int turn_redirections;
+	struct agent_stun_entry *relay_entry;
+
+} agent_stun_entry_t;
+
+struct juice_agent {
+	juice_config_t config;
+	juice_state_t state;
+	agent_mode_t mode;
+	juice_ice_tcp_mode_t ice_tcp_mode;
+
+	ice_description_t local;
+	ice_description_t remote;
+
+	ice_candidate_pair_t candidate_pairs[MAX_CANDIDATE_PAIRS_COUNT];
+	ice_candidate_pair_t *ordered_pairs[MAX_CANDIDATE_PAIRS_COUNT];
+	ice_candidate_pair_t *selected_pair;
+	int candidate_pairs_count;
+
+	agent_stun_entry_t entries[MAX_STUN_ENTRIES_COUNT];
+	int entries_count;
+	atomic_ptr(agent_stun_entry_t) selected_entry;
+
+	uint64_t ice_tiebreaker;
+	timestamp_t pac_timestamp; // Patiently Awaiting Connectivity timer
+	timestamp_t nomination_timestamp;
+	bool gathering_done;
+
+	conn_registry_t *registry;
+	int conn_index;
+	void *conn_impl;
+
+	thread_t resolver_thread;
+	bool resolver_thread_started;
+};
+
+juice_agent_t *agent_create(const juice_config_t *config);
+void agent_destroy(juice_agent_t *agent);
+
+int agent_gather_candidates(juice_agent_t *agent);
+int agent_resolve_servers(juice_agent_t *agent);
+int agent_get_local_description(juice_agent_t *agent, char *buffer, size_t size);
+int agent_set_remote_description(juice_agent_t *agent, const char *sdp);
+int agent_add_remote_candidate(juice_agent_t *agent, const char *sdp);
+int agent_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
+int agent_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server);
+int agent_set_remote_gathering_done(juice_agent_t *agent);
+int agent_send(juice_agent_t *agent, const char *data, size_t size, int ds);
+int agent_direct_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                      int ds);
+int agent_relay_send(juice_agent_t *agent, agent_stun_entry_t *entry, const addr_record_t *dst,
+                     const char *data, size_t size, int ds);
+int agent_channel_send(juice_agent_t *agent, agent_stun_entry_t *entry, const addr_record_t *dst,
+                       const char *data, size_t size, int ds);
+juice_state_t agent_get_state(juice_agent_t *agent);
+int agent_get_selected_candidate_pair(juice_agent_t *agent, ice_candidate_t *local,
+                                      ice_candidate_t *remote);
+
+int agent_conn_recv(juice_agent_t *agent, char *buf, size_t len, const addr_record_t *src);
+int agent_conn_update(juice_agent_t *agent, timestamp_t *next_timestamp);
+int agent_conn_tcp_state(juice_agent_t *agent, const addr_record_t *dst, tcp_state_t state);
+int agent_conn_fail(juice_agent_t *agent);
+
+int agent_input(juice_agent_t *agent, char *buf, size_t len, const addr_record_t *src,
+                const addr_record_t *relayed); // relayed may be NULL
+int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp);
+void agent_change_state(juice_agent_t *agent, juice_state_t state);
+int agent_verify_stun_binding(juice_agent_t *agent, void *buf, size_t size,
+                              const stun_message_t *msg);
+int agent_verify_credentials(juice_agent_t *agent, const agent_stun_entry_t *entry, void *buf,
+                             size_t size, stun_message_t *msg);
+int agent_dispatch_stun(juice_agent_t *agent, void *buf, size_t size, stun_message_t *msg,
+                        const addr_record_t *src,
+                        const addr_record_t *relayed); // relayed may be NULL
+int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
+                               agent_stun_entry_t *entry, const addr_record_t *src,
+                               const addr_record_t *relayed); // relayed may be NULL
+int agent_send_stun_binding(juice_agent_t *agent, agent_stun_entry_t *entry, stun_class_t msg_class,
+                            unsigned int error_code, const uint8_t *transaction_id,
+                            const addr_record_t *mapped);
+int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
+                                agent_stun_entry_t *entry);
+int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entry_t *entry,
+                                     stun_method_t method);
+int agent_process_turn_create_permission(juice_agent_t *agent, const stun_message_t *msg,
+                                         agent_stun_entry_t *entry);
+int agent_send_turn_create_permission_request(juice_agent_t *agent, agent_stun_entry_t *entry,
+                                              const addr_record_t *record, int ds);
+int agent_process_turn_channel_bind(juice_agent_t *agent, const stun_message_t *msg,
+                                    agent_stun_entry_t *entry);
+int agent_send_turn_channel_bind_request(juice_agent_t *agent, agent_stun_entry_t *entry,
+                                         const addr_record_t *record, int ds,
+                                         uint16_t *out_channel); // out_channel may be NULL
+int agent_process_turn_data(juice_agent_t *agent, const stun_message_t *msg,
+                            agent_stun_entry_t *entry);
+int agent_process_channel_data(juice_agent_t *agent, agent_stun_entry_t *entry, char *buf,
+                               size_t len);
+
+int agent_add_local_relayed_candidate(juice_agent_t *agent, const addr_record_t *record);
+int agent_add_local_reflexive_candidate(juice_agent_t *agent, ice_candidate_type_t type,
+                                        const addr_record_t *record);
+int agent_add_remote_reflexive_candidate(juice_agent_t *agent, ice_candidate_type_t type,
+                                         uint32_t priority, const addr_record_t *record);
+int agent_add_local_tcp_active_candidate(juice_agent_t *agent, addr_record_t *record);
+int agent_add_candidate_pair(juice_agent_t *agent, ice_candidate_t *local,
+                             ice_candidate_t *remote); // local may be NULL
+int agent_add_candidate_pairs_for_remote(juice_agent_t *agent, ice_candidate_t *remote);
+int agent_unfreeze_candidate_pair(juice_agent_t *agent, ice_candidate_pair_t *pair);
+
+void agent_arm_keepalive(juice_agent_t *agent, agent_stun_entry_t *entry);
+void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, timediff_t delay);
+void agent_update_pac_timer(juice_agent_t *agent);
+void agent_update_gathering_done(juice_agent_t *agent);
+void agent_update_candidate_pairs(juice_agent_t *agent);
+void agent_update_ordered_pairs(juice_agent_t *agent);
+
+agent_stun_entry_t *agent_find_entry_from_transaction_id(juice_agent_t *agent,
+                                                         const uint8_t *transaction_id);
+agent_stun_entry_t *
+agent_find_entry_from_record(juice_agent_t *agent, const addr_record_t *record,
+                             const addr_record_t *relayed); // relayed may be NULL
+void agent_translate_host_candidate_entry(juice_agent_t *agent, agent_stun_entry_t *entry);
+int agent_set_ice_tcp_mode(juice_agent_t *agent, juice_ice_tcp_mode_t ice_tcp_mode);
+
+#endif

--- a/Source/3rdParty/libjuice/src/base64.c
+++ b/Source/3rdParty/libjuice/src/base64.c
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2021 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "base64.h"
+
+#include <string.h>
+#include <ctype.h>
+
+int juice_base64_encode(const void *data, size_t size, char *out, size_t out_size) {
+	static const char tab[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+	if (out_size < 4 * ((size + 2) / 3) + 1)
+		return -1;
+
+	const uint8_t *in = (const uint8_t *)data;
+	char *w = out;
+	while (size >= 3) {
+		*w++ = tab[*in >> 2];
+		*w++ = tab[((*in & 0x03) << 4) | (*(in + 1) >> 4)];
+		*w++ = tab[((*(in + 1) & 0x0F) << 2) | (*(in + 2) >> 6)];
+		*w++ = tab[*(in + 2) & 0x3F];
+		in += 3;
+		size -= 3;
+	}
+
+	if (size) {
+		*w++ = tab[*in >> 2];
+		if (size == 1) {
+			*w++ = tab[(*in & 0x03) << 4];
+			*w++ = '=';
+		} else { // size == 2
+			*w++ = tab[((*in & 0x03) << 4) | (*(in + 1) >> 4)];
+			*w++ = tab[(*(in + 1) & 0x0F) << 2];
+		}
+		*w++ = '=';
+	}
+
+	*w = '\0';
+	return (int)(w - out);
+}
+
+int juice_base64_decode(const char *str, void *out, size_t out_size) {
+	const uint8_t *in = (const uint8_t *)str;
+	uint8_t *w = (uint8_t *)out;
+	while (*in && *in != '=') {
+		uint8_t tab[4] = {0, 0, 0, 0};
+		size_t size = 0;
+		while (*in && size < 4) {
+			uint8_t c = *in++;
+			if (isspace(c))
+				continue;
+			if (c == '=')
+				break;
+
+			if ('A' <= c && c <= 'Z')
+				tab[size++] = c - 'A';
+			else if ('a' <= c && c <= 'z')
+				tab[size++] = c + 26 - 'a';
+			else if ('0' <= c && c <= '9')
+				tab[size++] = c + 52 - '0';
+			else if (c == '+' || c == '-')
+				tab[size++] = 62;
+			else if (c == '/' || c == '_')
+				tab[size++] = 63;
+			else
+				return -1; // Invalid character
+		}
+
+		if (size > 0) {
+			if (out_size < size - 1)
+				return -1;
+
+			out_size -= size - 1;
+
+			*w++ = (tab[0] << 2) | (tab[1] >> 4);
+			if (size > 1) {
+				*w++ = (tab[1] << 4) | (tab[2] >> 2);
+				if (size > 2)
+					*w++ = (tab[2] << 6) | tab[3];
+			}
+		}
+	}
+
+	return (int)(w - (uint8_t *)out);
+}

--- a/Source/3rdParty/libjuice/src/base64.h
+++ b/Source/3rdParty/libjuice/src/base64.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_BASE64_H
+#define JUICE_BASE64_H
+
+#include "juice.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+// RFC4648-compliant base64 encoder and decoder
+JUICE_EXPORT int juice_base64_encode(const void *data, size_t size, char *out, size_t out_size);
+JUICE_EXPORT int juice_base64_decode(const char *str, void *out, size_t out_size);
+
+#define BASE64_ENCODE(data, size, out, out_size) juice_base64_encode(data, size, out, out_size)
+#define BASE64_DECODE(str, out, out_size) juice_base64_decode(str, out, out_size)
+
+#endif // JUICE_BASE64_H

--- a/Source/3rdParty/libjuice/src/conn.c
+++ b/Source/3rdParty/libjuice/src/conn.c
@@ -1,0 +1,317 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "conn.h"
+#include "agent.h"
+#include "conn_mux.h"
+#include "conn_poll.h"
+#include "conn_thread.h"
+#include "log.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define INITIAL_REGISTRY_SIZE 16
+
+#define MODE_ENTRIES_SIZE 3
+
+static conn_mode_entry_t mode_entries[MODE_ENTRIES_SIZE] = {
+    {conn_poll_registry_init, conn_poll_registry_cleanup, conn_poll_init, conn_poll_cleanup,
+     conn_poll_lock, conn_poll_unlock, conn_poll_interrupt, conn_poll_send, conn_poll_tcp_connect, conn_poll_get_addrs,
+     NULL, NULL, NULL, MUTEX_INITIALIZER, NULL},
+    {conn_mux_registry_init, conn_mux_registry_cleanup, conn_mux_init, conn_mux_cleanup,
+     conn_mux_lock, conn_mux_unlock, conn_mux_interrupt, conn_mux_send, NULL, conn_mux_get_addrs,
+     conn_mux_listen, conn_mux_get_registry, conn_mux_can_release_registry, MUTEX_INITIALIZER, NULL},
+    {NULL, NULL, conn_thread_init, conn_thread_cleanup,
+     conn_thread_lock, conn_thread_unlock, conn_thread_interrupt, conn_thread_send, NULL, conn_thread_get_addrs,
+     NULL, NULL, NULL, MUTEX_INITIALIZER, NULL}
+};
+
+#define MODE_ENTRIES_SIZE 3
+
+static conn_mode_entry_t mode_entries[MODE_ENTRIES_SIZE];
+
+conn_mode_entry_t *get_mode_entry(juice_concurrency_mode_t mode) {
+	assert(mode >= 0 && mode < MODE_ENTRIES_SIZE);
+	return mode_entries + (int)mode;
+}
+
+static conn_mode_entry_t *get_agent_mode_entry(juice_agent_t *agent) {
+	juice_concurrency_mode_t mode = agent->config.concurrency_mode;
+	return get_mode_entry(mode);
+}
+
+static int acquire_registry(conn_mode_entry_t *entry, udp_socket_config_t *config, conn_registry_t **acquired) {
+	// entry must be locked
+	conn_registry_t *registry;
+
+	if (entry->get_registry_func) {
+		registry = entry->get_registry_func(config);
+	} else {
+		registry = entry->registry;
+	}
+
+	if (!registry) {
+		if (!entry->registry_init_func) {
+			*acquired = NULL;
+			return 0;
+		}
+
+		JLOG_DEBUG("Creating connections registry");
+
+		registry = calloc(1, sizeof(conn_registry_t));
+		if (!registry) {
+			JLOG_FATAL("Memory allocation failed for connections registry");
+			return -1;
+		}
+
+		registry->agents = malloc(INITIAL_REGISTRY_SIZE * sizeof(juice_agent_t *));
+		if (!registry->agents) {
+			JLOG_FATAL("Memory allocation failed for connections array");
+			free(registry);
+			return -1;
+		}
+
+		registry->agents_size = INITIAL_REGISTRY_SIZE;
+		registry->agents_count = 0;
+		memset(registry->agents, 0, INITIAL_REGISTRY_SIZE * sizeof(juice_agent_t *));
+
+		mutex_init(&registry->mutex, MUTEX_RECURSIVE);
+		mutex_lock(&registry->mutex);
+
+		if (entry->registry_init_func(registry, config)) {
+			JLOG_FATAL("Registry initialization failed");
+			mutex_unlock(&registry->mutex);
+			free(registry->agents);
+			free(registry);
+			return -1;
+		}
+
+		entry->registry = registry;
+	} else {
+		mutex_lock(&registry->mutex);
+	}
+
+	*acquired = registry;
+
+	// registry is locked
+	return 0;
+}
+
+static void release_registry(conn_mode_entry_t *entry, conn_registry_t *registry) {
+	// entry must be locked
+	if (!registry)
+		return;
+
+	// registry must be locked
+	bool can_release = entry->can_release_registry_func ? entry->can_release_registry_func(registry) : true;
+
+	if (registry->agents_count == 0 && can_release) {
+		JLOG_DEBUG("No connection left, destroying connections registry");
+		mutex_unlock(&registry->mutex);
+
+		if (entry->registry_cleanup_func)
+			entry->registry_cleanup_func(registry);
+
+		entry->registry = NULL;
+		mutex_destroy(&registry->mutex);
+		free(registry->agents);
+		free(registry);
+		return;
+	}
+
+	JLOG_VERBOSE("%d connection%s left", registry->agents_count,
+	             registry->agents_count >= 2 ? "s" : "");
+
+	mutex_unlock(&registry->mutex);
+}
+
+int conn_create(juice_agent_t *agent, udp_socket_config_t *config) {
+	conn_mode_entry_t *entry = get_agent_mode_entry(agent);
+	conn_registry_t *registry;
+	mutex_lock(&entry->mutex);
+	if (acquire_registry(entry, config, &registry)) { // locks the registry if created
+		mutex_unlock(&entry->mutex);
+		return -1;
+	}
+
+	agent->registry = registry;
+
+	JLOG_DEBUG("Creating connection");
+	if (registry) {
+		int i = 0;
+		while (i < registry->agents_size && registry->agents[i])
+			++i;
+
+		if (i == registry->agents_size) {
+			int new_size = registry->agents_size * 2;
+			JLOG_DEBUG("Reallocating connections array, new_size=%d", new_size);
+			assert(new_size > 0);
+
+			juice_agent_t **new_agents =
+			    realloc(registry->agents, new_size * sizeof(juice_agent_t *));
+			if (!new_agents) {
+				JLOG_FATAL("Memory reallocation failed for connections array");
+				mutex_unlock(&registry->mutex);
+				mutex_unlock(&entry->mutex);
+				return -1;
+			}
+
+			registry->agents = new_agents;
+			registry->agents_size = new_size;
+			memset(registry->agents + i, 0, (new_size - i) * sizeof(juice_agent_t *));
+		}
+
+		if (get_agent_mode_entry(agent)->init_func(agent, registry, config)) {
+			release_registry(entry, registry); // unlocks the registry
+			mutex_unlock(&entry->mutex);
+			return -1;
+		}
+
+		registry->agents[i] = agent;
+		agent->conn_index = i;
+		++registry->agents_count;
+
+		mutex_unlock(&registry->mutex);
+
+	} else {
+		if (get_agent_mode_entry(agent)->init_func(agent, NULL, config)) {
+			mutex_unlock(&entry->mutex);
+			return -1;
+		}
+
+		agent->conn_index = -1;
+	}
+
+	mutex_unlock(&entry->mutex);
+	conn_interrupt(agent);
+	return 0;
+}
+
+void conn_destroy(juice_agent_t *agent) {
+	conn_mode_entry_t *entry = get_agent_mode_entry(agent);
+	mutex_lock(&entry->mutex);
+
+	JLOG_DEBUG("Destroying connection");
+	conn_registry_t *registry = agent->registry;
+	if (registry) {
+		mutex_lock(&registry->mutex);
+
+		entry->cleanup_func(agent);
+
+		if (agent->conn_index >= 0) {
+			int i = agent->conn_index;
+			assert(registry->agents[i] == agent);
+			registry->agents[i] = NULL;
+			agent->conn_index = -1;
+		}
+
+		assert(registry->agents_count > 0);
+		--registry->agents_count;
+
+		agent->registry = NULL;
+		release_registry(entry, registry); // unlocks the registry
+
+	} else {
+		entry->cleanup_func(agent);
+		assert(agent->conn_index < 0);
+	}
+
+	mutex_unlock(&entry->mutex);
+}
+
+void conn_lock(juice_agent_t *agent) {
+	if (!agent->conn_impl)
+		return;
+
+	get_agent_mode_entry(agent)->lock_func(agent);
+}
+
+void conn_unlock(juice_agent_t *agent) {
+	if (!agent->conn_impl)
+		return;
+
+	get_agent_mode_entry(agent)->unlock_func(agent);
+}
+
+int conn_interrupt(juice_agent_t *agent) {
+	if (!agent->conn_impl)
+		return -1;
+
+	return get_agent_mode_entry(agent)->interrupt_func(agent);
+}
+
+int conn_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+              int ds) {
+	if (!agent->conn_impl)
+		return -1;
+
+	return get_agent_mode_entry(agent)->send_func(agent, dst, data, size, ds);
+}
+
+void conn_tcp_connect(juice_agent_t *agent, const addr_record_t *dst) {
+	if (!agent->conn_impl)
+		return;
+
+	conn_mode_entry_t *entry = get_agent_mode_entry(agent);
+	if (entry->tcp_connect_func)
+		entry->tcp_connect_func(agent, dst);
+}
+
+int conn_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	if (!agent->conn_impl)
+		return -1;
+
+	return get_agent_mode_entry(agent)->get_addrs_func(agent, records, size);
+}
+
+int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr) {
+	conn_mode_entry_t *entry = &mode_entries[JUICE_CONCURRENCY_MODE_MUX];
+
+	if (!entry->mux_listen_func) {
+		JLOG_DEBUG("juice_mux_listen mux_listen_func is not implemented");
+		return -1;
+	}
+
+	if (!entry->get_registry_func) {
+		JLOG_DEBUG("juice_mux_listen get_registry_func is not implemented");
+		return -1;
+	}
+
+	mutex_lock(&entry->mutex);
+
+	udp_socket_config_t config;
+	config.bind_address = bind_address;
+	config.port_begin = config.port_end = local_port;
+
+	conn_registry_t *registry;
+
+	// locks the registry, creating it first if required
+	if(acquire_registry(entry, &config, &registry)) {
+		JLOG_DEBUG("juice_mux_listen acquiring registry failed");
+		mutex_unlock(&entry->mutex);
+		return -1;
+	}
+
+	if (!registry) {
+		JLOG_DEBUG("juice_mux_listen registry not found after creating it");
+		mutex_unlock(&entry->mutex);
+		return -1;
+	}
+
+	if (entry->mux_listen_func(registry, cb, user_ptr)) {
+		JLOG_DEBUG("juice_mux_listen failed to call mux_listen_func for %s:%d", bind_address, local_port);
+		release_registry(entry, registry);
+		mutex_unlock(&entry->mutex);
+		return -1;
+	}
+
+	release_registry(entry, registry);
+	mutex_unlock(&entry->mutex);
+	return 0;
+}

--- a/Source/3rdParty/libjuice/src/conn.h
+++ b/Source/3rdParty/libjuice/src/conn.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_CONN_H
+#define JUICE_CONN_H
+
+#include "addr.h"
+#include "juice.h"
+#include "thread.h"
+#include "timestamp.h"
+#include "udp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct juice_agent juice_agent_t;
+
+// Generic connection interface for agents
+// This interface abstracts sockets and polling to allow for different concurrency modes.
+// See include/juice/juice.h for implemented concurrency modes
+
+typedef struct conn_registry {
+	void *impl;
+	mutex_t mutex;
+	juice_agent_t **agents;
+	int agents_size;
+	int agents_count;
+} conn_registry_t;
+
+typedef struct conn_mode_entry {
+	int (*registry_init_func)(conn_registry_t *registry, udp_socket_config_t *config);
+	void (*registry_cleanup_func)(conn_registry_t *registry);
+
+	int (*init_func)(juice_agent_t *agent, struct conn_registry *registry,
+	                 udp_socket_config_t *config);
+	void (*cleanup_func)(juice_agent_t *agent);
+	void (*lock_func)(juice_agent_t *agent);
+	void (*unlock_func)(juice_agent_t *agent);
+	int (*interrupt_func)(juice_agent_t *agent);
+	int (*send_func)(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+	                 int ds);
+	void (*tcp_connect_func)(juice_agent_t *agent, const addr_record_t *dst);
+	int (*get_addrs_func)(juice_agent_t *agent, addr_record_t *records, size_t size);
+	int (*mux_listen_func)(conn_registry_t *registry, juice_cb_mux_incoming_t cb, void *user_ptr);
+	conn_registry_t *(*get_registry_func)(udp_socket_config_t *config);
+	bool (*can_release_registry_func)(conn_registry_t *registry);
+
+	mutex_t mutex;
+	conn_registry_t *registry;
+} conn_mode_entry_t;
+
+conn_mode_entry_t *conn_get_mode_entry(juice_concurrency_mode_t mode);
+int conn_create(juice_agent_t *agent, udp_socket_config_t *config);
+void conn_destroy(juice_agent_t *agent);
+void conn_lock(juice_agent_t *agent);
+void conn_unlock(juice_agent_t *agent);
+int conn_interrupt(juice_agent_t *agent);
+int conn_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+              int ds);
+void conn_tcp_connect(juice_agent_t *agent, const addr_record_t *dst);
+int conn_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/Source/3rdParty/libjuice/src/conn_mux.c
+++ b/Source/3rdParty/libjuice/src/conn_mux.c
@@ -1,0 +1,703 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "conn_mux.h"
+#include "agent.h"
+#include "log.h"
+#include "socket.h"
+#include "stun.h"
+#include "thread.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define BUFFER_SIZE 4096
+#define INITIAL_MAP_SIZE 16
+
+typedef enum map_entry_type {
+	MAP_ENTRY_TYPE_EMPTY = 0,
+	MAP_ENTRY_TYPE_DELETED,
+	MAP_ENTRY_TYPE_FULL
+} map_entry_type_t;
+
+typedef struct map_entry {
+	map_entry_type_t type;
+	juice_agent_t *agent;
+	addr_record_t record;
+} map_entry_t;
+
+typedef struct registry_impl {
+	int conn_mux_registries_index;
+	uint16_t port;
+	thread_t thread;
+	socket_t sock;
+	mutex_t send_mutex;
+	int send_ds;
+	map_entry_t *map;
+	int map_size;
+	int map_count;
+	juice_cb_mux_incoming_t cb_mux_incoming;
+	void *mux_incoming_user_ptr;
+} registry_impl_t;
+
+typedef struct conn_impl {
+	conn_registry_t *registry;
+	timestamp_t next_timestamp;
+	bool finished;
+} conn_impl_t;
+
+static conn_registry_t **conn_mux_registries;
+static int conn_mux_registries_size;
+static int conn_mux_registries_count;
+
+conn_registry_t *conn_mux_get_registry(udp_socket_config_t *config) {
+	for (int i = 0; i < conn_mux_registries_size; i++) {
+		if (!conn_mux_registries[i]) {
+			continue;
+		}
+
+		conn_registry_t *registry = conn_mux_registries[i];
+		registry_impl_t *impl = registry->impl;
+
+		if (impl->port >= config->port_begin && (config->port_end == 0 || impl->port <= config->port_end)) {
+			return registry;
+		}
+	}
+
+	return NULL;
+}
+
+static int conn_mux_add_registry(conn_registry_t *registry) {
+	int i = 0;
+		while (i < conn_mux_registries_size && conn_mux_registries[i])
+			++i;
+
+	if (i == conn_mux_registries_size) {
+		int new_size = conn_mux_registries_size * 2;
+
+		if (new_size == 0) {
+			new_size = 1;
+		}
+
+		JLOG_DEBUG("Reallocating registries array, new_size=%d", new_size);
+		assert(new_size > 0);
+
+		conn_registry_t **new_registries =
+				realloc(conn_mux_registries, new_size * sizeof(conn_registry_t *));
+		if (!new_registries) {
+			JLOG_FATAL("Memory reallocation failed for registries array");
+			return -1;
+		}
+
+		conn_mux_registries = new_registries;
+		conn_mux_registries_size = new_size;
+		memset(conn_mux_registries + i, 0, (new_size - i) * sizeof(conn_registry_t *));
+	}
+
+	conn_mux_registries[i] = registry;
+	++conn_mux_registries_count;
+
+	registry_impl_t *impl = registry->impl;
+	impl->conn_mux_registries_index = i;
+
+	return 0;
+}
+
+static bool is_ready(const juice_agent_t *agent) {
+	if (!agent)
+		return false;
+
+	conn_impl_t *conn_impl = agent->conn_impl;
+	if (!conn_impl || conn_impl->finished)
+		return false;
+
+	return true;
+}
+
+static map_entry_t *find_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                                   bool allow_deleted);
+static int insert_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                            juice_agent_t *agent);
+static int remove_map_entries(registry_impl_t *impl, juice_agent_t *agent);
+static int grow_map(registry_impl_t *impl, int new_size);
+
+static map_entry_t *find_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                                   bool allow_deleted) {
+	unsigned long key = addr_record_hash(record, false) % impl->map_size;
+	unsigned long pos = key;
+	while (true) {
+		map_entry_t *entry = impl->map + pos;
+		if (entry->type == MAP_ENTRY_TYPE_EMPTY ||
+		    addr_record_is_equal(&entry->record, record, true)) // compare ports
+			break;
+
+		if (entry->type == MAP_ENTRY_TYPE_DELETED && allow_deleted)
+			break;
+
+		pos = (pos + 1) % impl->map_size;
+		if (pos == key)
+			return NULL;
+	}
+	return impl->map + pos;
+}
+
+static int insert_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                            juice_agent_t *agent) {
+
+	map_entry_t *entry = find_map_entry(impl, record, true); // allow deleted
+	if (!entry || (entry->type != MAP_ENTRY_TYPE_FULL && impl->map_count * 2 >= impl->map_size)) {
+		grow_map(impl, impl->map_size * 2);
+		return insert_map_entry(impl, record, agent);
+	}
+
+	if (entry->type != MAP_ENTRY_TYPE_FULL)
+		++impl->map_count;
+
+	entry->type = MAP_ENTRY_TYPE_FULL;
+	entry->agent = agent;
+	entry->record = *record;
+
+	JLOG_VERBOSE("Added map entry, count=%d", impl->map_count);
+	return 0;
+}
+
+static int remove_map_entries(registry_impl_t *impl, juice_agent_t *agent) {
+	int count = 0;
+	for (int i = 0; i < impl->map_size; ++i) {
+		map_entry_t *entry = impl->map + i;
+		if (entry->type == MAP_ENTRY_TYPE_FULL && entry->agent == agent) {
+			entry->type = MAP_ENTRY_TYPE_DELETED;
+			entry->agent = NULL;
+			++count;
+		}
+	}
+
+	assert(impl->map_count >= count);
+	impl->map_count -= count;
+
+	JLOG_VERBOSE("Removed %d map entries, count=%d", count, impl->map_count);
+	return 0;
+}
+
+static int grow_map(registry_impl_t *impl, int new_size) {
+	if (new_size <= impl->map_size)
+		return 0;
+
+	JLOG_DEBUG("Growing map, new_size=%d", new_size);
+
+	map_entry_t *new_map = calloc(1, new_size * sizeof(map_entry_t));
+	if (!new_map) {
+		JLOG_FATAL("Memory allocation failed for map");
+		return -1;
+	}
+
+	map_entry_t *old_map = impl->map;
+	int old_size = impl->map_size;
+	impl->map = new_map;
+	impl->map_size = new_size;
+	impl->map_count = 0;
+
+	for (int i = 0; i < old_size; ++i) {
+		map_entry_t *old_entry = old_map + i;
+		if (old_entry->type == MAP_ENTRY_TYPE_FULL)
+			insert_map_entry(impl, &old_entry->record, old_entry->agent);
+	}
+
+	free(old_map);
+	return 0;
+}
+
+int conn_mux_prepare(conn_registry_t *registry, struct pollfd *pfd, timestamp_t *next_timestamp);
+int conn_mux_process(conn_registry_t *registry, struct pollfd *pfd);
+int conn_mux_recv(conn_registry_t *registry, char *buffer, size_t size, addr_record_t *src);
+void conn_mux_fail(conn_registry_t *registry);
+int conn_mux_run(conn_registry_t *registry);
+
+static thread_return_t THREAD_CALL conn_mux_thread_entry(void *arg) {
+	thread_set_name_self("juice mux");
+	conn_registry_t *registry = (conn_registry_t *)arg;
+	conn_mux_run(registry);
+	return (thread_return_t)0;
+}
+
+int conn_mux_registry_init(conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config;
+	registry_impl_t *registry_impl = calloc(1, sizeof(registry_impl_t));
+	if (!registry_impl) {
+		JLOG_FATAL("Memory allocation failed for connections registry impl");
+		return -1;
+	}
+
+	registry_impl->map = calloc(INITIAL_MAP_SIZE, sizeof(map_entry_t));
+	if (!registry_impl->map) {
+		JLOG_FATAL("Memory allocation failed for map");
+		free(registry_impl);
+		return -1;
+	}
+	registry_impl->map_size = INITIAL_MAP_SIZE;
+	registry_impl->map_count = 0;
+
+	registry_impl->sock = udp_create_socket(config);
+	if (registry_impl->sock == INVALID_SOCKET) {
+		JLOG_FATAL("UDP socket creation failed");
+		free(registry_impl->map);
+		free(registry_impl);
+		return -1;
+	}
+
+	registry_impl->port = udp_get_port(registry_impl->sock);
+
+	mutex_init(&registry_impl->send_mutex, 0);
+	registry->impl = registry_impl;
+
+	JLOG_DEBUG("Starting connections thread");
+	int ret = thread_init(&registry_impl->thread, conn_mux_thread_entry, registry);
+	if (ret) {
+		JLOG_FATAL("Thread creation failed, error=%d", ret);
+		goto error;
+	}
+
+	if (conn_mux_add_registry(registry)) {
+		JLOG_FATAL("Could not add registry");
+		free(registry_impl->map);
+		free(registry_impl);
+		return -1;
+	}
+
+	return 0;
+
+error:
+	mutex_destroy(&registry_impl->send_mutex);
+	closesocket(registry_impl->sock);
+	free(registry_impl->map);
+	free(registry_impl);
+	registry->impl = NULL;
+	return -1;
+}
+
+void conn_mux_registry_cleanup(conn_registry_t *registry) {
+	registry_impl_t *registry_impl = registry->impl;
+
+	JLOG_VERBOSE("Waiting for connections thread");
+	thread_join(registry_impl->thread, NULL);
+
+	if (registry_impl->conn_mux_registries_index > -1) {
+		int i = registry_impl->conn_mux_registries_index;
+		assert(conn_mux_registries[i] == registry);
+		conn_mux_registries[i] = NULL;
+		registry_impl->conn_mux_registries_index = -1;
+	}
+
+	assert(conn_mux_registries_count > 0);
+	--conn_mux_registries_count;
+
+	mutex_destroy(&registry_impl->send_mutex);
+	closesocket(registry_impl->sock);
+	free(registry_impl->map);
+	free(registry->impl);
+	registry->impl = NULL;
+}
+
+int conn_mux_prepare(conn_registry_t *registry, struct pollfd *pfd, timestamp_t *next_timestamp) {
+	timestamp_t now = current_timestamp();
+	*next_timestamp = now + 60000;
+
+	mutex_lock(&registry->mutex);
+	registry_impl_t *registry_impl = registry->impl;
+	pfd->fd = registry_impl->sock;
+	pfd->events = POLLIN;
+
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (is_ready(agent)) {
+			conn_impl_t *conn_impl = agent->conn_impl;
+			if (*next_timestamp > conn_impl->next_timestamp)
+				*next_timestamp = conn_impl->next_timestamp;
+		}
+	}
+
+	int count = registry->agents_count;
+	registry_impl_t *impl = registry->impl;
+	if (impl->cb_mux_incoming)
+		++count;
+	mutex_unlock(&registry->mutex);
+	return count;
+}
+
+static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t len,
+                                   const addr_record_t *src) {
+	JLOG_VERBOSE("Looking up agent from address");
+
+	registry_impl_t *registry_impl = registry->impl;
+	map_entry_t *entry = find_map_entry(registry_impl, src, false);
+	juice_agent_t *agent = entry && entry->type == MAP_ENTRY_TYPE_FULL ? entry->agent : NULL;
+	if (agent) {
+		JLOG_DEBUG("Found agent from address");
+		return agent;
+	}
+
+	if (!is_stun_datagram(buf, len)) {
+		JLOG_INFO("Got non-STUN message from unknown source address");
+		return NULL;
+	}
+
+	JLOG_VERBOSE("Looking up agent from STUN message content");
+
+	stun_message_t msg;
+	if (stun_read(buf, len, &msg) < 0) {
+		JLOG_ERROR("STUN message reading failed");
+		return NULL;
+	}
+
+	if (msg.msg_class == STUN_CLASS_REQUEST && msg.msg_method == STUN_METHOD_BINDING &&
+	    msg.has_integrity) {
+		// Binding request from peer
+		char username[STUN_MAX_USERNAME_LEN];
+		strcpy(username, msg.credentials.username);
+		char *separator = strchr(username, ':');
+		if (!separator) {
+			JLOG_WARN("STUN username invalid, username=\"%s\"", username);
+			return NULL;
+		}
+		*separator = '\0';
+		const char *local_ufrag = username;
+		for (int i = 0; i < registry->agents_size; ++i) {
+			agent = registry->agents[i];
+			if (is_ready(agent)) {
+				if (strcmp(local_ufrag, agent->local.ice_ufrag) == 0) {
+					JLOG_DEBUG("Found agent from ICE ufrag");
+					insert_map_entry(registry_impl, src, agent);
+					return agent;
+				}
+			}
+		}
+
+		registry_impl_t *impl = registry->impl;
+
+		if (impl->cb_mux_incoming) {
+			JLOG_DEBUG("Found STUN request with unknown ICE ufrag");
+			char host[ADDR_MAX_NUMERICHOST_LEN];
+			if (getnameinfo((const struct sockaddr *)&src->addr, src->len, host, ADDR_MAX_NUMERICHOST_LEN, NULL, 0, NI_NUMERICHOST)) {
+				JLOG_ERROR("getnameinfo failed, errno=%d", sockerrno);
+				return NULL;
+			}
+
+			juice_mux_binding_request_t incoming_info;
+
+			incoming_info.local_ufrag = local_ufrag;
+			incoming_info.remote_ufrag = separator + 1;
+			incoming_info.address = host;
+			incoming_info.port = addr_get_port((struct sockaddr *)src);
+
+			impl->cb_mux_incoming(&incoming_info, impl->mux_incoming_user_ptr);
+
+			return NULL;
+		}
+	} else {
+		if (!STUN_IS_RESPONSE(msg.msg_class)) {
+			JLOG_INFO("Got unexpected STUN message from unknown source address");
+			return NULL;
+		}
+
+		for (int i = 0; i < registry->agents_size; ++i) {
+			agent = registry->agents[i];
+			if (is_ready(agent)) {
+				if (agent_find_entry_from_transaction_id(agent, msg.transaction_id)) {
+					JLOG_DEBUG("Found agent from transaction ID");
+					return agent;
+				}
+			}
+		}
+	}
+
+	return NULL;
+}
+
+int conn_mux_process(conn_registry_t *registry, struct pollfd *pfd) {
+	mutex_lock(&registry->mutex);
+
+	if (pfd->revents & POLLNVAL || pfd->revents & POLLERR) {
+		JLOG_ERROR("Error when polling socket");
+		conn_mux_fail(registry);
+		mutex_unlock(&registry->mutex);
+		return -1;
+	}
+
+	if (pfd->revents & POLLIN) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t src;
+		int left = 1000; // limit to ensure update is run and new agents are processed
+		int ret;
+		while (left--) {
+			if ((ret = conn_mux_recv(registry, buffer, BUFFER_SIZE, &src)) <= 0) {
+				break;
+			}
+
+			if (JLOG_DEBUG_ENABLED) {
+				char src_str[ADDR_MAX_STRING_LEN];
+				addr_record_to_string(&src, src_str, ADDR_MAX_STRING_LEN);
+				JLOG_DEBUG("Demultiplexing incoming datagram from %s", src_str);
+			}
+
+			juice_agent_t *agent = lookup_agent(registry, buffer, (size_t)ret, &src);
+			if (!agent || !is_ready(agent)) {
+				JLOG_DEBUG("Agent not found for incoming datagram, dropping");
+				continue;
+			}
+
+			conn_impl_t *conn_impl = agent->conn_impl;
+			if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
+				JLOG_WARN("Agent receive failed");
+				conn_impl->finished = true;
+				continue;
+			}
+
+			conn_impl->next_timestamp = current_timestamp();
+		}
+
+		if (ret < 0) {
+			conn_mux_fail(registry);
+			mutex_unlock(&registry->mutex);
+			return -1;
+		}
+	}
+
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (is_ready(agent)) {
+			conn_impl_t *conn_impl = agent->conn_impl;
+			if (conn_impl->next_timestamp <= current_timestamp()) {
+				if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+					JLOG_WARN("Agent update failed");
+					conn_impl->finished = true;
+					continue;
+				}
+			}
+		}
+	}
+
+	mutex_unlock(&registry->mutex);
+	return 0;
+}
+
+int conn_mux_recv(conn_registry_t *registry, char *buffer, size_t size, addr_record_t *src) {
+	JLOG_VERBOSE("Receiving datagram");
+	registry_impl_t *registry_impl = registry->impl;
+	int len;
+	while ((len = udp_recvfrom(registry_impl->sock, buffer, size, src)) == 0) {
+		// Empty datagram (used to interrupt)
+	}
+
+	if (len < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
+			return 0;
+		}
+		JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+	return len; // len > 0
+}
+
+void conn_mux_fail(conn_registry_t *registry) {
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (is_ready(agent)) {
+			conn_impl_t *conn_impl = agent->conn_impl;
+			agent_conn_fail(agent);
+			conn_impl->finished = true;
+		}
+	}
+}
+
+int conn_mux_run(conn_registry_t *registry) {
+	struct pollfd pfd[1];
+	timestamp_t next_timestamp;
+	while (conn_mux_prepare(registry, pfd, &next_timestamp) > 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		JLOG_VERBOSE("Entering poll for %d ms", (int)timediff);
+		int ret = poll(pfd, 1, (int)timediff);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (conn_mux_process(registry, pfd) < 0)
+			break;
+	}
+
+	JLOG_DEBUG("Leaving connections thread");
+	return 0;
+}
+
+int conn_mux_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config; // ignored, only the config from the first connection is used
+
+	conn_impl_t *conn_impl = calloc(1, sizeof(conn_impl_t));
+	if (!conn_impl) {
+		JLOG_FATAL("Memory allocation failed for connection impl");
+		return -1;
+	}
+
+	conn_impl->registry = registry;
+	agent->conn_impl = conn_impl;
+	return 0;
+}
+
+void conn_mux_cleanup(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+
+	mutex_lock(&registry->mutex);
+	registry_impl_t *registry_impl = registry->impl;
+	remove_map_entries(registry_impl, agent);
+	mutex_unlock(&registry->mutex);
+
+	conn_mux_interrupt(agent);
+
+	free(agent->conn_impl);
+	agent->conn_impl = NULL;
+}
+
+void conn_mux_lock(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+	mutex_lock(&registry->mutex);
+}
+
+void conn_mux_unlock(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+	mutex_unlock(&registry->mutex);
+}
+
+int conn_mux_interrupt_registry(conn_registry_t *registry) {
+	JLOG_VERBOSE("Interrupting connections thread");
+
+	registry_impl_t *registry_impl = registry->impl;
+	mutex_lock(&registry_impl->send_mutex);
+	char dummy = 0; // Some C libraries might error out on NULL pointers
+	if (udp_sendto_self(registry_impl->sock, &dummy, 0) < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
+		}
+		mutex_unlock(&registry_impl->send_mutex);
+		return -1;
+	}
+	mutex_unlock(&registry_impl->send_mutex);
+	return 0;
+}
+
+int conn_mux_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+
+	mutex_lock(&registry->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+	mutex_unlock(&registry->mutex);
+
+	return conn_mux_interrupt_registry(registry);
+}
+
+int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                  int ds) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	registry_impl_t *registry_impl = conn_impl->registry->impl;
+
+	mutex_lock(&registry_impl->send_mutex);
+
+	if (registry_impl->send_ds >= 0 && registry_impl->send_ds != ds) {
+		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+		if (udp_set_diffserv(registry_impl->sock, ds) == 0)
+			registry_impl->send_ds = ds;
+		else
+			registry_impl->send_ds = -1; // disable for next time
+	}
+
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret = udp_sendto(registry_impl->sock, data, size, dst);
+	if (ret < 0) {
+		ret = -sockerrno;
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
+			JLOG_INFO("Send failed, buffer is full");
+		else if (sockerrno == SEMSGSIZE)
+			JLOG_WARN("Send failed, datagram is too large");
+		else
+			JLOG_WARN("Send failed, errno=%d", sockerrno);
+	}
+
+	mutex_unlock(&registry_impl->send_mutex);
+	return ret;
+}
+
+int conn_mux_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	registry_impl_t *registry_impl = conn_impl->registry->impl;
+
+	return udp_get_addrs(registry_impl->sock, records, size);
+}
+
+int conn_mux_stop_listen(conn_registry_t *registry) {
+	registry_impl_t *registry_impl = registry->impl;
+	if (!registry_impl) {
+		JLOG_VERBOSE("conn_mux_stop_listen No registry impl found");
+		return -1;
+	}
+
+	JLOG_VERBOSE("conn_mux_stop_listen Removing mux handler callback");
+	registry_impl->cb_mux_incoming = NULL;
+	registry_impl->mux_incoming_user_ptr = NULL;
+
+	return conn_mux_interrupt_registry(registry);
+}
+
+int conn_mux_listen(conn_registry_t *registry, juice_cb_mux_incoming_t cb, void *user_ptr) {
+	if (!cb) {
+		return conn_mux_stop_listen(registry);
+	}
+
+	registry_impl_t *registry_impl = registry->impl;
+	if (!registry_impl) {
+		JLOG_VERBOSE("conn_mux_listen No registry impl found");
+		return -1;
+	}
+
+	if (registry_impl->cb_mux_incoming) {
+		JLOG_VERBOSE("conn_mux_listen Callback already registered\n");
+		return -1;
+	}
+
+	registry_impl->cb_mux_incoming = cb;
+	registry_impl->mux_incoming_user_ptr = user_ptr;
+
+	return 0;
+}
+
+bool conn_mux_can_release_registry(conn_registry_t *registry) {
+	registry_impl_t *registry_impl = registry->impl;
+
+	if (!registry_impl) {
+		JLOG_VERBOSE("conn_mux_can_release_registry No registry impl found");
+		return true;
+	}
+
+	return registry_impl->cb_mux_incoming == NULL;
+}

--- a/Source/3rdParty/libjuice/src/conn_mux.h
+++ b/Source/3rdParty/libjuice/src/conn_mux.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_CONN_MUX_H
+#define JUICE_CONN_MUX_H
+
+#include "addr.h"
+#include "conn.h"
+#include "thread.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int conn_mux_registry_init(conn_registry_t *registry, udp_socket_config_t *config);
+void conn_mux_registry_cleanup(conn_registry_t *registry);
+
+int conn_mux_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config);
+void conn_mux_cleanup(juice_agent_t *agent);
+void conn_mux_lock(juice_agent_t *agent);
+void conn_mux_unlock(juice_agent_t *agent);
+int conn_mux_interrupt_registry(conn_registry_t *registry);
+int conn_mux_interrupt(juice_agent_t *agent);
+int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                        int ds);
+int conn_mux_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+int conn_mux_listen(conn_registry_t *registry, juice_cb_mux_incoming_t cb, void *user_ptr);
+conn_registry_t *conn_mux_get_registry(udp_socket_config_t *config);
+bool conn_mux_can_release_registry(conn_registry_t *registry);
+
+#endif

--- a/Source/3rdParty/libjuice/src/conn_poll.c
+++ b/Source/3rdParty/libjuice/src/conn_poll.c
@@ -1,0 +1,679 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "conn_poll.h"
+#include "agent.h"
+#include "log.h"
+#include "socket.h"
+#include "tcp.h"
+#include "thread.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define BUFFER_SIZE 4096
+
+typedef struct registry_impl {
+	thread_t thread;
+#ifdef _WIN32
+	socket_t interrupt_sock;
+#else
+	int interrupt_pipe_out;
+	int interrupt_pipe_in;
+#endif
+} registry_impl_t;
+
+typedef enum conn_state { CONN_STATE_NEW = 0, CONN_STATE_READY, CONN_STATE_FINISHED } conn_state_t;
+
+typedef struct conn_impl {
+	conn_registry_t *registry;
+	conn_state_t state;
+	socket_t udp_sock;
+	socket_t tcp_sock;
+	tcp_ice_write_context_t tcp_ice_write_context;
+	tcp_ice_read_context_t tcp_ice_read_context;
+	addr_record_t tcp_dst;
+	tcp_state_t tcp_state;
+	mutex_t send_mutex;
+	int send_ds;
+	timestamp_t next_timestamp;
+} conn_impl_t;
+
+typedef struct pfds_record {
+	struct pollfd *pfds;
+	nfds_t size;
+} pfds_record_t;
+
+int conn_poll_prepare(conn_registry_t *registry, pfds_record_t *pfds, timestamp_t *next_timestamp);
+int conn_poll_process(conn_registry_t *registry, pfds_record_t *pfds);
+void conn_poll_process_udp(juice_agent_t *agent, struct pollfd *pfd);
+int conn_poll_recv_udp(socket_t sock, char *buffer, size_t size, addr_record_t *src);
+void conn_poll_process_tcp(juice_agent_t *agent, struct pollfd *pfd);
+void conn_poll_change_tcp_fail(juice_agent_t *agent);
+void conn_poll_change_tcp_state(juice_agent_t *agent, tcp_state_t state);
+int conn_poll_run(conn_registry_t *registry);
+
+static thread_return_t THREAD_CALL conn_thread_entry(void *arg) {
+	thread_set_name_self("juice poll");
+	conn_registry_t *registry = (conn_registry_t *)arg;
+	conn_poll_run(registry);
+	return (thread_return_t)0;
+}
+
+int conn_poll_registry_init(conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config;
+	registry_impl_t *registry_impl = calloc(1, sizeof(registry_impl_t));
+	if (!registry_impl) {
+		JLOG_FATAL("Memory allocation failed for connections registry impl");
+		return -1;
+	}
+
+#ifdef _WIN32
+	udp_socket_config_t interrupt_config;
+	memset(&interrupt_config, 0, sizeof(interrupt_config));
+	interrupt_config.bind_address = "localhost";
+	registry_impl->interrupt_sock = udp_create_socket(&interrupt_config);
+	if (registry_impl->interrupt_sock == INVALID_SOCKET) {
+		JLOG_FATAL("Dummy socket creation failed");
+		free(registry_impl);
+		return -1;
+	}
+#else
+	int pipefds[2];
+	if (pipe(pipefds)) {
+		JLOG_FATAL("Pipe creation failed");
+		free(registry_impl);
+		return -1;
+	}
+
+	fcntl(pipefds[0], F_SETFL, O_NONBLOCK);
+	fcntl(pipefds[1], F_SETFL, O_NONBLOCK);
+	registry_impl->interrupt_pipe_out = pipefds[1]; // read
+	registry_impl->interrupt_pipe_in = pipefds[0];  // write
+#endif
+
+	registry->impl = registry_impl;
+
+	JLOG_DEBUG("Starting connections thread");
+	int ret = thread_init(&registry_impl->thread, conn_thread_entry, registry);
+	if (ret) {
+		JLOG_FATAL("Thread creation failed, error=%d", ret);
+		goto error;
+	}
+
+	return 0;
+
+error:
+#ifndef _WIN32
+	close(registry_impl->interrupt_pipe_out);
+	close(registry_impl->interrupt_pipe_in);
+#endif
+	free(registry_impl);
+	registry->impl = NULL;
+	return -1;
+}
+
+void conn_poll_registry_cleanup(conn_registry_t *registry) {
+	registry_impl_t *registry_impl = registry->impl;
+
+	JLOG_VERBOSE("Waiting for connections thread");
+	thread_join(registry_impl->thread, NULL);
+
+#ifdef _WIN32
+	closesocket(registry_impl->interrupt_sock);
+#else
+	close(registry_impl->interrupt_pipe_out);
+	close(registry_impl->interrupt_pipe_in);
+#endif
+	free(registry->impl);
+	registry->impl = NULL;
+}
+
+int conn_poll_prepare(conn_registry_t *registry, pfds_record_t *pfds, timestamp_t *next_timestamp) {
+	timestamp_t now = current_timestamp();
+	*next_timestamp = now + 60000;
+
+	mutex_lock(&registry->mutex);
+	nfds_t size = 1;
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (!agent) {
+			continue;
+		}
+
+		conn_impl_t *conn_impl = agent->conn_impl;
+		if (!conn_impl ||
+		    (conn_impl->state != CONN_STATE_NEW && conn_impl->state != CONN_STATE_READY)) {
+			continue;
+		}
+
+		size++;
+		if (conn_impl->tcp_sock != INVALID_SOCKET) {
+			size++;
+		}
+	}
+
+	if (pfds->size != size) {
+		struct pollfd *new_pfds = realloc(pfds->pfds, sizeof(struct pollfd) * size);
+		if (!new_pfds) {
+			JLOG_FATAL("Memory allocation for poll file descriptors failed");
+			goto error;
+		}
+		pfds->pfds = new_pfds;
+		pfds->size = size;
+	}
+
+	registry_impl_t *registry_impl = registry->impl;
+	struct pollfd *interrupt_pfd = pfds->pfds;
+	assert(interrupt_pfd);
+#ifdef _WIN32
+	interrupt_pfd->fd = registry_impl->interrupt_sock;
+#else
+	interrupt_pfd->fd = registry_impl->interrupt_pipe_in;
+#endif
+	interrupt_pfd->events = POLLIN;
+
+	nfds_t i = 1;
+	for (int j = 0; j < registry->agents_size; ++j) {
+		juice_agent_t *agent = registry->agents[j];
+		if (!agent)
+			continue;
+
+		conn_impl_t *conn_impl = agent->conn_impl;
+		if (!conn_impl ||
+		    (conn_impl->state != CONN_STATE_NEW && conn_impl->state != CONN_STATE_READY))
+			continue;
+
+		if (conn_impl->state == CONN_STATE_NEW)
+			conn_impl->state = CONN_STATE_READY;
+
+		if (*next_timestamp > conn_impl->next_timestamp)
+			*next_timestamp = conn_impl->next_timestamp;
+
+		assert(i < pfds->size);
+
+		struct pollfd *udp_pfd = pfds->pfds + i;
+		udp_pfd->fd = conn_impl->udp_sock;
+		udp_pfd->events = POLLIN;
+		i++;
+
+		if (conn_impl->tcp_sock != INVALID_SOCKET) {
+			struct pollfd *tcp_pfd = pfds->pfds + i;
+			tcp_pfd->fd = conn_impl->tcp_sock;
+			if (conn_impl->tcp_state == TCP_STATE_CONNECTING) {
+				tcp_pfd->events = POLLOUT;
+			} else {
+				tcp_pfd->events = POLLIN;
+				if(conn_impl->tcp_ice_write_context.pending)
+					tcp_pfd->events |= POLLOUT;
+			}
+
+			i++;
+		}
+	}
+
+	mutex_unlock(&registry->mutex);
+	return size - 1;
+
+error:
+	mutex_unlock(&registry->mutex);
+	return -1;
+}
+
+void conn_poll_process_udp(juice_agent_t *agent, struct pollfd *pfd) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	if (pfd->revents & POLLNVAL) {
+		JLOG_WARN("Invalid socket");
+		return;
+	}
+
+	if (pfd->revents & POLLERR) {
+		JLOG_WARN("UDP socket error");
+		agent_conn_fail(agent);
+		conn_impl->state = CONN_STATE_FINISHED;
+	}
+
+	if (pfd->revents & POLLIN) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t src;
+		int ret = 0;
+		int left = 1000; // limit for fairness between sockets
+		while (left--) {
+			if ((ret = conn_poll_recv_udp(conn_impl->udp_sock, buffer, BUFFER_SIZE,
+							&src)) <= 0) {
+				break;
+			}
+
+			if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
+				JLOG_WARN("Agent receive failed");
+				conn_impl->state = CONN_STATE_FINISHED;
+				break;
+			}
+		}
+
+		if (conn_impl->state == CONN_STATE_FINISHED)
+			return;
+
+		if (ret > 0) {
+			// There are more datagrams but we need to give other sockets a turn
+			JLOG_VERBOSE("Fairness limit reached, will continue on next poll");
+		} else if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
+		} else {
+			agent_conn_fail(agent);
+			conn_impl->state = CONN_STATE_FINISHED;
+			return;
+		}
+
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			conn_impl->state = CONN_STATE_FINISHED;
+			return;
+		}
+
+	} else if (conn_impl->next_timestamp <= current_timestamp()) {
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			conn_impl->state = CONN_STATE_FINISHED;
+			return;
+		}
+	}
+
+}
+
+int conn_poll_recv_udp(socket_t sock, char *buffer, size_t size, addr_record_t *src) {
+	JLOG_VERBOSE("Receiving datagram");
+	int len;
+	while ((len = udp_recvfrom(sock, buffer, size, src)) == 0) {
+		// Empty datagram, ignore
+	}
+
+	if (len < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK)
+			JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+
+		return -sockerrno;
+	}
+
+	addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+	return len; // len > 0
+}
+
+void conn_poll_process_tcp(juice_agent_t *agent, struct pollfd *pfd) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	if (pfd->revents & POLLNVAL) {
+		JLOG_WARN("Invalid socket");
+		return;
+	}
+
+	if (pfd->revents & POLLERR || (pfd->revents & POLLHUP && !(pfd->revents & POLLIN))) {
+		JLOG_DEBUG("TCP connection failed");
+		conn_poll_change_tcp_fail(agent);
+		return;
+	}
+
+	if (pfd->revents & POLLOUT) {
+		if (conn_impl->tcp_state == TCP_STATE_CONNECTING) {
+			int err = 0;
+			socklen_t errlen = sizeof(err);
+			if (getsockopt(conn_impl->tcp_sock, SOL_SOCKET, SO_ERROR, (char *)&err, &errlen) != 0) {
+				JLOG_DEBUG("Failed to get socket error code");
+				conn_poll_change_tcp_fail(agent);
+				return;
+			}
+
+			if (err != 0) {
+				JLOG_DEBUG("TCP connection failed, errno=%d", err);
+				conn_poll_change_tcp_fail(agent);
+				return;
+			}
+
+			conn_poll_change_tcp_state(agent, TCP_STATE_CONNECTED);
+		} else {
+			tcp_ice_write_context_t *context = &conn_impl->tcp_ice_write_context;
+			if(context->pending) {
+				int ret = tcp_ice_write(conn_impl->tcp_sock, NULL, 0, context);
+				if (ret >= 0) {
+					JLOG_DEBUG("Finished sending ICE-TCP datagram");
+				} else if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
+					JLOG_WARN("TCP send failed, errno=%d", -ret);
+					conn_poll_change_tcp_fail(agent);
+					return;
+				}
+			}
+		}
+	}
+
+	if (pfd->revents & POLLIN) {
+		int ret = 0;
+		int left = 1000; // limit for fairness between sockets
+		while (left--) {
+			tcp_ice_read_context_t *context = &conn_impl->tcp_ice_read_context;
+			if ((ret = tcp_ice_read(conn_impl->tcp_sock, context)) <= 0) {
+				break;
+			}
+
+			if (agent_conn_recv(agent, context->buffer, (size_t)ret, &conn_impl->tcp_dst) != 0) {
+				JLOG_WARN("Agent receive failed");
+				conn_impl->state = CONN_STATE_FINISHED;
+				break;
+			}
+		}
+
+		if (conn_impl->state == CONN_STATE_FINISHED)
+			return;
+
+		if (ret > 0) {
+			// There are more datagrams but we need to give other sockets a turn
+			JLOG_VERBOSE("Fairness limit reached, will continue on next poll");
+		} else if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more ICE-TCP datagrams to receive");
+		} else {
+			if (ret == 0) JLOG_DEBUG("TCP connection closed");
+			else JLOG_DEBUG("TCP connection failed");
+			conn_poll_change_tcp_fail(agent);
+			return;
+		}
+
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			conn_impl->state = CONN_STATE_FINISHED;
+			return;
+		}
+
+	} else if (conn_impl->next_timestamp <= current_timestamp()) {
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			conn_impl->state = CONN_STATE_FINISHED;
+			return;
+		}
+	}
+}
+
+void conn_poll_change_tcp_fail(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	if (conn_impl->tcp_sock != INVALID_SOCKET) {
+		closesocket(conn_impl->tcp_sock);
+		conn_impl->tcp_sock = INVALID_SOCKET;
+	}
+	memset(&conn_impl->tcp_ice_write_context, 0, sizeof(tcp_ice_write_context_t));
+	memset(&conn_impl->tcp_ice_read_context, 0, sizeof(tcp_ice_read_context_t));
+	conn_poll_change_tcp_state(agent, TCP_STATE_FAILED);
+}
+
+void conn_poll_change_tcp_state(juice_agent_t *agent, tcp_state_t state) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	if(conn_impl->tcp_state != state) {
+		switch(state) {
+			case TCP_STATE_DISCONNECTED:
+				JLOG_DEBUG("TCP state changed to disconnected");
+				break;
+			case TCP_STATE_CONNECTING:
+				JLOG_DEBUG("TCP state changed to connecting");
+				break;
+			case TCP_STATE_CONNECTED:
+				JLOG_DEBUG("TCP state changed to connected");
+				break;
+			case TCP_STATE_FAILED:
+				JLOG_DEBUG("TCP state changed to failed");
+				break;
+			default:
+				break;
+		}
+		conn_impl->tcp_state = state;
+		if (agent_conn_tcp_state(agent, &conn_impl->tcp_dst, state) != 0) {
+			if (conn_impl->tcp_sock != INVALID_SOCKET) {
+				closesocket(conn_impl->tcp_sock);
+				conn_impl->tcp_sock = INVALID_SOCKET;
+			}
+			conn_impl->tcp_state = TCP_STATE_DISCONNECTED;
+		}
+	}
+}
+
+int conn_poll_process(conn_registry_t *registry, pfds_record_t *pfds) {
+	struct pollfd *interrupt_pfd = pfds->pfds;
+	if (interrupt_pfd->revents & POLLIN) {
+#ifdef _WIN32
+		char dummy;
+		addr_record_t src;
+		while (udp_recvfrom(interrupt_pfd->fd, &dummy, 1, &src) >= 0) {
+			// Ignore
+		}
+#else
+		char dummy;
+		while (read(interrupt_pfd->fd, &dummy, 1) > 0) {
+			// Ignore
+		}
+#endif
+	}
+
+	mutex_lock(&registry->mutex);
+
+	nfds_t i = 1;
+	for (int j = 0; j < registry->agents_size; ++j) {
+		juice_agent_t *agent = registry->agents[j];
+		if (!agent)
+			continue;
+
+		conn_impl_t *conn_impl = agent->conn_impl;
+		if (!conn_impl || (conn_impl->state != CONN_STATE_NEW && conn_impl->state != CONN_STATE_READY))
+			continue;
+
+		if (i >= pfds->size)
+			break;
+
+		struct pollfd *udp_pfd = pfds->pfds + i;
+		if (udp_pfd->fd != conn_impl->udp_sock)
+			break;
+
+		conn_poll_process_udp(agent, udp_pfd);
+		i++;
+
+		if (conn_impl->tcp_sock == INVALID_SOCKET)
+			continue;
+
+		struct pollfd *tcp_pfd = pfds->pfds + i;
+		if (tcp_pfd->fd != conn_impl->tcp_sock)
+			break;
+
+		conn_poll_process_tcp(agent, tcp_pfd);
+		i++;
+	}
+
+	mutex_unlock(&registry->mutex);
+	return 0;
+}
+
+int conn_poll_run(conn_registry_t *registry) {
+	pfds_record_t pfds;
+	pfds.pfds = NULL;
+	pfds.size = 0;
+	timestamp_t next_timestamp = 0;
+	int count;
+	while ((count = conn_poll_prepare(registry, &pfds, &next_timestamp)) > 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		JLOG_VERBOSE("Entering poll on %d sockets for %d ms", count, (int)timediff);
+		int ret = poll(pfds.pfds, pfds.size, (int)timediff);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+#ifdef _WIN32
+			if (sockerrno == WSAENOTSOCK)
+				continue; // prepare again as the fd has been removed
+#endif
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (conn_poll_process(registry, &pfds) < 0)
+			break;
+	}
+
+	JLOG_DEBUG("Leaving connections thread");
+	free(pfds.pfds);
+	return 0;
+}
+
+int conn_poll_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config) {
+	conn_impl_t *conn_impl = calloc(1, sizeof(conn_impl_t));
+	if (!conn_impl) {
+		JLOG_FATAL("Memory allocation failed for connection impl");
+		return -1;
+	}
+
+	conn_impl->udp_sock = udp_create_socket(config);
+	if (conn_impl->udp_sock == INVALID_SOCKET) {
+		JLOG_ERROR("UDP socket creation failed");
+		free(conn_impl);
+		return -1;
+	}
+
+	mutex_init(&conn_impl->send_mutex, 0);
+	conn_impl->registry = registry;
+	conn_impl->tcp_sock = INVALID_SOCKET;
+	conn_impl->tcp_state = TCP_STATE_DISCONNECTED;
+	memset(&conn_impl->tcp_ice_write_context, 0, sizeof(tcp_ice_write_context_t));
+	memset(&conn_impl->tcp_ice_read_context, 0, sizeof(tcp_ice_read_context_t));
+
+	agent->conn_impl = conn_impl;
+	return 0;
+}
+
+void conn_poll_cleanup(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	conn_poll_interrupt(agent);
+
+	mutex_destroy(&conn_impl->send_mutex);
+	closesocket(conn_impl->udp_sock);
+	closesocket(conn_impl->tcp_sock);
+	free(agent->conn_impl);
+	agent->conn_impl = NULL;
+}
+
+void conn_poll_lock(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+	mutex_lock(&registry->mutex);
+}
+
+void conn_poll_unlock(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+	mutex_unlock(&registry->mutex);
+}
+
+int conn_poll_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+	registry_impl_t *registry_impl = registry->impl;
+
+	mutex_lock(&registry->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+	mutex_unlock(&registry->mutex);
+
+	JLOG_VERBOSE("Interrupting connections thread");
+
+	char dummy = 0;
+#ifdef _WIN32
+	if (udp_sendto_self(registry_impl->interrupt_sock, &dummy, 0) < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
+		}
+		return -1;
+	}
+#else
+	if (write(registry_impl->interrupt_pipe_out, &dummy, 1) < 0 && errno != EAGAIN &&
+	    errno != EWOULDBLOCK) {
+		JLOG_WARN("Failed to interrupt poll by writing to pipe, errno=%d", errno);
+	}
+#endif
+	return 0;
+}
+
+int conn_poll_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                   int ds) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->send_mutex);
+
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret;
+	if (dst->socktype == SOCK_STREAM) {
+		tcp_ice_write_context_t *context = &conn_impl->tcp_ice_write_context;
+		if (!context->pending) {
+			ret = tcp_ice_write(conn_impl->tcp_sock, data, size, context);
+			if (context->pending && (ret == SEAGAIN || ret == SEWOULDBLOCK))
+				ret = (int)size; // datagram is buffered, consider it sent
+		} else {
+			// another datagram is buffered, drop
+			ret = -SEAGAIN;
+		}
+	} else {
+		if (conn_impl->send_ds >= 0 && conn_impl->send_ds != ds) {
+			JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+			if (udp_set_diffserv(conn_impl->udp_sock, ds) == 0)
+				conn_impl->send_ds = ds;
+			else
+				conn_impl->send_ds = -1; // disable for next time
+		}
+
+		ret = udp_sendto(conn_impl->udp_sock, data, size, dst);
+		if (ret < 0)
+			ret = -sockerrno;
+	}
+
+	if (ret < 0) {
+		if (ret == -SEAGAIN || ret == -SEWOULDBLOCK)
+			JLOG_INFO("Send failed, buffer is full");
+		else if (ret == -SEMSGSIZE)
+			JLOG_WARN("Send failed, datagram is too large");
+		else
+			JLOG_WARN("Send failed, errno=%d", -ret);
+	}
+
+	mutex_unlock(&conn_impl->send_mutex);
+	return ret;
+}
+
+void conn_poll_tcp_connect(juice_agent_t *agent, const addr_record_t *dst) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->registry->mutex);
+	mutex_lock(&conn_impl->send_mutex);
+	if (conn_impl->tcp_sock == INVALID_SOCKET) {
+		if (JLOG_DEBUG_ENABLED) {
+			char dst_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(dst, dst_str, ADDR_MAX_STRING_LEN);
+			JLOG_DEBUG("Attempting ICE-TCP connection to %s", dst_str);
+		}
+		conn_impl->tcp_sock = tcp_create_socket(dst);
+		memcpy(&conn_impl->tcp_dst, dst, sizeof(conn_impl->tcp_dst));
+		conn_poll_change_tcp_state(agent, TCP_STATE_CONNECTING);
+	}
+	mutex_unlock(&conn_impl->send_mutex);
+	mutex_unlock(&conn_impl->registry->mutex);
+}
+
+int conn_poll_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	return udp_get_addrs(conn_impl->udp_sock, records, size);
+}

--- a/Source/3rdParty/libjuice/src/conn_poll.h
+++ b/Source/3rdParty/libjuice/src/conn_poll.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_CONN_POLL_H
+#define JUICE_CONN_POLL_H
+
+#include "addr.h"
+#include "conn.h"
+#include "thread.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int conn_poll_registry_init(conn_registry_t *registry, udp_socket_config_t *config);
+void conn_poll_registry_cleanup(conn_registry_t *registry);
+
+int conn_poll_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config);
+void conn_poll_cleanup(juice_agent_t *agent);
+void conn_poll_lock(juice_agent_t *agent);
+void conn_poll_unlock(juice_agent_t *agent);
+int conn_poll_interrupt(juice_agent_t *agent);
+int conn_poll_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                        int ds);
+void conn_poll_tcp_connect(juice_agent_t *agent, const addr_record_t *dst);
+int conn_poll_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/Source/3rdParty/libjuice/src/conn_thread.c
+++ b/Source/3rdParty/libjuice/src/conn_thread.c
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "conn_thread.h"
+#include "agent.h"
+#include "log.h"
+#include "socket.h"
+#include "thread.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define BUFFER_SIZE 4096
+
+typedef struct conn_impl {
+	thread_t thread;
+	socket_t sock;
+	mutex_t mutex;
+	mutex_t send_mutex;
+	int send_ds;
+	timestamp_t next_timestamp;
+	bool stopped;
+} conn_impl_t;
+
+int conn_thread_run(juice_agent_t *agent);
+int conn_thread_prepare(juice_agent_t *agent, struct pollfd *pfd, timestamp_t *next_timestamp);
+int conn_thread_process(juice_agent_t *agent, struct pollfd *pfd);
+int conn_thread_recv(socket_t sock, char *buffer, size_t size, addr_record_t *src);
+
+static thread_return_t THREAD_CALL conn_thread_entry(void *arg) {
+	thread_set_name_self("juice agent");
+	juice_agent_t *agent = (juice_agent_t *)arg;
+	conn_thread_run(agent);
+	return (thread_return_t)0;
+}
+
+int conn_thread_prepare(juice_agent_t *agent, struct pollfd *pfd, timestamp_t *next_timestamp) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	mutex_lock(&conn_impl->mutex);
+	if (conn_impl->stopped) {
+		mutex_unlock(&conn_impl->mutex);
+		return 0;
+	}
+
+	pfd->fd = conn_impl->sock;
+	pfd->events = POLLIN;
+
+	*next_timestamp = conn_impl->next_timestamp;
+
+	mutex_unlock(&conn_impl->mutex);
+	return 1;
+}
+
+int conn_thread_process(juice_agent_t *agent, struct pollfd *pfd) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	mutex_lock(&conn_impl->mutex);
+	if (conn_impl->stopped) {
+		mutex_unlock(&conn_impl->mutex);
+		return -1;
+	}
+
+	if (pfd->revents & POLLNVAL || pfd->revents & POLLERR) {
+		JLOG_ERROR("Error when polling socket");
+		agent_conn_fail(agent);
+		mutex_unlock(&conn_impl->mutex);
+		return -1;
+	}
+
+	if (pfd->revents & POLLIN) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t src;
+		int ret;
+		while ((ret = conn_thread_recv(conn_impl->sock, buffer, BUFFER_SIZE, &src)) > 0) {
+			if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
+				JLOG_WARN("Agent receive failed");
+				mutex_unlock(&conn_impl->mutex);
+				return -1;
+			}
+		}
+
+		if (ret < 0) {
+			agent_conn_fail(agent);
+			mutex_unlock(&conn_impl->mutex);
+			return -1;
+		}
+
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			mutex_unlock(&conn_impl->mutex);
+			return -1;
+		}
+
+	} else if (conn_impl->next_timestamp <= current_timestamp()) {
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			mutex_unlock(&conn_impl->mutex);
+			return -1;
+		}
+	}
+
+	mutex_unlock(&conn_impl->mutex);
+	return 0;
+}
+
+int conn_thread_recv(socket_t sock, char *buffer, size_t size, addr_record_t *src) {
+	JLOG_VERBOSE("Receiving datagram");
+	int len;
+	while ((len = udp_recvfrom(sock, buffer, size, src)) == 0) {
+		// Empty datagram (used to interrupt)
+	}
+
+	if (len < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
+			return 0;
+		}
+		JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+	return len; // len > 0
+}
+
+int conn_thread_run(juice_agent_t *agent) {
+	struct pollfd pfd[1];
+	timestamp_t next_timestamp;
+	while (conn_thread_prepare(agent, pfd, &next_timestamp) > 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		JLOG_VERBOSE("Entering poll for %d ms", (int)timediff);
+		int ret = poll(pfd, 1, (int)timediff);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (conn_thread_process(agent, pfd) < 0)
+			break;
+	}
+
+	JLOG_DEBUG("Leaving connection thread");
+	return 0;
+}
+
+int conn_thread_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)registry;
+
+	conn_impl_t *conn_impl = calloc(1, sizeof(conn_impl_t));
+	if (!conn_impl) {
+		JLOG_FATAL("Memory allocation failed for connection impl");
+		return -1;
+	}
+
+	conn_impl->sock = udp_create_socket(config);
+	if (conn_impl->sock == INVALID_SOCKET) {
+		JLOG_ERROR("UDP socket creation failed");
+		free(conn_impl);
+		return -1;
+	}
+
+	mutex_init(&conn_impl->mutex, MUTEX_RECURSIVE); // Recursive to allow calls from user callbacks
+	mutex_init(&conn_impl->send_mutex, 0);
+
+	agent->conn_impl = conn_impl;
+
+	JLOG_DEBUG("Starting connection thread");
+	int ret = thread_init(&conn_impl->thread, conn_thread_entry, agent);
+	if (ret) {
+		JLOG_FATAL("Thread creation failed, error=%d", ret);
+		free(conn_impl);
+		agent->conn_impl = NULL;
+		return -1;
+	}
+
+	return 0;
+}
+
+void conn_thread_cleanup(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->mutex);
+	conn_impl->stopped = true;
+	mutex_unlock(&conn_impl->mutex);
+
+	conn_thread_interrupt(agent);
+
+	JLOG_VERBOSE("Waiting for connection thread");
+	thread_join(conn_impl->thread, NULL);
+
+	closesocket(conn_impl->sock);
+	mutex_destroy(&conn_impl->mutex);
+	mutex_destroy(&conn_impl->send_mutex);
+	free(agent->conn_impl);
+	agent->conn_impl = NULL;
+}
+
+void conn_thread_lock(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	mutex_lock(&conn_impl->mutex);
+}
+
+void conn_thread_unlock(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	mutex_unlock(&conn_impl->mutex);
+}
+
+int conn_thread_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+	mutex_unlock(&conn_impl->mutex);
+
+	JLOG_VERBOSE("Interrupting connection thread");
+
+	mutex_lock(&conn_impl->send_mutex);
+	char dummy = 0; // Some C libraries might error out on NULL pointers
+	if (udp_sendto_self(conn_impl->sock, &dummy, 0) < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
+		}
+		mutex_unlock(&conn_impl->send_mutex);
+		return -1;
+	}
+
+	mutex_unlock(&conn_impl->send_mutex);
+	return 0;
+}
+
+int conn_thread_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                     int ds) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->send_mutex);
+
+	if (conn_impl->send_ds >= 0 && conn_impl->send_ds != ds) {
+		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+		if (udp_set_diffserv(conn_impl->sock, ds) == 0)
+			conn_impl->send_ds = ds;
+		else
+			conn_impl->send_ds = -1; // disable for next time
+	}
+
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret = udp_sendto(conn_impl->sock, data, size, dst);
+	if (ret < 0) {
+		ret = -sockerrno;
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
+			JLOG_INFO("Send failed, buffer is full");
+		else if (sockerrno == SEMSGSIZE)
+			JLOG_WARN("Send failed, datagram is too large");
+		else
+			JLOG_WARN("Send failed, errno=%d", sockerrno);
+	}
+
+	mutex_unlock(&conn_impl->send_mutex);
+	return ret;
+}
+
+int conn_thread_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	return udp_get_addrs(conn_impl->sock, records, size);
+}

--- a/Source/3rdParty/libjuice/src/conn_thread.h
+++ b/Source/3rdParty/libjuice/src/conn_thread.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_CONN_THREAD_H
+#define JUICE_CONN_THREAD_H
+
+#include "addr.h"
+#include "conn.h"
+#include "thread.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int conn_thread_registry_init(conn_registry_t *registry, udp_socket_config_t *config);
+void conn_thread_registry_cleanup(conn_registry_t *registry);
+
+int conn_thread_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config);
+void conn_thread_cleanup(juice_agent_t *agent);
+void conn_thread_lock(juice_agent_t *agent);
+void conn_thread_unlock(juice_agent_t *agent);
+int conn_thread_interrupt(juice_agent_t *agent);
+int conn_thread_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                     int ds);
+int conn_thread_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/Source/3rdParty/libjuice/src/const_time.c
+++ b/Source/3rdParty/libjuice/src/const_time.c
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "const_time.h"
+
+int const_time_memcmp(const void *a, const void *b, size_t len) {
+	const unsigned char *ca = a;
+	const unsigned char *cb = b;
+	unsigned char x = 0;
+	for (size_t i = 0; i < len; i++)
+		x |= ca[i] ^ cb[i];
+
+	return x;
+}
+
+int const_time_strcmp(const void *a, const void *b) {
+	const unsigned char *ca = a;
+	const unsigned char *cb = b;
+	unsigned char x = 0;
+	size_t i = 0;
+	for(;;) {
+		x |= ca[i] ^ cb[i];
+		if (!ca[i] || !cb[i])
+			break;
+		++i;
+	}
+
+	return x;
+}

--- a/Source/3rdParty/libjuice/src/const_time.h
+++ b/Source/3rdParty/libjuice/src/const_time.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_CONST_TIME_H
+#define JUICE_CONST_TIME_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+int const_time_memcmp(const void *a, const void *b, size_t len);
+int const_time_strcmp(const void *a, const void *b);
+
+#endif

--- a/Source/3rdParty/libjuice/src/crc32.c
+++ b/Source/3rdParty/libjuice/src/crc32.c
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "crc32.h"
+
+#define CRC32_REVERSED_POLY 0xEDB88320
+#define CRC32_INIT 0xFFFFFFFF
+#define CRC32_XOR 0xFFFFFFFF
+
+static uint32_t crc32_byte(uint32_t crc) {
+	for (int i = 0; i < 8; ++i)
+		if (crc & 1)
+			crc = (crc >> 1) ^ CRC32_REVERSED_POLY;
+		else
+			crc = (crc >> 1);
+	return crc;
+}
+
+static uint32_t crc32_table(const uint8_t *p, size_t size, uint32_t *table) {
+	uint32_t crc = CRC32_INIT;
+	while (size--)
+		crc = table[(uint8_t)(crc & 0xFF) ^ *p++] ^ (crc >> 8);
+	return crc ^ CRC32_XOR;
+}
+
+JUICE_EXPORT uint32_t juice_crc32(const void *data, size_t size) {
+	static uint32_t table[256] = {0};
+	if (table[255] == 0)
+		for (uint32_t i = 0; i < 256; ++i)
+			table[i] = crc32_byte(i);
+
+	return crc32_table(data, size, table);
+}

--- a/Source/3rdParty/libjuice/src/crc32.h
+++ b/Source/3rdParty/libjuice/src/crc32.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_CRC32_H
+#define JUICE_CRC32_H
+
+#include "juice.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+JUICE_EXPORT uint32_t juice_crc32(const void *data, size_t size);
+
+#define CRC32(data, size) juice_crc32(data, size)
+
+#endif // JUICE_CRC32_H

--- a/Source/3rdParty/libjuice/src/hash.c
+++ b/Source/3rdParty/libjuice/src/hash.c
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "hash.h"
+
+#if USE_NETTLE
+#include <nettle/md5.h>
+#include <nettle/sha1.h>
+#include <nettle/sha2.h>
+#include <nettle/version.h>
+#else
+#include "picohash.h"
+#endif
+
+void juice_hash_md5(const void *message, size_t size, void *digest) {
+#if USE_NETTLE
+	struct md5_ctx ctx;
+	md5_init(&ctx);
+	md5_update(&ctx, size, message);
+#if NETTLE_VERSION_MAJOR >= 4
+	md5_digest(&ctx, digest);
+#else
+	md5_digest(&ctx, HASH_MD5_SIZE, digest);
+#endif
+#else
+	picohash_ctx_t ctx;
+	picohash_init_md5(&ctx);
+	picohash_update(&ctx, message, size);
+	picohash_final(&ctx, digest);
+#endif
+}
+
+void juice_hash_sha1(const void *message, size_t size, void *digest) {
+#if USE_NETTLE
+	struct sha1_ctx ctx;
+	sha1_init(&ctx);
+	sha1_update(&ctx, size, message);
+#if NETTLE_VERSION_MAJOR >= 4
+	sha1_digest(&ctx, digest);
+#else
+	sha1_digest(&ctx, HASH_SHA1_SIZE, digest);
+#endif
+#else
+	picohash_ctx_t ctx;
+	picohash_init_sha1(&ctx);
+	picohash_update(&ctx, message, size);
+	picohash_final(&ctx, digest);
+#endif
+}
+
+void juice_hash_sha256(const void *message, size_t size, void *digest) {
+#if USE_NETTLE
+	struct sha256_ctx ctx;
+	sha256_init(&ctx);
+	sha256_update(&ctx, size, message);
+#if NETTLE_VERSION_MAJOR >= 4
+	sha256_digest(&ctx, digest);
+#else
+	sha256_digest(&ctx, HASH_SHA256_SIZE, digest);
+#endif
+#else
+	picohash_ctx_t ctx;
+	picohash_init_sha256(&ctx);
+	picohash_update(&ctx, message, size);
+	picohash_final(&ctx, digest);
+#endif
+}

--- a/Source/3rdParty/libjuice/src/hash.h
+++ b/Source/3rdParty/libjuice/src/hash.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_HASH_H
+#define JUICE_HASH_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define HASH_MD5_SIZE 16
+#define HASH_SHA1_SIZE 24
+#define HASH_SHA256_SIZE 32
+
+void juice_hash_md5(const void *message, size_t size, void *digest);
+void juice_hash_sha1(const void *message, size_t size, void *digest);
+void juice_hash_sha256(const void *message, size_t size, void *digest);
+
+#endif

--- a/Source/3rdParty/libjuice/src/hmac.c
+++ b/Source/3rdParty/libjuice/src/hmac.c
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "hmac.h"
+
+#if USE_NETTLE
+#include <nettle/hmac.h>
+#include <nettle/version.h>
+#else
+#include "picohash.h"
+#endif
+
+void hmac_sha1(const void *message, size_t size, const void *key, size_t key_size, void *digest) {
+#if USE_NETTLE
+	struct hmac_sha1_ctx ctx;
+	hmac_sha1_set_key(&ctx, key_size, key);
+	hmac_sha1_update(&ctx, size, message);
+#if NETTLE_VERSION_MAJOR >= 4
+	hmac_sha1_digest(&ctx, digest);
+#else
+	hmac_sha1_digest(&ctx, HMAC_SHA1_SIZE, digest);
+#endif
+#else
+	picohash_ctx_t ctx;
+	picohash_init_hmac(&ctx, picohash_init_sha1, key, key_size);
+	picohash_update(&ctx, message, size);
+	picohash_final(&ctx, digest);
+#endif
+}
+
+void hmac_sha256(const void *message, size_t size, const void *key, size_t key_size, void *digest) {
+#if USE_NETTLE
+	struct hmac_sha256_ctx ctx;
+	hmac_sha256_set_key(&ctx, key_size, key);
+	hmac_sha256_update(&ctx, size, message);
+#if NETTLE_VERSION_MAJOR >= 4
+	hmac_sha256_digest(&ctx, digest);
+#else
+	hmac_sha256_digest(&ctx, HMAC_SHA256_SIZE, digest);
+#endif
+#else
+	picohash_ctx_t ctx;
+	picohash_init_hmac(&ctx, picohash_init_sha256, key, key_size);
+	picohash_update(&ctx, message, size);
+	picohash_final(&ctx, digest);
+#endif
+}

--- a/Source/3rdParty/libjuice/src/hmac.h
+++ b/Source/3rdParty/libjuice/src/hmac.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_HMAC_H
+#define JUICE_HMAC_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define HMAC_SHA1_SIZE 20
+#define HMAC_SHA256_SIZE 32
+
+void hmac_sha1(const void *message, size_t size, const void *key, size_t key_size, void *digest);
+void hmac_sha256(const void *message, size_t size, const void *key, size_t key_size, void *digest);
+
+#endif

--- a/Source/3rdParty/libjuice/src/ice.c
+++ b/Source/3rdParty/libjuice/src/ice.c
@@ -1,0 +1,506 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "ice.h"
+#include "log.h"
+#include "random.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BUFFER_SIZE 1024
+
+#define CLAMP(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
+
+// See RFC4566 for SDP format: https://www.rfc-editor.org/rfc/rfc4566.html
+
+static const char *skip_prefix(const char *str, const char *prefix) {
+	size_t len = strlen(prefix);
+	return strncmp(str, prefix, len) == 0 ? str + len : str;
+}
+
+static bool match_prefix(const char *str, const char *prefix, const char **end) {
+	*end = skip_prefix(str, prefix);
+	return *end != str || !*prefix;
+}
+
+static int parse_sdp_line(const char *line, ice_description_t *description) {
+	const char *arg;
+	if (match_prefix(line, "a=ice-ufrag:", &arg)) {
+		sscanf(arg, "%256s", description->ice_ufrag);
+		return 0;
+	}
+	if (match_prefix(line, "a=ice-pwd:", &arg)) {
+		sscanf(arg, "%256s", description->ice_pwd);
+		return 0;
+	}
+	if (match_prefix(line, "a=ice-lite", &arg)) {
+		description->ice_lite = true;
+		return 0;
+	}
+	if (match_prefix(line, "a=end-of-candidates", &arg)) {
+		description->finished = true;
+		return 0;
+	}
+	ice_candidate_t candidate;
+	if (ice_parse_candidate_sdp(line, &candidate) == 0) {
+		ice_add_candidate(&candidate, description);
+		return 0;
+	}
+	return ICE_PARSE_IGNORED;
+}
+
+static int parse_sdp_candidate(const char *line, ice_candidate_t *candidate) {
+	memset(candidate, 0, sizeof(*candidate));
+
+	line = skip_prefix(line, "a=");
+	line = skip_prefix(line, "candidate:");
+
+	char type[32 + 1];
+	char transport[32 + 1];
+	char tcp_type_ext[7 + 1] = {0};
+	char tcp_type[7 + 1] = {0};
+
+	int res = sscanf(line, "%32s %d %32s %u %256s %32s typ %32s %7s %7s", candidate->foundation,
+	           &candidate->component, transport, &candidate->priority,
+	           candidate->hostname, candidate->service, type, tcp_type_ext, tcp_type);
+	if (res != 7 && res != 9) {
+		JLOG_WARN("Failed to parse candidate: %s", line);
+		return ICE_PARSE_ERROR;
+	}
+
+	for (int i = 0; transport[i]; ++i)
+		transport[i] = toupper((unsigned char)transport[i]);
+
+	for (int i = 0; type[i]; ++i)
+		type[i] = tolower((unsigned char)type[i]);
+
+	if (strcmp(type, "host") == 0)
+		candidate->type = ICE_CANDIDATE_TYPE_HOST;
+	else if (strcmp(type, "srflx") == 0)
+		candidate->type = ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE;
+	else if (strcmp(type, "relay") == 0)
+		candidate->type = ICE_CANDIDATE_TYPE_RELAYED;
+	else {
+		JLOG_WARN("Ignoring candidate with unknown type \"%s\"", type);
+		return ICE_PARSE_IGNORED;
+	}
+	if (strcmp(transport, "TCP") == 0) {
+		if (strcmp(tcp_type, "active") == 0) {
+			candidate->transport = ICE_CANDIDATE_TRANSPORT_TCP_TYPE_ACTIVE;
+		} else if (strcmp(tcp_type, "passive") == 0) {
+			candidate->transport = ICE_CANDIDATE_TRANSPORT_TCP_TYPE_PASSIVE;
+		} else if (strcmp(tcp_type, "so") == 0) {
+			candidate->transport = ICE_CANDIDATE_TRANSPORT_TCP_TYPE_SO;
+		} else {
+			JLOG_WARN("Ignoring candidate with unknown tcptype \"%s\"", tcp_type);
+			return ICE_PARSE_IGNORED;
+		}
+	} else if (strcmp(transport, "UDP") == 0)  {
+		candidate->transport = ICE_CANDIDATE_TRANSPORT_UDP;
+	} else {
+		JLOG_WARN("Ignoring candidate with transport %s", transport);
+		return ICE_PARSE_IGNORED;
+	}
+
+	return 0;
+}
+
+int ice_parse_sdp(const char *sdp, ice_description_t *description) {
+	memset(description, 0, sizeof(*description));
+	description->ice_lite = false;
+	description->candidates_count = 0;
+	description->finished = false;
+
+	char buffer[BUFFER_SIZE];
+	size_t size = 0;
+	while (*sdp) {
+		if (*sdp == '\n') {
+			if (size) {
+				buffer[size++] = '\0';
+				if (parse_sdp_line(buffer, description) == ICE_PARSE_ERROR)
+					return ICE_PARSE_ERROR;
+
+				size = 0;
+			}
+		} else if (*sdp != '\r' && size + 1 < BUFFER_SIZE) {
+			buffer[size++] = *sdp;
+		}
+		++sdp;
+	}
+	ice_sort_candidates(description);
+
+	JLOG_DEBUG("Parsed remote description: ufrag=\"%s\", pwd=\"%s\", candidates=%d",
+	           description->ice_ufrag, description->ice_pwd, description->candidates_count);
+
+	if (*description->ice_ufrag == '\0')
+		return ICE_PARSE_MISSING_UFRAG;
+
+	if (*description->ice_pwd == '\0')
+		return ICE_PARSE_MISSING_PWD;
+
+	return 0;
+}
+
+int ice_parse_candidate_sdp(const char *line, ice_candidate_t *candidate) {
+	const char *arg;
+	if (match_prefix(line, "a=candidate:", &arg)) {
+		int ret = parse_sdp_candidate(line, candidate);
+		if (ret < 0)
+			return ret;
+		ice_resolve_candidate(candidate, ICE_RESOLVE_MODE_SIMPLE);
+		return 0;
+	}
+	return ICE_PARSE_ERROR;
+}
+
+int ice_create_local_description(ice_description_t *description) {
+	memset(description, 0, sizeof(*description));
+	juice_random_str64(description->ice_ufrag, 4 + 1);
+	juice_random_str64(description->ice_pwd, 22 + 1);
+	description->ice_lite = false;
+	description->candidates_count = 0;
+	description->finished = false;
+	JLOG_DEBUG("Created local description: ufrag=\"%s\", pwd=\"%s\"", description->ice_ufrag,
+	           description->ice_pwd);
+	return 0;
+}
+
+int ice_create_local_candidate(ice_candidate_type_t type, int component, int index,
+                               const addr_record_t *record, ice_candidate_t *candidate, ice_candidate_transport_t transport) {
+	memset(candidate, 0, sizeof(*candidate));
+	candidate->type = type;
+	candidate->component = component;
+	candidate->resolved = *record;
+	candidate->transport = transport;
+	strcpy(candidate->foundation, "-");
+
+	int socktype = transport == ICE_CANDIDATE_TRANSPORT_UDP ? SOCK_DGRAM : SOCK_STREAM;
+	if (record->socktype && record->socktype != socktype) {
+		JLOG_WARN("Incorrect socket type for candidate transport");
+	}
+	candidate->resolved.socktype = socktype;
+
+	candidate->priority = ice_compute_priority(candidate->type, candidate->resolved.addr.ss_family,
+	                                           candidate->component, index, candidate->transport);
+
+	if (getnameinfo((struct sockaddr *)&record->addr, record->len, candidate->hostname, 256,
+	                candidate->service, 32, NI_NUMERICHOST | NI_NUMERICSERV | NI_DGRAM)) {
+		JLOG_ERROR("getnameinfo failed, errno=%d", sockerrno);
+		return -1;
+	}
+	return 0;
+}
+
+int ice_resolve_candidate(ice_candidate_t *candidate, ice_resolve_mode_t mode) {
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	if (candidate->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_protocol = IPPROTO_TCP;
+	} else {
+		hints.ai_socktype = SOCK_DGRAM;
+		hints.ai_protocol = IPPROTO_UDP;
+	}
+#ifdef AI_ADDRCONFIG
+	hints.ai_flags = AI_ADDRCONFIG;
+#endif
+	if (mode != ICE_RESOLVE_MODE_LOOKUP)
+		hints.ai_flags |= AI_NUMERICHOST | AI_NUMERICSERV;
+	struct addrinfo *ai_list = NULL;
+	if (getaddrinfo(candidate->hostname, candidate->service, &hints, &ai_list)) {
+		JLOG_INFO("Failed to resolve address: %s:%s", candidate->hostname, candidate->service);
+		candidate->resolved.len = 0;
+		return -1;
+	}
+	for (struct addrinfo *ai = ai_list; ai; ai = ai->ai_next) {
+		if (ai->ai_family == AF_INET || ai->ai_family == AF_INET6) {
+			candidate->resolved.len = (socklen_t)ai->ai_addrlen;
+			memcpy(&candidate->resolved.addr, ai->ai_addr, ai->ai_addrlen);
+			candidate->resolved.socktype = ai->ai_socktype;
+			break;
+		}
+	}
+	freeaddrinfo(ai_list);
+	return 0;
+}
+
+int ice_add_candidate(ice_candidate_t *candidate, ice_description_t *description) {
+	if (candidate->type == ICE_CANDIDATE_TYPE_UNKNOWN)
+		return -1;
+
+	if (description->candidates_count >= ICE_MAX_CANDIDATES_COUNT) {
+		JLOG_WARN("Description already has the maximum number of candidates");
+		return -1;
+	}
+
+	if (strcmp(candidate->foundation, "-") == 0)
+		snprintf(candidate->foundation, 32, "%u",
+		         (unsigned int)(description->candidates_count + 1));
+
+	ice_candidate_t *pos = description->candidates + description->candidates_count;
+	*pos = *candidate;
+	++description->candidates_count;
+	return 0;
+}
+
+void ice_sort_candidates(ice_description_t *description) {
+	// In-place insertion sort
+	ice_candidate_t *begin = description->candidates;
+	ice_candidate_t *end = begin + description->candidates_count;
+	ice_candidate_t *cur = begin;
+	while (++cur < end) {
+		uint32_t priority = cur->priority;
+		ice_candidate_t *prev = cur;
+		ice_candidate_t tmp = *prev;
+		while (--prev >= begin && prev->priority < priority) {
+			*(prev + 1) = *prev;
+		}
+		if (prev + 1 != cur)
+			*(prev + 1) = tmp;
+	}
+}
+
+ice_candidate_t *ice_find_candidate_from_addr(ice_description_t *description,
+                                              const addr_record_t *record,
+                                              ice_candidate_type_t type) {
+	ice_candidate_t *cur = description->candidates;
+	ice_candidate_t *end = cur + description->candidates_count;
+	while (cur != end) {
+		if ((type == ICE_CANDIDATE_TYPE_UNKNOWN || cur->type == type) &&
+		    addr_is_equal((struct sockaddr *)&record->addr, (struct sockaddr *)&cur->resolved.addr,
+		                  true))
+			return cur;
+		++cur;
+	}
+	return NULL;
+}
+
+int ice_generate_sdp(const ice_description_t *description, char *buffer, size_t size) {
+	if (!*description->ice_ufrag || !*description->ice_pwd)
+		return -1;
+
+	int len = 0;
+	char *begin = buffer;
+	char *end = begin + size;
+
+	// Round 0: description
+	// Round i with i>0 and i<count+1: candidate i-1
+	// Round count + 1: end-of-candidates and ice-options lines
+	for (int i = 0; i < description->candidates_count + 2; ++i) {
+		int ret;
+		if (i == 0) {
+			ret = snprintf(begin, end - begin, "a=ice-ufrag:%s\r\na=ice-pwd:%s\r\n",
+			               description->ice_ufrag, description->ice_pwd);
+			if (description->ice_lite)
+				ret = snprintf(begin, end - begin, "a=ice-lite\r\n");
+
+		} else if (i < description->candidates_count + 1) {
+			const ice_candidate_t *candidate = description->candidates + i - 1;
+			if (candidate->type == ICE_CANDIDATE_TYPE_UNKNOWN ||
+			    candidate->type == ICE_CANDIDATE_TYPE_PEER_REFLEXIVE)
+				continue;
+			char tmp[BUFFER_SIZE];
+			if (ice_generate_candidate_sdp(candidate, tmp, BUFFER_SIZE) < 0)
+				continue;
+			ret = snprintf(begin, end - begin, "%s\r\n", tmp);
+		} else { // i == description->candidates_count + 1
+			// RFC 8445 10. ICE Option: An agent compliant to this specification MUST inform the
+			// peer about the compliance using the 'ice2' option.
+			if (description->finished)
+				ret = snprintf(begin, end - begin, "a=end-of-candidates\r\na=ice-options:ice2\r\n");
+			else
+				ret = snprintf(begin, end - begin, "a=ice-options:ice2,trickle\r\n");
+		}
+		if (ret < 0)
+			return -1;
+
+		len += ret;
+
+		if (begin < end)
+			begin += ret >= end - begin ? end - begin - 1 : ret;
+	}
+	return len;
+}
+
+int ice_generate_candidate_sdp(const ice_candidate_t *candidate, char *buffer, size_t size) {
+	const char *type = NULL;
+	const char *suffix = NULL;
+	const char *transport = NULL;
+
+	switch (candidate->type) {
+	case ICE_CANDIDATE_TYPE_HOST:
+		type = "host";
+		break;
+	case ICE_CANDIDATE_TYPE_PEER_REFLEXIVE:
+		type = "prflx";
+		break;
+	case ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE:
+		type = "srflx";
+		suffix = "raddr 0.0.0.0 rport 0"; // This is needed for compatibility with Firefox
+		break;
+	case ICE_CANDIDATE_TYPE_RELAYED:
+		type = "relay";
+		suffix = "raddr 0.0.0.0 rport 0"; // This is needed for compatibility with Firefox
+		break;
+	default:
+		JLOG_ERROR("Unknown candidate type");
+		return -1;
+	}
+
+	switch (candidate->transport) {
+		case  ICE_CANDIDATE_TRANSPORT_UDP:
+			transport = "UDP";
+			break;
+		case  ICE_CANDIDATE_TRANSPORT_TCP_TYPE_ACTIVE:
+			transport = "TCP";
+			suffix = "tcptype active";
+			break;
+		default:
+			JLOG_ERROR("Unknown candidate transport");
+			return -1;
+	}
+
+	return snprintf(buffer, size, "a=candidate:%s %u %s %u %s %s typ %s%s%s",
+	                candidate->foundation, candidate->component, transport, candidate->priority,
+	                candidate->hostname, candidate->service, type, suffix ? " " : "",
+	                suffix ? suffix : "");
+}
+
+int ice_create_candidate_pair(ice_candidate_t *local, ice_candidate_t *remote, bool is_controlling,
+                              ice_candidate_pair_t *pair) { // local or remote might be NULL
+	if (local && remote && local->resolved.addr.ss_family != remote->resolved.addr.ss_family) {
+		JLOG_ERROR("Mismatching candidates address families");
+		return -1;
+	}
+
+	memset(pair, 0, sizeof(*pair));
+	pair->local = local;
+	pair->remote = remote;
+	pair->state = ICE_CANDIDATE_PAIR_STATE_FROZEN;
+	return ice_update_candidate_pair(pair, is_controlling);
+}
+
+int ice_update_candidate_pair(ice_candidate_pair_t *pair, bool is_controlling) {
+	// Compute pair priority according to RFC 8445, extended to support generic pairs missing local
+	// or remote See https://www.rfc-editor.org/rfc/rfc8445.html#section-6.1.2.3
+	if (!pair->local && !pair->remote)
+		return 0;
+	uint64_t local_priority =
+	    pair->local
+	        ? pair->local->priority
+	        : ice_compute_priority(ICE_CANDIDATE_TYPE_HOST, pair->remote->resolved.addr.ss_family,
+	                               pair->remote->component, 0, pair->remote->transport);
+	uint64_t remote_priority =
+	    pair->remote
+	        ? pair->remote->priority
+	        : ice_compute_priority(ICE_CANDIDATE_TYPE_HOST, pair->local->resolved.addr.ss_family,
+	                               pair->local->component, 0, pair->local->transport);
+	uint64_t g = is_controlling ? local_priority : remote_priority;
+	uint64_t d = is_controlling ? remote_priority : local_priority;
+	uint64_t min = g < d ? g : d;
+	uint64_t max = g > d ? g : d;
+	pair->priority = (min << 32) + (max << 1) + (g > d ? 1 : 0);
+	return 0;
+}
+
+int ice_candidates_count(const ice_description_t *description, ice_candidate_type_t type) {
+	int count = 0;
+	for (int i = 0; i < description->candidates_count; ++i) {
+		const ice_candidate_t *candidate = description->candidates + i;
+		if (candidate->type == type)
+			++count;
+	}
+	return count;
+}
+
+uint32_t ice_compute_priority(ice_candidate_type_t type, int family, int component, int index, ice_candidate_transport_t transport) {
+    // Compute candidate priority according to RFC 8445
+    // See https://www.rfc-editor.org/rfc/rfc8445.html#section-5.1.2.1
+    uint32_t p = 0;
+
+    // Type preference
+    switch (type) {
+    case ICE_CANDIDATE_TYPE_HOST:
+        p += ICE_CANDIDATE_PREF_HOST;
+        break;
+    case ICE_CANDIDATE_TYPE_PEER_REFLEXIVE:
+        p += ICE_CANDIDATE_PREF_PEER_REFLEXIVE;
+        break;
+    case ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE:
+        p += ICE_CANDIDATE_PREF_SERVER_REFLEXIVE;
+        break;
+    case ICE_CANDIDATE_TYPE_RELAYED:
+        p += ICE_CANDIDATE_PREF_RELAYED;
+        break;
+    default:
+        break;
+    }
+
+    // Prefer UDP over TCP
+    if (transport != ICE_CANDIDATE_TRANSPORT_UDP) {
+        if (p >= ICE_CANDIDATE_PENALTY_TCP)
+            p -= ICE_CANDIDATE_PENALTY_TCP;
+        else
+            p = 0;
+    }
+
+    p <<= 16;
+
+    // Local preference
+    // See https://www.rfc-editor.org/rfc/rfc6544#section-4.2
+    uint32_t local = 0;
+    switch (transport) {
+        case ICE_CANDIDATE_TRANSPORT_TCP_TYPE_ACTIVE:
+            local += 6;
+            break;
+        case ICE_CANDIDATE_TRANSPORT_TCP_TYPE_PASSIVE:
+            local += 4;
+            break;
+        case ICE_CANDIDATE_TRANSPORT_TCP_TYPE_SO:
+            local += 2;
+            break;
+        default:
+            break;
+    }
+    local <<= 13;
+    // Prefer IPv6 over IPv4
+    switch (family) {
+    case AF_INET6:
+        local += 8191;
+        break;
+    case AF_INET:
+        local += 4095;
+        break;
+    default:
+        break;
+    }
+    local -= CLAMP(index, 0, 4095);
+
+    p += local;
+    p <<= 8;
+
+    // 256 - component ID
+    p += 256 - CLAMP(component, 1, 256);
+    return p;
+}
+
+bool ice_is_valid_string(const char *str) {
+	if (!str)
+		return false;
+
+	for (size_t i = 0; i < strlen(str); ++i)
+		if (!isalpha(str[i]) && !isdigit(str[i]) && str[i] != '+' && str[i] != '/')
+			return false;
+
+	return true;
+}

--- a/Source/3rdParty/libjuice/src/ice.h
+++ b/Source/3rdParty/libjuice/src/ice.h
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_ICE_H
+#define JUICE_ICE_H
+
+#include "addr.h"
+#include "juice.h"
+#include "tcp.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef ICE_MAX_CANDIDATES_COUNT
+#define ICE_MAX_CANDIDATES_COUNT 30 // ~ 500B * 30 = 15KB
+#endif
+
+#define ICE_CANDIDATE_PENALTY_TCP 50
+
+typedef enum ice_candidate_type {
+	ICE_CANDIDATE_TYPE_UNKNOWN,
+	ICE_CANDIDATE_TYPE_HOST,
+	ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE,
+	ICE_CANDIDATE_TYPE_PEER_REFLEXIVE,
+	ICE_CANDIDATE_TYPE_RELAYED,
+} ice_candidate_type_t;
+
+typedef enum ice_candidate_transport {
+	ICE_CANDIDATE_TRANSPORT_UDP,
+	ICE_CANDIDATE_TRANSPORT_TCP_TYPE_ACTIVE,
+	ICE_CANDIDATE_TRANSPORT_TCP_TYPE_PASSIVE,
+	ICE_CANDIDATE_TRANSPORT_TCP_TYPE_SO,
+} ice_candidate_transport_t;
+
+// RFC 8445: The RECOMMENDED values for type preferences are 126 for host candidates, 110 for
+// peer-reflexive candidates, 100 for server-reflexive candidates, and 0 for relayed candidates.
+#define ICE_CANDIDATE_PREF_HOST 126
+#define ICE_CANDIDATE_PREF_PEER_REFLEXIVE 110
+#define ICE_CANDIDATE_PREF_SERVER_REFLEXIVE 100
+#define ICE_CANDIDATE_PREF_RELAYED 0
+
+typedef struct ice_candidate {
+	ice_candidate_type_t type;
+	uint32_t priority;
+	int component;
+	char foundation[32 + 1]; // 1 to 32 characters
+	ice_candidate_transport_t transport;
+	char hostname[256 + 1];
+	char service[32 + 1];
+	addr_record_t resolved;
+} ice_candidate_t;
+
+typedef struct ice_description {
+	char ice_ufrag[256 + 1]; // 4 to 256 characters
+	char ice_pwd[256 + 1];   // 22 to 256 characters
+	bool ice_lite;
+	ice_candidate_t candidates[ICE_MAX_CANDIDATES_COUNT];
+	int candidates_count;
+	bool finished;
+} ice_description_t;
+
+typedef enum ice_candidate_pair_state {
+	ICE_CANDIDATE_PAIR_STATE_PENDING,
+	ICE_CANDIDATE_PAIR_STATE_SUCCEEDED,
+	ICE_CANDIDATE_PAIR_STATE_FAILED,
+	ICE_CANDIDATE_PAIR_STATE_FROZEN,
+} ice_candidate_pair_state_t;
+
+typedef struct ice_candidate_pair {
+	ice_candidate_t *local;
+	ice_candidate_t *remote;
+	uint64_t priority;
+	ice_candidate_pair_state_t state;
+	bool nominated;
+	bool nomination_requested;
+	timestamp_t consent_expiry;
+} ice_candidate_pair_t;
+
+typedef enum ice_resolve_mode {
+	ICE_RESOLVE_MODE_SIMPLE,
+	ICE_RESOLVE_MODE_LOOKUP,
+} ice_resolve_mode_t;
+
+#define ICE_PARSE_ERROR -1
+#define ICE_PARSE_IGNORED -2
+#define ICE_PARSE_MISSING_UFRAG -3
+#define ICE_PARSE_MISSING_PWD -4
+
+int ice_parse_sdp(const char *sdp, ice_description_t *description);
+int ice_parse_candidate_sdp(const char *line, ice_candidate_t *candidate);
+int ice_create_local_description(ice_description_t *description);
+int ice_create_local_candidate(ice_candidate_type_t type, int component, int index,
+                               const addr_record_t *record, ice_candidate_t *candidate,
+                               ice_candidate_transport_t transport);
+int ice_resolve_candidate(ice_candidate_t *candidate, ice_resolve_mode_t mode);
+int ice_add_candidate(ice_candidate_t *candidate, ice_description_t *description);
+void ice_sort_candidates(ice_description_t *description);
+ice_candidate_t *ice_find_candidate_from_addr(ice_description_t *description,
+                                              const addr_record_t *record,
+                                              ice_candidate_type_t type);
+int ice_generate_sdp(const ice_description_t *description, char *buffer, size_t size);
+int ice_generate_candidate_sdp(const ice_candidate_t *candidate, char *buffer, size_t size);
+int ice_create_candidate_pair(ice_candidate_t *local, ice_candidate_t *remote, bool is_controlling,
+                              ice_candidate_pair_t *pair); // local or remote might be NULL
+int ice_update_candidate_pair(ice_candidate_pair_t *pair, bool is_controlling);
+
+int ice_candidates_count(const ice_description_t *description, ice_candidate_type_t type);
+
+uint32_t ice_compute_priority(ice_candidate_type_t type, int family, int component, int index,
+                              ice_candidate_transport_t transport);
+
+bool ice_is_valid_string(const char *str);
+
+#endif

--- a/Source/3rdParty/libjuice/src/juice.c
+++ b/Source/3rdParty/libjuice/src/juice.c
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "juice.h"
+#include "addr.h"
+#include "agent.h"
+#include "ice.h"
+
+#ifndef NO_SERVER
+#include "server.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+JUICE_EXPORT juice_agent_t *juice_create(const juice_config_t *config) {
+	if (!config)
+		return NULL;
+
+	return agent_create(config);
+}
+
+JUICE_EXPORT void juice_destroy(juice_agent_t *agent) {
+	if (agent)
+		agent_destroy(agent);
+}
+
+JUICE_EXPORT int juice_gather_candidates(juice_agent_t *agent) {
+	if (!agent)
+		return JUICE_ERR_INVALID;
+
+	if (agent_gather_candidates(agent) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+JUICE_EXPORT int juice_get_local_description(juice_agent_t *agent, char *buffer, size_t size) {
+	if (!agent || (!buffer && size))
+		return JUICE_ERR_INVALID;
+
+	if (agent_get_local_description(agent, buffer, size) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+JUICE_EXPORT int juice_set_remote_description(juice_agent_t *agent, const char *sdp) {
+	if (!agent || !sdp)
+		return JUICE_ERR_INVALID;
+
+	return agent_set_remote_description(agent, sdp);
+}
+
+JUICE_EXPORT int juice_add_remote_candidate(juice_agent_t *agent, const char *sdp) {
+	if (!agent || !sdp)
+		return JUICE_ERR_INVALID;
+
+	return agent_add_remote_candidate(agent, sdp);
+}
+
+JUICE_EXPORT int juice_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server) {
+	if (!agent || !turn_server)
+		return JUICE_ERR_INVALID;
+
+	if (agent_add_turn_server(agent, turn_server) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+JUICE_EXPORT int juice_set_remote_gathering_done(juice_agent_t *agent) {
+	if (!agent)
+		return JUICE_ERR_INVALID;
+
+	if (agent_set_remote_gathering_done(agent) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size) {
+	return juice_send_diffserv(agent, data, size, 0);
+}
+
+JUICE_EXPORT int juice_send_diffserv(juice_agent_t *agent, const char *data, size_t size, int ds) {
+	if (!agent || (!data && size))
+		return JUICE_ERR_INVALID;
+
+	int ret = agent_send(agent, data, size, ds);
+	if(ret >= 0)
+		return JUICE_ERR_SUCCESS;
+	if(ret == -SEAGAIN || ret == -SEWOULDBLOCK)
+		return JUICE_ERR_AGAIN;
+	if(ret == -SEMSGSIZE)
+		return JUICE_ERR_TOO_LARGE;
+	return JUICE_ERR_FAILED;
+}
+
+JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent) { return agent_get_state(agent); }
+
+JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,
+                                               char *remote, size_t remote_size) {
+	if (!agent || (!local && local_size) || (!remote && remote_size))
+		return JUICE_ERR_INVALID;
+
+	ice_candidate_t local_cand, remote_cand;
+	if (agent_get_selected_candidate_pair(agent, &local_cand, &remote_cand))
+		return JUICE_ERR_NOT_AVAIL;
+
+	if (local_size && ice_generate_candidate_sdp(&local_cand, local, local_size) < 0)
+		return JUICE_ERR_FAILED;
+
+	if (remote_size && ice_generate_candidate_sdp(&remote_cand, remote, remote_size) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,
+                                              char *remote, size_t remote_size) {
+	if (!agent || (!local && local_size) || (!remote && remote_size))
+		return JUICE_ERR_INVALID;
+
+	ice_candidate_t local_cand, remote_cand;
+	if (agent_get_selected_candidate_pair(agent, &local_cand, &remote_cand))
+		return JUICE_ERR_NOT_AVAIL;
+
+	if (local_size && addr_record_to_string(&local_cand.resolved, local, local_size) < 0)
+		return JUICE_ERR_FAILED;
+
+	if (remote_size && addr_record_to_string(&remote_cand.resolved, remote, remote_size) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd)
+{
+	if (!ufrag || !pwd)
+		return JUICE_ERR_INVALID;
+
+	return agent_set_local_ice_attributes(agent, ufrag, pwd);
+}
+
+JUICE_EXPORT const char *juice_state_to_string(juice_state_t state) {
+	switch (state) {
+	case JUICE_STATE_DISCONNECTED:
+		return "disconnected";
+	case JUICE_STATE_GATHERING:
+		return "gathering";
+	case JUICE_STATE_CONNECTING:
+		return "connecting";
+	case JUICE_STATE_CONNECTED:
+		return "connected";
+	case JUICE_STATE_COMPLETED:
+		return "completed";
+	case JUICE_STATE_FAILED:
+		return "failed";
+	default:
+		return "unknown";
+	}
+}
+
+JUICE_EXPORT juice_server_t *juice_server_create(const juice_server_config_t *config) {
+#ifndef NO_SERVER
+	if (!config)
+		return NULL;
+
+	return server_create(config);
+#else
+	(void)config;
+	JLOG_FATAL("The library was compiled without server support");
+	return NULL;
+#endif
+}
+
+JUICE_EXPORT void juice_server_destroy(juice_server_t *server) {
+#ifndef NO_SERVER
+	if (server)
+		server_destroy(server);
+#else
+	(void)server;
+#endif
+}
+
+JUICE_EXPORT uint16_t juice_server_get_port(juice_server_t *server) {
+#ifndef NO_SERVER
+	return server ? server_get_port(server) : 0;
+#else
+	(void)server;
+	return 0;
+#endif
+}
+
+JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
+                                              const juice_server_credentials_t *credentials,
+                                              unsigned long lifetime_ms) {
+#ifndef NO_SERVER
+	if (!server || !credentials)
+		return JUICE_ERR_INVALID;
+
+	if (server_add_credentials(server, credentials, (timediff_t)lifetime_ms) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+#else
+	(void)server;
+	(void)credentials;
+	(void)lifetime_ms;
+	return JUICE_ERR_INVALID;
+#endif
+}
+
+int juice_set_ice_tcp_mode(juice_agent_t *agent, juice_ice_tcp_mode_t ice_tcp_mode)
+{
+	if (!agent)
+		return JUICE_ERR_INVALID;
+
+	return agent_set_ice_tcp_mode(agent, ice_tcp_mode);
+}

--- a/Source/3rdParty/libjuice/src/log.c
+++ b/Source/3rdParty/libjuice/src/log.c
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "log.h"
+#include "thread.h" // for mutexes and atomics
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#define BUFFER_SIZE 4096
+
+static const char *log_level_names[] = {"VERBOSE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
+
+static const char *log_level_colors[] = {
+    "\x1B[90m",        // grey
+    "\x1B[96m",        // cyan
+    "\x1B[39m",        // default foreground
+    "\x1B[93m",        // yellow
+    "\x1B[91m",        // red
+    "\x1B[97m\x1B[41m" // white on red
+};
+
+static mutex_t log_mutex = MUTEX_INITIALIZER;
+static volatile juice_log_cb_t log_cb = NULL;
+static atomic(juice_log_level_t) log_level = JUICE_LOG_LEVEL_WARN;
+
+static bool use_color(void) {
+#ifdef _WIN32
+	return false;
+#else
+	return isatty(fileno(stdout)) != 0;
+#endif
+}
+
+static int get_localtime(const time_t *t, struct tm *buf) {
+#ifdef _WIN32
+	// Windows does not have POSIX localtime_r...
+	return localtime_s(buf, t) == 0 ? 0 : -1;
+#else // POSIX
+	return localtime_r(t, buf) != NULL ? 0 : -1;
+#endif
+}
+
+JUICE_EXPORT void juice_set_log_level(juice_log_level_t level) { atomic_store(&log_level, level); }
+
+JUICE_EXPORT void juice_set_log_handler(juice_log_cb_t cb) {
+	mutex_lock(&log_mutex);
+	log_cb = cb;
+	mutex_unlock(&log_mutex);
+}
+
+bool juice_log_is_enabled(juice_log_level_t level) {
+	return level != JUICE_LOG_LEVEL_NONE && level >= atomic_load(&log_level);
+}
+
+void juice_log_write(juice_log_level_t level, const char *file, int line, const char *fmt, ...) {
+	if (!juice_log_is_enabled(level))
+		return;
+
+	mutex_lock(&log_mutex);
+
+#if !RELEASE
+	const char *filename = file + strlen(file);
+	while (filename != file && *filename != '/' && *filename != '\\')
+		--filename;
+	if (filename != file)
+		++filename;
+#else
+	(void)file;
+	(void)line;
+#endif
+
+	if (log_cb) {
+		char message[BUFFER_SIZE];
+		int len = 0;
+#if !RELEASE
+		len = snprintf(message, BUFFER_SIZE, "%s:%d: ", filename, line);
+		if (len < 0)
+			goto __exit;
+#endif
+		if (len < BUFFER_SIZE) {
+			va_list args;
+			va_start(args, fmt);
+			vsnprintf(message + len, BUFFER_SIZE - len, fmt, args);
+			va_end(args);
+		}
+
+		log_cb(level, message);
+
+	} else {
+		time_t t = time(NULL);
+		struct tm lt;
+		char buffer[16];
+		if (get_localtime(&t, &lt) != 0 || strftime(buffer, 16, "%H:%M:%S", &lt) == 0)
+			buffer[0] = '\0';
+
+		if (use_color())
+			fprintf(stdout, "%s", log_level_colors[level]);
+
+		fprintf(stdout, "%s %-7s ", buffer, log_level_names[level]);
+
+#if !RELEASE
+		fprintf(stdout, "%s:%d: ", filename, line);
+#endif
+
+		va_list args;
+		va_start(args, fmt);
+		vfprintf(stdout, fmt, args);
+		va_end(args);
+
+		if (use_color())
+			fprintf(stdout, "%s", "\x1B[0m\x1B[0K");
+
+		fprintf(stdout, "\n");
+		fflush(stdout);
+	}
+
+#if !RELEASE
+__exit:
+#endif
+	mutex_unlock(&log_mutex);
+}

--- a/Source/3rdParty/libjuice/src/log.h
+++ b/Source/3rdParty/libjuice/src/log.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_LOG_H
+#define JUICE_LOG_H
+
+#include "juice.h"
+
+#include <stdarg.h>
+
+bool juice_log_is_enabled(juice_log_level_t level);
+void juice_log_write(juice_log_level_t level, const char *file, int line, const char *fmt, ...);
+
+#define JLOG_VERBOSE(...) juice_log_write(JUICE_LOG_LEVEL_VERBOSE, __FILE__, __LINE__, __VA_ARGS__)
+#define JLOG_DEBUG(...) juice_log_write(JUICE_LOG_LEVEL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+#define JLOG_INFO(...) juice_log_write(JUICE_LOG_LEVEL_INFO, __FILE__, __LINE__, __VA_ARGS__)
+#define JLOG_WARN(...) juice_log_write(JUICE_LOG_LEVEL_WARN, __FILE__, __LINE__, __VA_ARGS__)
+#define JLOG_ERROR(...) juice_log_write(JUICE_LOG_LEVEL_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+#define JLOG_FATAL(...) juice_log_write(JUICE_LOG_LEVEL_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+
+#define JLOG_VERBOSE_ENABLED juice_log_is_enabled(JUICE_LOG_LEVEL_VERBOSE)
+#define JLOG_DEBUG_ENABLED juice_log_is_enabled(JUICE_LOG_LEVEL_DEBUG)
+#define JLOG_INFO_ENABLED juice_log_is_enabled(JUICE_LOG_LEVEL_INFO)
+#define JLOG_WARN_ENABLED juice_log_is_enabled(JUICE_LOG_LEVEL_WARN)
+#define JLOG_ERROR_ENABLED juice_log_is_enabled(JUICE_LOG_LEVEL_ERROR)
+#define JLOG_FATAL_ENABLED juice_log_is_enabled(JUICE_LOG_LEVEL_FATAL)
+
+#endif // JUICE_LOG_H

--- a/Source/3rdParty/libjuice/src/picohash.h
+++ b/Source/3rdParty/libjuice/src/picohash.h
@@ -1,0 +1,747 @@
+/*
+ * The code is placed under public domain by Kazuho Oku <kazuhooku@gmail.com>.
+ *
+ * The MD5 implementation is based on a public domain implementation written by
+ * Solar Designer <solar@openwall.com> in 2001, which is used by Dovecot.
+ *
+ * The SHA1 implementation is based on a public domain implementation written
+ * by Wei Dai and other contributors for libcrypt, used also in liboauth.
+ *
+ * The SHA224/SHA256 implementation is based on a public domain implementation
+ * by Sam Hocevar <sam@hocevar.net> for LibTomCrypt.
+ */
+#ifndef _picohash_h_
+#define _picohash_h_
+
+#include <assert.h>
+#include <inttypes.h>
+#include <string.h>
+
+#ifdef _WIN32
+/* assume Windows is little endian */
+#elif defined __BIG_ENDIAN__
+#define _PICOHASH_BIG_ENDIAN
+#elif defined __LITTLE_ENDIAN__
+/* override */
+#elif defined __BYTE_ORDER
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define _PICOHASH_BIG_ENDIAN
+#endif
+#else               // ! defined __LITTLE_ENDIAN__
+#include <endian.h> // machine/endian.h
+#if BYTE_ORDER == BIG_ENDIAN
+#define _PICOHASH_BIG_ENDIAN
+#endif
+#endif
+
+#define PICOHASH_MD5_BLOCK_LENGTH 64
+#define PICOHASH_MD5_DIGEST_LENGTH 16
+
+typedef struct {
+    uint_fast32_t lo, hi;
+    uint_fast32_t a, b, c, d;
+    unsigned char buffer[64];
+    uint_fast32_t block[PICOHASH_MD5_DIGEST_LENGTH];
+} _picohash_md5_ctx_t;
+
+static void _picohash_md5_init(_picohash_md5_ctx_t *ctx);
+static void _picohash_md5_update(_picohash_md5_ctx_t *ctx, const void *data, size_t size);
+static void _picohash_md5_final(_picohash_md5_ctx_t *ctx, void *digest);
+
+#define PICOHASH_SHA1_BLOCK_LENGTH 64
+#define PICOHASH_SHA1_DIGEST_LENGTH 20
+
+typedef struct {
+    uint32_t buffer[PICOHASH_SHA1_BLOCK_LENGTH / 4];
+    uint32_t state[PICOHASH_SHA1_DIGEST_LENGTH / 4];
+    uint64_t byteCount;
+    uint8_t bufferOffset;
+} _picohash_sha1_ctx_t;
+
+static void _picohash_sha1_init(_picohash_sha1_ctx_t *ctx);
+static void _picohash_sha1_update(_picohash_sha1_ctx_t *ctx, const void *input, size_t len);
+static void _picohash_sha1_final(_picohash_sha1_ctx_t *ctx, void *digest);
+
+#define PICOHASH_SHA256_BLOCK_LENGTH 64
+#define PICOHASH_SHA256_DIGEST_LENGTH 32
+#define PICOHASH_SHA224_BLOCK_LENGTH PICOHASH_SHA256_BLOCK_LENGTH
+#define PICOHASH_SHA224_DIGEST_LENGTH 28
+
+typedef struct {
+    uint64_t length;
+    uint32_t state[PICOHASH_SHA256_DIGEST_LENGTH / 4];
+    uint32_t curlen;
+    unsigned char buf[PICOHASH_SHA256_BLOCK_LENGTH];
+} _picohash_sha256_ctx_t;
+
+static void _picohash_sha256_init(_picohash_sha256_ctx_t *ctx);
+static void _picohash_sha256_update(_picohash_sha256_ctx_t *ctx, const void *data, size_t len);
+static void _picohash_sha256_final(_picohash_sha256_ctx_t *ctx, void *digest);
+static void _picohash_sha224_init(_picohash_sha256_ctx_t *ctx);
+static void _picohash_sha224_final(_picohash_sha256_ctx_t *ctx, void *digest);
+
+#define PICOHASH_MAX_BLOCK_LENGTH 64
+#define PICOHASH_MAX_DIGEST_LENGTH 32
+
+typedef struct {
+    union {
+        _picohash_md5_ctx_t _md5;
+        _picohash_sha1_ctx_t _sha1;
+        _picohash_sha256_ctx_t _sha256;
+    };
+    size_t block_length;
+    size_t digest_length;
+    void (*_reset)(void *ctx);
+    void (*_update)(void *ctx, const void *input, size_t len);
+    void (*_final)(void *ctx, void *digest);
+    struct {
+        unsigned char key[PICOHASH_MAX_BLOCK_LENGTH];
+        void (*hash_reset)(void *ctx);
+        void (*hash_final)(void *ctx, void *digest);
+    } _hmac;
+} picohash_ctx_t;
+
+static void picohash_init_md5(picohash_ctx_t *ctx);
+static void picohash_init_sha1(picohash_ctx_t *ctx);
+static void picohash_init_sha224(picohash_ctx_t *ctx);
+static void picohash_init_sha256(picohash_ctx_t *ctx);
+static void picohash_update(picohash_ctx_t *ctx, const void *input, size_t len);
+static void picohash_final(picohash_ctx_t *ctx, void *digest);
+static void picohash_reset(picohash_ctx_t *ctx);
+
+static void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t *), const void *key, size_t key_len);
+
+/* following are private definitions */
+
+/*
+ * The basic MD5 functions.
+ *
+ * F is optimized compared to its RFC 1321 definition just like in Colin
+ * Plumb's implementation.
+ */
+#define _PICOHASH_MD5_F(x, y, z) ((z) ^ ((x) & ((y) ^ (z))))
+#define _PICOHASH_MD5_G(x, y, z) ((y) ^ ((z) & ((x) ^ (y))))
+#define _PICOHASH_MD5_H(x, y, z) ((x) ^ (y) ^ (z))
+#define _PICOHASH_MD5_I(x, y, z) ((y) ^ ((x) | ~(z)))
+
+/*
+ * The MD5 transformation for all four rounds.
+ */
+#define _PICOHASH_MD5_STEP(f, a, b, c, d, x, t, s)                                                                                 \
+    (a) += f((b), (c), (d)) + (x) + (t);                                                                                           \
+    (a) = (((a) << (s)) | (((a)&0xffffffff) >> (32 - (s))));                                                                       \
+    (a) += (b);
+
+/*
+ * SET reads 4 input bytes in little-endian byte order and stores them
+ * in a properly aligned word in host byte order.
+ *
+ * Paul-Louis Ageneau: Removed optimization for little-endian architectures
+ * as it resulted in incorrect behavior when compiling with gcc optimizations.
+ */
+#define _PICOHASH_MD5_SET(n)                                                                                                       \
+    (ctx->block[(n)] = (uint_fast32_t)ptr[(n)*4] | ((uint_fast32_t)ptr[(n)*4 + 1] << 8) | ((uint_fast32_t)ptr[(n)*4 + 2] << 16) |  \
+                       ((uint_fast32_t)ptr[(n)*4 + 3] << 24))
+#define _PICOHASH_MD5_GET(n) (ctx->block[(n)])
+
+/*
+ * This processes one or more 64-byte data blocks, but does NOT update
+ * the bit counters.  There're no alignment requirements.
+ */
+static const void *_picohash_md5_body(_picohash_md5_ctx_t *ctx, const void *data, size_t size)
+{
+    const unsigned char *ptr;
+    uint_fast32_t a, b, c, d;
+    uint_fast32_t saved_a, saved_b, saved_c, saved_d;
+
+    ptr = data;
+
+    a = ctx->a;
+    b = ctx->b;
+    c = ctx->c;
+    d = ctx->d;
+
+    do {
+        saved_a = a;
+        saved_b = b;
+        saved_c = c;
+        saved_d = d;
+
+        /* Round 1 */
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, a, b, c, d, _PICOHASH_MD5_SET(0), 0xd76aa478, 7)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, d, a, b, c, _PICOHASH_MD5_SET(1), 0xe8c7b756, 12)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, c, d, a, b, _PICOHASH_MD5_SET(2), 0x242070db, 17)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, b, c, d, a, _PICOHASH_MD5_SET(3), 0xc1bdceee, 22)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, a, b, c, d, _PICOHASH_MD5_SET(4), 0xf57c0faf, 7)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, d, a, b, c, _PICOHASH_MD5_SET(5), 0x4787c62a, 12)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, c, d, a, b, _PICOHASH_MD5_SET(6), 0xa8304613, 17)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, b, c, d, a, _PICOHASH_MD5_SET(7), 0xfd469501, 22)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, a, b, c, d, _PICOHASH_MD5_SET(8), 0x698098d8, 7)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, d, a, b, c, _PICOHASH_MD5_SET(9), 0x8b44f7af, 12)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, c, d, a, b, _PICOHASH_MD5_SET(10), 0xffff5bb1, 17)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, b, c, d, a, _PICOHASH_MD5_SET(11), 0x895cd7be, 22)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, a, b, c, d, _PICOHASH_MD5_SET(12), 0x6b901122, 7)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, d, a, b, c, _PICOHASH_MD5_SET(13), 0xfd987193, 12)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, c, d, a, b, _PICOHASH_MD5_SET(14), 0xa679438e, 17)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_F, b, c, d, a, _PICOHASH_MD5_SET(15), 0x49b40821, 22)
+
+        /* Round 2 */
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, a, b, c, d, _PICOHASH_MD5_GET(1), 0xf61e2562, 5)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, d, a, b, c, _PICOHASH_MD5_GET(6), 0xc040b340, 9)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, c, d, a, b, _PICOHASH_MD5_GET(11), 0x265e5a51, 14)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, b, c, d, a, _PICOHASH_MD5_GET(0), 0xe9b6c7aa, 20)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, a, b, c, d, _PICOHASH_MD5_GET(5), 0xd62f105d, 5)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, d, a, b, c, _PICOHASH_MD5_GET(10), 0x02441453, 9)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, c, d, a, b, _PICOHASH_MD5_GET(15), 0xd8a1e681, 14)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, b, c, d, a, _PICOHASH_MD5_GET(4), 0xe7d3fbc8, 20)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, a, b, c, d, _PICOHASH_MD5_GET(9), 0x21e1cde6, 5)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, d, a, b, c, _PICOHASH_MD5_GET(14), 0xc33707d6, 9)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, c, d, a, b, _PICOHASH_MD5_GET(3), 0xf4d50d87, 14)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, b, c, d, a, _PICOHASH_MD5_GET(8), 0x455a14ed, 20)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, a, b, c, d, _PICOHASH_MD5_GET(13), 0xa9e3e905, 5)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, d, a, b, c, _PICOHASH_MD5_GET(2), 0xfcefa3f8, 9)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, c, d, a, b, _PICOHASH_MD5_GET(7), 0x676f02d9, 14)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_G, b, c, d, a, _PICOHASH_MD5_GET(12), 0x8d2a4c8a, 20)
+
+        /* Round 3 */
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, a, b, c, d, _PICOHASH_MD5_GET(5), 0xfffa3942, 4)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, d, a, b, c, _PICOHASH_MD5_GET(8), 0x8771f681, 11)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, c, d, a, b, _PICOHASH_MD5_GET(11), 0x6d9d6122, 16)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, b, c, d, a, _PICOHASH_MD5_GET(14), 0xfde5380c, 23)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, a, b, c, d, _PICOHASH_MD5_GET(1), 0xa4beea44, 4)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, d, a, b, c, _PICOHASH_MD5_GET(4), 0x4bdecfa9, 11)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, c, d, a, b, _PICOHASH_MD5_GET(7), 0xf6bb4b60, 16)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, b, c, d, a, _PICOHASH_MD5_GET(10), 0xbebfbc70, 23)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, a, b, c, d, _PICOHASH_MD5_GET(13), 0x289b7ec6, 4)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, d, a, b, c, _PICOHASH_MD5_GET(0), 0xeaa127fa, 11)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, c, d, a, b, _PICOHASH_MD5_GET(3), 0xd4ef3085, 16)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, b, c, d, a, _PICOHASH_MD5_GET(6), 0x04881d05, 23)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, a, b, c, d, _PICOHASH_MD5_GET(9), 0xd9d4d039, 4)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, d, a, b, c, _PICOHASH_MD5_GET(12), 0xe6db99e5, 11)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, c, d, a, b, _PICOHASH_MD5_GET(15), 0x1fa27cf8, 16)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_H, b, c, d, a, _PICOHASH_MD5_GET(2), 0xc4ac5665, 23)
+
+        /* Round 4 */
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, a, b, c, d, _PICOHASH_MD5_GET(0), 0xf4292244, 6)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, d, a, b, c, _PICOHASH_MD5_GET(7), 0x432aff97, 10)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, c, d, a, b, _PICOHASH_MD5_GET(14), 0xab9423a7, 15)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, b, c, d, a, _PICOHASH_MD5_GET(5), 0xfc93a039, 21)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, a, b, c, d, _PICOHASH_MD5_GET(12), 0x655b59c3, 6)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, d, a, b, c, _PICOHASH_MD5_GET(3), 0x8f0ccc92, 10)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, c, d, a, b, _PICOHASH_MD5_GET(10), 0xffeff47d, 15)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, b, c, d, a, _PICOHASH_MD5_GET(1), 0x85845dd1, 21)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, a, b, c, d, _PICOHASH_MD5_GET(8), 0x6fa87e4f, 6)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, d, a, b, c, _PICOHASH_MD5_GET(15), 0xfe2ce6e0, 10)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, c, d, a, b, _PICOHASH_MD5_GET(6), 0xa3014314, 15)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, b, c, d, a, _PICOHASH_MD5_GET(13), 0x4e0811a1, 21)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, a, b, c, d, _PICOHASH_MD5_GET(4), 0xf7537e82, 6)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, d, a, b, c, _PICOHASH_MD5_GET(11), 0xbd3af235, 10)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, c, d, a, b, _PICOHASH_MD5_GET(2), 0x2ad7d2bb, 15)
+        _PICOHASH_MD5_STEP(_PICOHASH_MD5_I, b, c, d, a, _PICOHASH_MD5_GET(9), 0xeb86d391, 21)
+
+        a += saved_a;
+        b += saved_b;
+        c += saved_c;
+        d += saved_d;
+
+        ptr += 64;
+    } while (size -= 64);
+
+    ctx->a = a;
+    ctx->b = b;
+    ctx->c = c;
+    ctx->d = d;
+
+    return ptr;
+}
+
+inline void _picohash_md5_init(_picohash_md5_ctx_t *ctx)
+{
+    ctx->a = 0x67452301;
+    ctx->b = 0xefcdab89;
+    ctx->c = 0x98badcfe;
+    ctx->d = 0x10325476;
+
+    ctx->lo = 0;
+    ctx->hi = 0;
+}
+
+inline void _picohash_md5_update(_picohash_md5_ctx_t *ctx, const void *data, size_t size)
+{
+    uint_fast32_t saved_lo;
+    unsigned long used, free;
+
+    saved_lo = ctx->lo;
+    if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo)
+        ctx->hi++;
+    ctx->hi += (uint_fast32_t)(size >> 29);
+
+    used = saved_lo & 0x3f;
+
+    if (used) {
+        free = 64 - used;
+
+        if (size < free) {
+            memcpy(&ctx->buffer[used], data, size);
+            return;
+        }
+
+        memcpy(&ctx->buffer[used], data, free);
+        data = (const unsigned char *)data + free;
+        size -= free;
+        _picohash_md5_body(ctx, ctx->buffer, 64);
+    }
+
+    if (size >= 64) {
+        data = _picohash_md5_body(ctx, data, size & ~(unsigned long)0x3f);
+        size &= 0x3f;
+    }
+
+    memcpy(ctx->buffer, data, size);
+}
+
+inline void _picohash_md5_final(_picohash_md5_ctx_t *ctx, void *_digest)
+{
+    unsigned char *digest = _digest;
+    unsigned long used, free;
+
+    used = ctx->lo & 0x3f;
+
+    ctx->buffer[used++] = 0x80;
+
+    free = 64 - used;
+
+    if (free < 8) {
+        memset(&ctx->buffer[used], 0, free);
+        _picohash_md5_body(ctx, ctx->buffer, 64);
+        used = 0;
+        free = 64;
+    }
+
+    memset(&ctx->buffer[used], 0, free - 8);
+
+    ctx->lo <<= 3;
+    ctx->buffer[56] = ctx->lo;
+    ctx->buffer[57] = ctx->lo >> 8;
+    ctx->buffer[58] = ctx->lo >> 16;
+    ctx->buffer[59] = ctx->lo >> 24;
+    ctx->buffer[60] = ctx->hi;
+    ctx->buffer[61] = ctx->hi >> 8;
+    ctx->buffer[62] = ctx->hi >> 16;
+    ctx->buffer[63] = ctx->hi >> 24;
+
+    _picohash_md5_body(ctx, ctx->buffer, 64);
+
+    digest[0] = ctx->a;
+    digest[1] = ctx->a >> 8;
+    digest[2] = ctx->a >> 16;
+    digest[3] = ctx->a >> 24;
+    digest[4] = ctx->b;
+    digest[5] = ctx->b >> 8;
+    digest[6] = ctx->b >> 16;
+    digest[7] = ctx->b >> 24;
+    digest[8] = ctx->c;
+    digest[9] = ctx->c >> 8;
+    digest[10] = ctx->c >> 16;
+    digest[11] = ctx->c >> 24;
+    digest[12] = ctx->d;
+    digest[13] = ctx->d >> 8;
+    digest[14] = ctx->d >> 16;
+    digest[15] = ctx->d >> 24;
+
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+#define _PICOHASH_SHA1_K0 0x5a827999
+#define _PICOHASH_SHA1_K20 0x6ed9eba1
+#define _PICOHASH_SHA1_K40 0x8f1bbcdc
+#define _PICOHASH_SHA1_K60 0xca62c1d6
+
+static inline uint32_t _picohash_sha1_rol32(uint32_t number, uint8_t bits)
+{
+    return ((number << bits) | (number >> (32 - bits)));
+}
+
+static inline void _picohash_sha1_hash_block(_picohash_sha1_ctx_t *s)
+{
+    uint8_t i;
+    uint32_t a, b, c, d, e, t;
+
+    a = s->state[0];
+    b = s->state[1];
+    c = s->state[2];
+    d = s->state[3];
+    e = s->state[4];
+    for (i = 0; i < 80; i++) {
+        if (i >= 16) {
+            t = s->buffer[(i + 13) & 15] ^ s->buffer[(i + 8) & 15] ^ s->buffer[(i + 2) & 15] ^ s->buffer[i & 15];
+            s->buffer[i & 15] = _picohash_sha1_rol32(t, 1);
+        }
+        if (i < 20) {
+            t = (d ^ (b & (c ^ d))) + _PICOHASH_SHA1_K0;
+        } else if (i < 40) {
+            t = (b ^ c ^ d) + _PICOHASH_SHA1_K20;
+        } else if (i < 60) {
+            t = ((b & c) | (d & (b | c))) + _PICOHASH_SHA1_K40;
+        } else {
+            t = (b ^ c ^ d) + _PICOHASH_SHA1_K60;
+        }
+        t += _picohash_sha1_rol32(a, 5) + e + s->buffer[i & 15];
+        e = d;
+        d = c;
+        c = _picohash_sha1_rol32(b, 30);
+        b = a;
+        a = t;
+    }
+    s->state[0] += a;
+    s->state[1] += b;
+    s->state[2] += c;
+    s->state[3] += d;
+    s->state[4] += e;
+}
+
+static inline void _picohash_sha1_add_uncounted(_picohash_sha1_ctx_t *s, uint8_t data)
+{
+    uint8_t *const b = (uint8_t *)s->buffer;
+#ifdef _PICOHASH_BIG_ENDIAN
+    b[s->bufferOffset] = data;
+#else
+    b[s->bufferOffset ^ 3] = data;
+#endif
+    s->bufferOffset++;
+    if (s->bufferOffset == PICOHASH_SHA1_BLOCK_LENGTH) {
+        _picohash_sha1_hash_block(s);
+        s->bufferOffset = 0;
+    }
+}
+
+inline void _picohash_sha1_init(_picohash_sha1_ctx_t *s)
+{
+    s->state[0] = 0x67452301;
+    s->state[1] = 0xefcdab89;
+    s->state[2] = 0x98badcfe;
+    s->state[3] = 0x10325476;
+    s->state[4] = 0xc3d2e1f0;
+    s->byteCount = 0;
+    s->bufferOffset = 0;
+}
+
+inline void _picohash_sha1_update(_picohash_sha1_ctx_t *s, const void *_data, size_t len)
+{
+    const uint8_t *data = _data;
+    for (; len != 0; --len) {
+        ++s->byteCount;
+        _picohash_sha1_add_uncounted(s, *data++);
+    }
+}
+
+inline void _picohash_sha1_final(_picohash_sha1_ctx_t *s, void *digest)
+{
+    // Pad with 0x80 followed by 0x00 until the end of the block
+    _picohash_sha1_add_uncounted(s, 0x80);
+    while (s->bufferOffset != 56)
+        _picohash_sha1_add_uncounted(s, 0x00);
+
+    // Append length in the last 8 bytes
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 53)); // Shifting to multiply by 8
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 45)); // as SHA-1 supports bitstreams
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 37)); // as well as byte.
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 29));
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 21));
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 13));
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 5));
+    _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount << 3));
+
+#ifndef SHA_BIG_ENDIAN
+    { // Swap byte order back
+        int i;
+        for (i = 0; i < 5; i++) {
+            s->state[i] = (((s->state[i]) << 24) & 0xff000000) | (((s->state[i]) << 8) & 0x00ff0000) |
+                          (((s->state[i]) >> 8) & 0x0000ff00) | (((s->state[i]) >> 24) & 0x000000ff);
+        }
+    }
+#endif
+
+    memcpy(digest, s->state, sizeof(s->state));
+}
+
+#define _picohash_sha256_ch(x, y, z) (z ^ (x & (y ^ z)))
+#define _picohash_sha256_maj(x, y, z) (((x | y) & z) | (x & y))
+#define _picohash_sha256_s(x, y)                                                                                                   \
+    (((((uint32_t)(x)&0xFFFFFFFFUL) >> (uint32_t)((y)&31)) | ((uint32_t)(x) << (uint32_t)(32 - ((y)&31)))) & 0xFFFFFFFFUL)
+#define _picohash_sha256_r(x, n) (((x)&0xFFFFFFFFUL) >> (n))
+#define _picohash_sha256_sigma0(x) (_picohash_sha256_s(x, 2) ^ _picohash_sha256_s(x, 13) ^ _picohash_sha256_s(x, 22))
+#define _picohash_sha256_sigma1(x) (_picohash_sha256_s(x, 6) ^ _picohash_sha256_s(x, 11) ^ _picohash_sha256_s(x, 25))
+#define _picohash_sha256_gamma0(x) (_picohash_sha256_s(x, 7) ^ _picohash_sha256_s(x, 18) ^ _picohash_sha256_r(x, 3))
+#define _picohash_sha256_gamma1(x) (_picohash_sha256_s(x, 17) ^ _picohash_sha256_s(x, 19) ^ _picohash_sha256_r(x, 10))
+#define _picohash_sha256_rnd(a, b, c, d, e, f, g, h, i)                                                                            \
+    t0 = h + _picohash_sha256_sigma1(e) + _picohash_sha256_ch(e, f, g) + K[i] + W[i];                                              \
+    t1 = _picohash_sha256_sigma0(a) + _picohash_sha256_maj(a, b, c);                                                               \
+    d += t0;                                                                                                                       \
+    h = t0 + t1;
+
+static inline void _picohash_sha256_compress(_picohash_sha256_ctx_t *ctx, unsigned char *buf)
+{
+    static const uint32_t K[64] = {
+        0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL, 0x3956c25bUL, 0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL,
+        0xd807aa98UL, 0x12835b01UL, 0x243185beUL, 0x550c7dc3UL, 0x72be5d74UL, 0x80deb1feUL, 0x9bdc06a7UL, 0xc19bf174UL,
+        0xe49b69c1UL, 0xefbe4786UL, 0x0fc19dc6UL, 0x240ca1ccUL, 0x2de92c6fUL, 0x4a7484aaUL, 0x5cb0a9dcUL, 0x76f988daUL,
+        0x983e5152UL, 0xa831c66dUL, 0xb00327c8UL, 0xbf597fc7UL, 0xc6e00bf3UL, 0xd5a79147UL, 0x06ca6351UL, 0x14292967UL,
+        0x27b70a85UL, 0x2e1b2138UL, 0x4d2c6dfcUL, 0x53380d13UL, 0x650a7354UL, 0x766a0abbUL, 0x81c2c92eUL, 0x92722c85UL,
+        0xa2bfe8a1UL, 0xa81a664bUL, 0xc24b8b70UL, 0xc76c51a3UL, 0xd192e819UL, 0xd6990624UL, 0xf40e3585UL, 0x106aa070UL,
+        0x19a4c116UL, 0x1e376c08UL, 0x2748774cUL, 0x34b0bcb5UL, 0x391c0cb3UL, 0x4ed8aa4aUL, 0x5b9cca4fUL, 0x682e6ff3UL,
+        0x748f82eeUL, 0x78a5636fUL, 0x84c87814UL, 0x8cc70208UL, 0x90befffaUL, 0xa4506cebUL, 0xbef9a3f7UL, 0xc67178f2UL};
+    uint32_t S[8], W[64], t, t0, t1;
+    int i;
+
+    /* copy state into S */
+    for (i = 0; i < 8; i++)
+        S[i] = ctx->state[i];
+
+    /* copy the state into 512-bits into W[0..15] */
+    for (i = 0; i < 16; i++)
+        W[i] =
+            (uint32_t)buf[4 * i] << 24 | (uint32_t)buf[4 * i + 1] << 16 | (uint32_t)buf[4 * i + 2] << 8 | (uint32_t)buf[4 * i + 3];
+
+    /* fill W[16..63] */
+    for (i = 16; i < 64; i++)
+        W[i] = _picohash_sha256_gamma1(W[i - 2]) + W[i - 7] + _picohash_sha256_gamma0(W[i - 15]) + W[i - 16];
+
+    /* Compress */
+    for (i = 0; i < 64; ++i) {
+        _picohash_sha256_rnd(S[0], S[1], S[2], S[3], S[4], S[5], S[6], S[7], i);
+        t = S[7];
+        S[7] = S[6];
+        S[6] = S[5];
+        S[5] = S[4];
+        S[4] = S[3];
+        S[3] = S[2];
+        S[2] = S[1];
+        S[1] = S[0];
+        S[0] = t;
+    }
+
+    /* feedback */
+    for (i = 0; i < 8; i++)
+        ctx->state[i] = ctx->state[i] + S[i];
+}
+
+static inline void _picohash_sha256_do_final(_picohash_sha256_ctx_t *ctx, void *digest, size_t len)
+{
+    unsigned char *out = digest;
+    size_t i;
+
+    /* increase the length of the message */
+    ctx->length += ctx->curlen * 8;
+
+    /* append the '1' bit */
+    ctx->buf[ctx->curlen++] = (unsigned char)0x80;
+
+    /* if the length is currently above 56 bytes we append zeros
+     * then compress.  Then we can fall back to padding zeros and length
+     * encoding like normal.
+     */
+    if (ctx->curlen > 56) {
+        while (ctx->curlen < 64) {
+            ctx->buf[ctx->curlen++] = (unsigned char)0;
+        }
+        _picohash_sha256_compress(ctx, ctx->buf);
+        ctx->curlen = 0;
+    }
+
+    /* pad upto 56 bytes of zeroes */
+    while (ctx->curlen < 56) {
+        ctx->buf[ctx->curlen++] = (unsigned char)0;
+    }
+
+    /* store length */
+    for (i = 0; i != 8; ++i)
+        ctx->buf[56 + i] = (unsigned char)(ctx->length >> (56 - 8 * i));
+    _picohash_sha256_compress(ctx, ctx->buf);
+
+    /* copy output */
+    for (i = 0; i != len / 4; ++i) {
+        out[i * 4] = ctx->state[i] >> 24;
+        out[i * 4 + 1] = ctx->state[i] >> 16;
+        out[i * 4 + 2] = ctx->state[i] >> 8;
+        out[i * 4 + 3] = ctx->state[i];
+    }
+}
+
+inline void _picohash_sha256_init(_picohash_sha256_ctx_t *ctx)
+{
+    ctx->curlen = 0;
+    ctx->length = 0;
+    ctx->state[0] = 0x6A09E667UL;
+    ctx->state[1] = 0xBB67AE85UL;
+    ctx->state[2] = 0x3C6EF372UL;
+    ctx->state[3] = 0xA54FF53AUL;
+    ctx->state[4] = 0x510E527FUL;
+    ctx->state[5] = 0x9B05688CUL;
+    ctx->state[6] = 0x1F83D9ABUL;
+    ctx->state[7] = 0x5BE0CD19UL;
+}
+
+inline void _picohash_sha256_update(_picohash_sha256_ctx_t *ctx, const void *data, size_t len)
+{
+    const unsigned char *in = data;
+    size_t n;
+
+    while (len > 0) {
+        if (ctx->curlen == 0 && len >= PICOHASH_SHA256_BLOCK_LENGTH) {
+            _picohash_sha256_compress(ctx, (unsigned char *)in);
+            ctx->length += PICOHASH_SHA256_BLOCK_LENGTH * 8;
+            in += PICOHASH_SHA256_BLOCK_LENGTH;
+            len -= PICOHASH_SHA256_BLOCK_LENGTH;
+        } else {
+            n = PICOHASH_SHA256_BLOCK_LENGTH - ctx->curlen;
+            if (n > len)
+                n = len;
+            memcpy(ctx->buf + ctx->curlen, in, n);
+            ctx->curlen += (uint32_t)n;
+            in += n;
+            len -= n;
+            if (ctx->curlen == 64) {
+                _picohash_sha256_compress(ctx, ctx->buf);
+                ctx->length += 8 * PICOHASH_SHA256_BLOCK_LENGTH;
+                ctx->curlen = 0;
+            }
+        }
+    }
+}
+
+inline void _picohash_sha256_final(_picohash_sha256_ctx_t *ctx, void *digest)
+{
+    _picohash_sha256_do_final(ctx, digest, PICOHASH_SHA256_DIGEST_LENGTH);
+}
+
+inline void _picohash_sha224_init(_picohash_sha256_ctx_t *ctx)
+{
+    ctx->curlen = 0;
+    ctx->length = 0;
+    ctx->state[0] = 0xc1059ed8UL;
+    ctx->state[1] = 0x367cd507UL;
+    ctx->state[2] = 0x3070dd17UL;
+    ctx->state[3] = 0xf70e5939UL;
+    ctx->state[4] = 0xffc00b31UL;
+    ctx->state[5] = 0x68581511UL;
+    ctx->state[6] = 0x64f98fa7UL;
+    ctx->state[7] = 0xbefa4fa4UL;
+}
+
+inline void _picohash_sha224_final(_picohash_sha256_ctx_t *ctx, void *digest)
+{
+    _picohash_sha256_do_final(ctx, digest, PICOHASH_SHA224_DIGEST_LENGTH);
+}
+
+inline void picohash_init_md5(picohash_ctx_t *ctx)
+{
+    ctx->block_length = PICOHASH_MD5_BLOCK_LENGTH;
+    ctx->digest_length = PICOHASH_MD5_DIGEST_LENGTH;
+    ctx->_reset = (void *)_picohash_md5_init;
+    ctx->_update = (void *)_picohash_md5_update;
+    ctx->_final = (void *)_picohash_md5_final;
+
+    _picohash_md5_init(&ctx->_md5);
+}
+
+inline void picohash_init_sha1(picohash_ctx_t *ctx)
+{
+    ctx->block_length = PICOHASH_SHA1_BLOCK_LENGTH;
+    ctx->digest_length = PICOHASH_SHA1_DIGEST_LENGTH;
+    ctx->_reset = (void *)_picohash_sha1_init;
+    ctx->_update = (void *)_picohash_sha1_update;
+    ctx->_final = (void *)_picohash_sha1_final;
+    _picohash_sha1_init(&ctx->_sha1);
+}
+
+inline void picohash_init_sha224(picohash_ctx_t *ctx)
+{
+    ctx->block_length = PICOHASH_SHA224_BLOCK_LENGTH;
+    ctx->digest_length = PICOHASH_SHA224_DIGEST_LENGTH;
+    ctx->_reset = (void *)_picohash_sha224_init;
+    ctx->_update = (void *)_picohash_sha256_update;
+    ctx->_final = (void *)_picohash_sha224_final;
+    _picohash_sha224_init(&ctx->_sha256);
+}
+
+inline void picohash_init_sha256(picohash_ctx_t *ctx)
+{
+    ctx->block_length = PICOHASH_SHA256_BLOCK_LENGTH;
+    ctx->digest_length = PICOHASH_SHA256_DIGEST_LENGTH;
+    ctx->_reset = (void *)_picohash_sha256_init;
+    ctx->_update = (void *)_picohash_sha256_update;
+    ctx->_final = (void *)_picohash_sha256_final;
+    _picohash_sha256_init(&ctx->_sha256);
+}
+
+inline void picohash_update(picohash_ctx_t *ctx, const void *input, size_t len)
+{
+    ctx->_update(ctx, input, len);
+}
+
+inline void picohash_final(picohash_ctx_t *ctx, void *digest)
+{
+    ctx->_final(ctx, digest);
+}
+
+inline void picohash_reset(picohash_ctx_t *ctx)
+{
+    ctx->_reset(ctx);
+}
+
+static inline void _picohash_hmac_apply_key(picohash_ctx_t *ctx, unsigned char delta)
+{
+    size_t i;
+    for (i = 0; i != ctx->block_length; ++i)
+        ctx->_hmac.key[i] ^= delta;
+    picohash_update(ctx, ctx->_hmac.key, ctx->block_length);
+    for (i = 0; i != ctx->block_length; ++i)
+        ctx->_hmac.key[i] ^= delta;
+}
+
+static void _picohash_hmac_final(picohash_ctx_t *ctx, void *digest)
+{
+    unsigned char inner_digest[PICOHASH_MAX_DIGEST_LENGTH];
+
+    ctx->_hmac.hash_final(ctx, inner_digest);
+
+    ctx->_hmac.hash_reset(ctx);
+    _picohash_hmac_apply_key(ctx, 0x5c);
+    picohash_update(ctx, inner_digest, ctx->digest_length);
+    memset(inner_digest, 0, ctx->digest_length);
+
+    ctx->_hmac.hash_final(ctx, digest);
+}
+
+static inline void _picohash_hmac_reset(picohash_ctx_t *ctx)
+{
+    ctx->_hmac.hash_reset(ctx);
+    _picohash_hmac_apply_key(ctx, 0x36);
+}
+
+inline void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t *), const void *key, size_t key_len)
+{
+    initf(ctx);
+
+    memset(ctx->_hmac.key, 0, ctx->block_length);
+    if (key_len > ctx->block_length) {
+        /* hash the key if it is too long */
+        picohash_update(ctx, key, key_len);
+        picohash_final(ctx, ctx->_hmac.key);
+        picohash_reset(ctx);
+    } else {
+        memcpy(ctx->_hmac.key, key, key_len);
+    }
+
+    /* replace reset and final function */
+    ctx->_hmac.hash_reset = ctx->_reset;
+    ctx->_hmac.hash_final = ctx->_final;
+    ctx->_reset = (void *)_picohash_hmac_reset;
+    ctx->_final = (void *)_picohash_hmac_final;
+
+    /* start calculating the inner hash */
+    _picohash_hmac_apply_key(ctx, 0x36);
+}
+
+#endif

--- a/Source/3rdParty/libjuice/src/random.c
+++ b/Source/3rdParty/libjuice/src/random.c
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "random.h"
+#include "log.h"
+#include "thread.h" // for mutexes
+
+#include <math.h>
+#include <stdbool.h>
+#include <time.h>
+
+// getrandom() is not available in Android NDK API < 28 and needs glibc >= 2.25
+#if defined(__linux__) && !defined(__ANDROID__) && (!defined(__GLIBC__) || __GLIBC__ > 2 || __GLIBC_MINOR__ >= 25)
+
+#include <errno.h>
+#include <sys/random.h>
+
+static int random_bytes(void *buf, size_t size) {
+	ssize_t ret = getrandom(buf, size, 0);
+	if (ret < 0) {
+		JLOG_WARN("getrandom failed, errno=%d", errno);
+		return -1;
+	}
+	if ((size_t)ret < size) {
+		JLOG_WARN("getrandom returned too few bytes, size=%zu, returned=%zu", size, (size_t)ret);
+		return -1;
+	}
+	return 0;
+}
+
+#elif defined(_WIN32)
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601 // Windows 7
+#endif
+
+#include <windows.h>
+//
+#include <bcrypt.h>
+
+static int random_bytes(void *buf, size_t size) {
+	// Requires Windows 7 or later
+	NTSTATUS status = BCryptGenRandom(NULL, (PUCHAR)buf, (ULONG)size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+	return !status ? 0 : -1;
+}
+
+#else
+static int random_bytes(void *buf, size_t size) {
+	(void)buf;
+	(void)size;
+	return -1;
+}
+#endif
+
+static unsigned int generate_seed() {
+#ifdef _WIN32
+	return (unsigned int)GetTickCount();
+#else
+	struct timespec ts;
+	if (clock_gettime(CLOCK_REALTIME, &ts) == 0)
+		return (unsigned int)(ts.tv_sec ^ ts.tv_nsec);
+	else
+		return (unsigned int)time(NULL);
+#endif
+}
+
+void juice_random(void *buf, size_t size) {
+	if (random_bytes(buf, size) == 0)
+		return;
+
+	// rand() is not thread-safe
+	static mutex_t rand_mutex = MUTEX_INITIALIZER;
+	mutex_lock(&rand_mutex);
+
+	static bool srandom_called = false;
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+#define random_func random
+#define srandom_func srandom
+	if (!srandom_called)
+		JLOG_DEBUG("Using random() for random bytes");
+#else
+#define random_func rand
+#define srandom_func srand
+	if (!srandom_called)
+		JLOG_WARN("Falling back on rand() for random bytes");
+#endif
+	if (!srandom_called) {
+		srandom_func(generate_seed());
+		srandom_called = true;
+	}
+	// RAND_MAX is guaranteed to be at least 2^15 - 1
+	uint8_t *bytes = buf;
+	for (size_t i = 0; i < size; ++i)
+		bytes[i] = (uint8_t)((random_func() & 0x7f80) >> 7);
+
+	mutex_unlock(&rand_mutex);
+}
+
+void juice_random_str64(char *buf, size_t size) {
+	static const char chars64[] =
+	    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	size_t i = 0;
+	for (i = 0; i + 1 < size; ++i) {
+		uint8_t byte = 0;
+		juice_random(&byte, 1);
+		buf[i] = chars64[byte & 0x3F];
+	}
+	buf[i] = '\0';
+}
+
+uint32_t juice_rand32(void) {
+	uint32_t r = 0;
+	juice_random(&r, sizeof(r));
+	return r;
+}
+
+uint64_t juice_rand64(void) {
+	uint64_t r = 0;
+	juice_random(&r, sizeof(r));
+	return r;
+}

--- a/Source/3rdParty/libjuice/src/random.h
+++ b/Source/3rdParty/libjuice/src/random.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_RANDOM_H
+#define JUICE_RANDOM_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+void juice_random(void *buf, size_t size);
+void juice_random_str64(char *buf, size_t size);
+
+uint32_t juice_rand32(void);
+uint64_t juice_rand64(void);
+
+#endif // JUICE_RANDOM_H

--- a/Source/3rdParty/libjuice/src/server.c
+++ b/Source/3rdParty/libjuice/src/server.c
@@ -1,0 +1,1189 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef NO_SERVER
+
+#include "server.h"
+#include "const_time.h"
+#include "hmac.h"
+#include "ice.h"
+#include "juice.h"
+#include "log.h"
+#include "random.h"
+#include "stun.h"
+#include "turn.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#define ALLOCATION_LIFETIME 600000 // ms
+
+// RFC 8656: The Permission Lifetime MUST be 300 seconds (= 5 minutes)
+#define PERMISSION_LIFETIME 300000 // ms
+
+// RFC 8656: Channel bindings last for 10 minutes unless refreshed
+#define BIND_LIFETIME 600000 // ms
+
+#define MAX_RELAYED_RECORDS_COUNT 8
+#define BUFFER_SIZE 4096
+
+static char *alloc_string_copy(const char *orig, bool *alloc_failed) {
+	if (!orig)
+		return NULL;
+
+	char *copy = malloc(strlen(orig) + 1);
+	if (!copy) {
+		if (alloc_failed)
+			*alloc_failed = true;
+
+		return NULL;
+	}
+	strcpy(copy, orig);
+	return copy;
+}
+
+static server_turn_alloc_t *find_allocation(server_turn_alloc_t allocs[], int size,
+                                            const addr_record_t *record, bool allow_deleted) {
+	unsigned long key = addr_record_hash(record, true) % size;
+	unsigned long pos = key;
+	while (!(allocs[pos].state == SERVER_TURN_ALLOC_EMPTY ||
+	         (allow_deleted && allocs[pos].state == SERVER_TURN_ALLOC_DELETED) ||
+	         addr_record_is_equal(&allocs[pos].record, record, true))) {
+		pos = (pos + 1) % size;
+		if (pos == key) {
+			JLOG_VERBOSE("TURN allocation map is full");
+			return NULL;
+		}
+	}
+	return allocs + pos;
+}
+
+static void delete_allocation(server_turn_alloc_t *alloc) {
+	if (alloc->state != SERVER_TURN_ALLOC_FULL)
+		return;
+
+	++alloc->credentials->allocations_quota;
+
+	alloc->state = SERVER_TURN_ALLOC_DELETED;
+	turn_destroy_map(&alloc->map);
+	closesocket(alloc->sock);
+	alloc->sock = INVALID_SOCKET;
+	alloc->credentials = NULL;
+}
+
+static thread_return_t THREAD_CALL server_thread_entry(void *arg) {
+	thread_set_name_self("juice server");
+	server_run((juice_server_t *)arg);
+	return (thread_return_t)0;
+}
+
+juice_server_t *server_create(const juice_server_config_t *config) {
+	JLOG_VERBOSE("Creating server");
+
+#ifdef _WIN32
+	WSADATA wsaData;
+	if (WSAStartup(MAKEWORD(2, 2), &wsaData)) {
+		JLOG_FATAL("WSAStartup failed");
+		return NULL;
+	}
+#endif
+
+	juice_server_t *server = calloc(1, sizeof(juice_server_t));
+	if (!server) {
+		JLOG_FATAL("Memory allocation for server data failed");
+		return NULL;
+	}
+
+	udp_socket_config_t socket_config;
+	memset(&socket_config, 0, sizeof(socket_config));
+	socket_config.bind_address = config->bind_address;
+	socket_config.port_begin = config->port;
+	socket_config.port_end = config->port;
+
+	server->sock = udp_create_socket(&socket_config);
+	if (server->sock == INVALID_SOCKET) {
+		JLOG_FATAL("Server socket opening failed");
+		free(server);
+		return NULL;
+	}
+
+	mutex_init(&server->mutex, MUTEX_RECURSIVE);
+
+	bool alloc_failed = false;
+	server->config.max_allocations =
+	    config->max_allocations > 0 ? config->max_allocations : SERVER_DEFAULT_MAX_ALLOCATIONS;
+	server->config.max_peers = config->max_peers;
+	server->config.bind_address = alloc_string_copy(config->bind_address, &alloc_failed);
+	server->config.external_address = alloc_string_copy(config->external_address, &alloc_failed);
+	server->config.port = config->port;
+	server->config.relay_port_range_begin = config->relay_port_range_begin;
+	server->config.relay_port_range_end = config->relay_port_range_end;
+	server->config.realm = alloc_string_copy(
+	    config->realm && *config->realm != '\0' ? config->realm : SERVER_DEFAULT_REALM,
+	    &alloc_failed);
+	if (alloc_failed) {
+		JLOG_FATAL("Memory allocation for server configuration failed");
+		goto error;
+	}
+
+	// Don't copy credentials but process them
+	server->config.credentials = NULL;
+	server->config.credentials_count = 0;
+	if (config->credentials_count <= 0) {
+		// TURN disabled
+		JLOG_INFO("TURN relaying disabled, STUN-only mode");
+		server->allocs = NULL;
+		server->allocs_count = 0;
+
+	} else {
+		// TURN enabled
+		server->allocs = calloc(server->config.max_allocations, sizeof(server_turn_alloc_t));
+		if (!server->allocs) {
+			JLOG_FATAL("Memory allocation for TURN allocation table failed");
+			goto error;
+		}
+		server->allocs_count = (int)server->config.max_allocations;
+
+		for (int i = 0; i < config->credentials_count; ++i) {
+			juice_server_credentials_t *credentials = config->credentials + i;
+			if (server->config.max_allocations < credentials->allocations_quota)
+				server->config.max_allocations = credentials->allocations_quota;
+
+			if (!server_do_add_credentials(server, credentials, 0)) { // never expires
+				JLOG_FATAL("Failed to add TURN credentials");
+				goto error;
+			}
+		}
+
+		juice_credentials_list_t *node = server->credentials;
+		while (node) {
+			juice_server_credentials_t *credentials = &node->credentials;
+			if (credentials->allocations_quota == 0) // unlimited
+				credentials->allocations_quota = server->config.max_allocations;
+
+			node = node->next;
+		}
+	}
+
+	server->config.port = udp_get_port(server->sock);
+	server->nonce_key_timestamp = 0;
+	if (server->config.max_peers == 0)
+		server->config.max_peers = SERVER_DEFAULT_MAX_PEERS;
+
+	if (server->config.bind_address)
+		JLOG_INFO("Created server on %s:%hu", server->config.bind_address, server->config.port);
+	else
+		JLOG_INFO("Created server on port %hu", server->config.port);
+
+	int ret = thread_init(&server->thread, server_thread_entry, server);
+	if (ret) {
+		JLOG_FATAL("Thread creation failed, error=%d", ret);
+		goto error;
+	}
+
+	return server;
+
+error:
+	server_do_destroy(server);
+	return NULL;
+}
+
+void server_do_destroy(juice_server_t *server) {
+	JLOG_DEBUG("Destroying server");
+
+	closesocket(server->sock);
+	mutex_destroy(&server->mutex);
+
+	server_turn_alloc_t *end = server->allocs + server->allocs_count;
+	for (server_turn_alloc_t *alloc = server->allocs; alloc < end; ++alloc) {
+		delete_allocation(alloc);
+	}
+	free((void *)server->allocs);
+
+	juice_credentials_list_t *node = server->credentials;
+	while (node) {
+		juice_credentials_list_t *prev = node;
+		node = node->next;
+		free((void *)prev->credentials.username);
+		free((void *)prev->credentials.password);
+		free(prev);
+	}
+
+	free((void *)server->config.bind_address);
+	free((void *)server->config.external_address);
+	free((void *)server->config.realm);
+	free(server);
+
+#ifdef _WIN32
+	WSACleanup();
+#endif
+	JLOG_VERBOSE("Destroyed server");
+}
+
+void server_destroy(juice_server_t *server) {
+	mutex_lock(&server->mutex);
+
+	JLOG_VERBOSE("Waiting for server thread");
+	server->thread_stopped = true;
+	mutex_unlock(&server->mutex);
+	server_interrupt(server);
+	thread_join(server->thread, NULL);
+
+	server_do_destroy(server);
+}
+
+uint16_t server_get_port(juice_server_t *server) {
+	mutex_lock(&server->mutex);
+	uint16_t port = server->config.port; // updated at creation
+	mutex_unlock(&server->mutex);
+	return port;
+}
+
+int server_add_credentials(juice_server_t *server, const juice_server_credentials_t *credentials,
+                           timediff_t lifetime) {
+	mutex_lock(&server->mutex);
+
+	if (server->config.max_allocations < credentials->allocations_quota)
+		server->config.max_allocations = credentials->allocations_quota;
+
+	if (server->allocs_count < (int)server->config.max_allocations) {
+		if (server->allocs_count == 0)
+			JLOG_INFO("Enabling TURN relaying");
+
+		server_turn_alloc_t *reallocated =
+		    realloc(server->allocs, server->config.max_allocations * sizeof(server_turn_alloc_t));
+		if (!reallocated) {
+			JLOG_ERROR("Memory allocation for TURN allocation table failed");
+			mutex_unlock(&server->mutex);
+			return -1;
+		}
+		memset(reallocated + server->allocs_count, 0,
+		       ((int)server->config.max_allocations - server->allocs_count) *
+		           sizeof(server_turn_alloc_t));
+		server->allocs_count = (int)server->config.max_allocations;
+		server->allocs = reallocated;
+	}
+
+	juice_credentials_list_t *node = server_do_add_credentials(server, credentials, lifetime);
+	if (!node) {
+		mutex_unlock(&server->mutex);
+		return -1;
+	}
+
+	if (node->credentials.allocations_quota == 0) // unlimited
+		node->credentials.allocations_quota = server->config.max_allocations;
+
+	mutex_unlock(&server->mutex);
+	return 0;
+}
+
+juice_credentials_list_t *server_do_add_credentials(juice_server_t *server,
+                                                    const juice_server_credentials_t *credentials,
+                                                    timediff_t lifetime) {
+	juice_credentials_list_t *node = calloc(1, sizeof(juice_credentials_list_t));
+	if (!node) {
+		JLOG_ERROR("Memory allocation for TURN credentials failed");
+		goto error;
+	}
+
+	bool alloc_failed = false;
+	node->credentials.username =
+	    alloc_string_copy(credentials->username ? credentials->username : "", &alloc_failed);
+	node->credentials.password =
+	    alloc_string_copy(credentials->password ? credentials->password : "", &alloc_failed);
+	node->credentials.allocations_quota = credentials->allocations_quota;
+	if (alloc_failed) {
+		JLOG_ERROR("Memory allocation for TURN credentials failed");
+		goto error;
+	}
+
+	stun_compute_userhash(node->credentials.username, server->config.realm, node->userhash);
+
+	if (lifetime > 0)
+		node->timestamp = current_timestamp() + lifetime;
+	else
+		node->timestamp = 0; // never expires
+
+	node->next = server->credentials;
+	server->credentials = node;
+	return server->credentials;
+
+error:
+	if (node) {
+		free((void *)node->credentials.username);
+		free((void *)node->credentials.password);
+		free(node);
+	}
+	return NULL;
+}
+
+void server_run(juice_server_t *server) {
+	mutex_lock(&server->mutex);
+	nfds_t nfd = 0;
+	struct pollfd *pfd = NULL;
+
+	// Main loop
+	timestamp_t next_timestamp;
+	while (server_bookkeeping(server, &next_timestamp) == 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		if (!pfd || nfd != (nfds_t)(1 + server->allocs_count)) {
+			free(pfd);
+			nfd = (nfds_t)(1 + server->allocs_count);
+			pfd = calloc(nfd, sizeof(struct pollfd));
+			if (!pfd) {
+				JLOG_FATAL("Memory allocation for poll descriptors failed");
+				break;
+			}
+		}
+
+		pfd[0].fd = server->sock;
+		pfd[0].events = POLLIN;
+
+		for (int i = 0; i < server->allocs_count; ++i) {
+			server_turn_alloc_t *alloc = server->allocs + i;
+			if (alloc->state == SERVER_TURN_ALLOC_FULL) {
+				pfd[1 + i].fd = alloc->sock;
+				pfd[1 + i].events = POLLIN;
+			} else {
+				pfd[1 + i].fd = -1; // ignore
+			}
+		}
+
+		JLOG_VERBOSE("Entering poll for %d ms", (int)timediff);
+		mutex_unlock(&server->mutex);
+		int ret = poll(pfd, nfd, (int)timediff);
+		mutex_lock(&server->mutex);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (server->thread_stopped) {
+			JLOG_VERBOSE("Server destruction requested");
+			break;
+		}
+
+		if (pfd[0].revents & POLLNVAL || pfd[0].revents & POLLERR) {
+			JLOG_FATAL("Error when polling server socket");
+			break;
+		}
+
+		if (pfd[0].revents & POLLIN) {
+			if (server_recv(server) < 0)
+				break;
+		}
+
+		for (int i = 0; i < server->allocs_count; ++i) {
+			server_turn_alloc_t *alloc = server->allocs + i;
+			if (alloc->state == SERVER_TURN_ALLOC_FULL && pfd[1 + i].revents & POLLIN)
+				server_forward(server, alloc);
+		}
+	}
+
+	JLOG_DEBUG("Leaving server thread");
+	free(pfd);
+	mutex_unlock(&server->mutex);
+}
+
+int server_send(juice_server_t *server, const addr_record_t *dst, const char *data, size_t size) {
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret = udp_sendto(server->sock, data, size, dst);
+	if (ret < 0 && sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK)
+		JLOG_WARN("Send failed, errno=%d", sockerrno);
+
+	return ret;
+}
+
+int server_stun_send(juice_server_t *server, const addr_record_t *dst, const stun_message_t *msg,
+                     const char *password) {
+	char buffer[BUFFER_SIZE];
+	int size = stun_write(buffer, BUFFER_SIZE, msg, password);
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+
+	if (server_send(server, dst, buffer, size) < 0) {
+		JLOG_WARN("STUN message send failed, errno=%d", sockerrno);
+		return -1;
+	}
+	return 0;
+}
+
+int server_recv(juice_server_t *server) {
+	JLOG_VERBOSE("Receiving datagrams");
+	while (true) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t record;
+		int len = udp_recvfrom(server->sock, buffer, BUFFER_SIZE, &record);
+		if (len < 0) {
+			if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+				JLOG_VERBOSE("No more datagrams to receive");
+				break;
+			}
+			JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+			return -1;
+		}
+		if (len == 0) {
+			// Empty datagram (used to interrupt)
+			continue;
+		}
+
+		addr_unmap_inet6_v4mapped((struct sockaddr *)&record.addr, &record.len);
+		server_input(server, buffer, len, &record);
+	}
+
+	return 0;
+}
+
+int server_forward(juice_server_t *server, server_turn_alloc_t *alloc) {
+	JLOG_VERBOSE("Forwarding datagrams");
+	while (true) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t record;
+		int len = udp_recvfrom(alloc->sock, buffer, BUFFER_SIZE, &record);
+		if (len < 0) {
+			if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+				break;
+			}
+			JLOG_WARN("recvfrom failed, errno=%d", sockerrno);
+			return -1;
+		}
+		addr_unmap_inet6_v4mapped((struct sockaddr *)&record.addr, &record.len);
+
+		// RFC 5766 8. Permissions:
+		// When a UDP datagram arrives at the relayed transport address for the allocation, the
+		// server extracts the source IP address from the IP header. The server then compares this
+		// address with the IP address associated with each permission in the list of permissions
+		// for the allocation. If no match is found, relaying is not permitted, and the server
+		// silently discards the UDP datagram.
+		if (!turn_has_permission(&alloc->map, &record)) {
+			if (JLOG_DEBUG_ENABLED) {
+				char record_str[ADDR_MAX_STRING_LEN];
+				addr_record_to_string(&record, record_str, ADDR_MAX_STRING_LEN);
+				JLOG_DEBUG("No permission for remote address %s, discarding", record_str);
+			}
+			return -1;
+		}
+
+		uint16_t channel;
+		if (turn_get_bound_channel(&alloc->map, &record, &channel)) {
+			// Use ChannelData
+			len = turn_wrap_channel_data(buffer, BUFFER_SIZE, buffer, len, channel);
+			if (len <= 0) {
+				JLOG_ERROR("TURN ChannelData wrapping failed");
+				return -1;
+			}
+
+			JLOG_VERBOSE("Forwarding as ChannelData, size=%d", len);
+
+			int ret = udp_sendto(server->sock, buffer, len, &alloc->record);
+			if (ret < 0 && sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK)
+				JLOG_WARN("Send failed, errno=%d", sockerrno);
+
+			return ret;
+
+		} else {
+			// Use TURN Data indication
+			JLOG_VERBOSE("Forwarding as TURN Data indication");
+
+			stun_message_t msg;
+			memset(&msg, 0, sizeof(msg));
+			msg.msg_class = STUN_CLASS_INDICATION;
+			msg.msg_method = STUN_METHOD_DATA;
+			msg.peers_size = 1;
+			msg.peers[0] = record;
+			msg.data = buffer;
+			msg.data_size = len;
+			juice_random(msg.transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+			return server_stun_send(server, &alloc->record, &msg, NULL);
+		}
+	}
+
+	return 0;
+}
+
+int server_input(juice_server_t *server, char *buf, size_t len, const addr_record_t *src) {
+	JLOG_VERBOSE("Received datagram, size=%d", len);
+
+	if (is_stun_datagram(buf, len)) {
+		if (JLOG_DEBUG_ENABLED) {
+			char src_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+			JLOG_DEBUG("Received STUN datagram from %s", src_str);
+		}
+		stun_message_t msg;
+		if (stun_read(buf, len, &msg) < 0) {
+			JLOG_ERROR("STUN message reading failed");
+			return -1;
+		}
+		return server_dispatch_stun(server, buf, len, &msg, src);
+	}
+
+	if (is_channel_data(buf, len)) {
+		if (JLOG_DEBUG_ENABLED) {
+			char src_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+			JLOG_DEBUG("Received ChannelData datagram from %s", src_str);
+		}
+		return server_process_channel_data(server, buf, len, src);
+	}
+
+	if (JLOG_WARN_ENABLED) {
+		char src_str[ADDR_MAX_STRING_LEN];
+		addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+		JLOG_WARN("Received unexpected non-STUN datagram from %s, ignoring", src_str);
+	}
+	return -1;
+}
+
+int server_interrupt(juice_server_t *server) {
+	JLOG_VERBOSE("Interrupting server thread");
+	mutex_lock(&server->mutex);
+	if (server->sock == INVALID_SOCKET) {
+		mutex_unlock(&server->mutex);
+		return -1;
+	}
+
+	char dummy = 0; // Some C libraries might error out on NULL pointers
+	if (udp_sendto_self(server->sock, &dummy, 0) < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+			JLOG_WARN("Failed to interrupt thread by triggering socket, errno=%d", sockerrno);
+			mutex_unlock(&server->mutex);
+			return -1;
+		}
+	}
+
+	mutex_unlock(&server->mutex);
+	return 0;
+}
+
+int server_bookkeeping(juice_server_t *server, timestamp_t *next_timestamp) {
+	timestamp_t now = current_timestamp();
+	*next_timestamp = now + 60000;
+
+	// Handle allocations
+	for (int i = 0; i < server->allocs_count; ++i) {
+		server_turn_alloc_t *alloc = server->allocs + i;
+		if (alloc->state != SERVER_TURN_ALLOC_FULL)
+			continue;
+
+		if (alloc->timestamp <= now) {
+			JLOG_DEBUG("Allocation timed out");
+			delete_allocation(alloc);
+			continue;
+		}
+
+		if (alloc->timestamp < *next_timestamp)
+			*next_timestamp = alloc->timestamp;
+	}
+
+	// Handle credentials
+	juice_credentials_list_t **pnode = &server->credentials; // We are deleting some elements
+	while (*pnode) {
+		if ((*pnode)->timestamp && (*pnode)->timestamp <= now) {
+			JLOG_DEBUG("Credentials timed out");
+			juice_credentials_list_t *next = (*pnode)->next;
+			free((void *)(*pnode)->credentials.username);
+			free((void *)(*pnode)->credentials.password);
+			free((*pnode));
+			*pnode = next;
+			continue;
+		}
+
+		pnode = &(*pnode)->next;
+	}
+
+	return 0;
+}
+
+void server_get_nonce(juice_server_t *server, const addr_record_t *src, char *nonce) {
+	timestamp_t now = current_timestamp();
+	if (now >= server->nonce_key_timestamp) {
+		juice_random(server->nonce_key, SERVER_NONCE_KEY_SIZE);
+		server->nonce_key_timestamp = now + SERVER_NONCE_KEY_LIFETIME;
+	}
+
+	uint8_t digest[HMAC_SHA256_SIZE];
+	hmac_sha256(&src->addr, src->len, server->nonce_key, SERVER_NONCE_KEY_SIZE, digest);
+
+	size_t len = HMAC_SHA256_SIZE;
+	if (len > STUN_MAX_NONCE_LEN)
+		len = STUN_MAX_NONCE_LEN;
+
+	// RFC 4648 base64url character table
+	const char *table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+	for (size_t i = 0; i < len; ++i)
+		nonce[i] = table[digest[i] % 64];
+
+	nonce[len] = '\0';
+
+	stun_prepend_nonce_cookie(nonce);
+}
+
+void server_prepare_credentials(juice_server_t *server, const addr_record_t *src,
+                                const juice_server_credentials_t *credentials,
+                                stun_message_t *msg) {
+	snprintf(msg->credentials.realm, STUN_MAX_REALM_LEN, "%s", server->config.realm);
+	server_get_nonce(server, src, msg->credentials.nonce);
+
+	if (credentials)
+		snprintf(msg->credentials.username, STUN_MAX_USERNAME_LEN, "%s", credentials->username);
+}
+
+int server_dispatch_stun(juice_server_t *server, void *buf, size_t size, stun_message_t *msg,
+                         const addr_record_t *src) {
+
+	if (!(msg->msg_class == STUN_CLASS_REQUEST ||
+	      (msg->msg_class == STUN_CLASS_INDICATION &&
+	       (msg->msg_method == STUN_METHOD_BINDING || msg->msg_method == STUN_METHOD_SEND)))) {
+		JLOG_WARN("Unexpected STUN message, class=0x%X, method=0x%X", msg->msg_class,
+		          msg->msg_method);
+		return -1;
+	}
+
+	if (server->allocs_count == 0 && msg->msg_method != STUN_METHOD_BINDING) {
+		// TURN support is disabled
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                400, // Bad request
+		                                NULL);
+	}
+
+	if (msg->error_code == STUN_ERROR_INTERNAL_VALIDATION_FAILED) {
+		if (msg->msg_class == STUN_CLASS_REQUEST) {
+			JLOG_WARN("Invalid STUN message, answering bad request error response");
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                400, // Bad request
+			                                NULL);
+		} else {
+			JLOG_WARN("Invalid STUN message, dropping");
+			return -1;
+		}
+	}
+
+	juice_server_credentials_t *credentials = NULL;
+	if (msg->msg_method != STUN_METHOD_BINDING && msg->msg_class != STUN_CLASS_INDICATION) {
+		if (!msg->has_integrity || //
+		    *msg->credentials.realm == '\0' || *msg->credentials.nonce == '\0' ||
+		    (*msg->credentials.username == '\0' && !msg->credentials.enable_userhash)) {
+			JLOG_DEBUG("Answering STUN unauthorized error response");
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                401,   // Unauthorized
+			                                NULL); // No username
+		}
+
+		char nonce[STUN_MAX_NONCE_LEN];
+		server_get_nonce(server, src, nonce);
+		if (strcmp(msg->credentials.nonce, nonce) != 0 ||
+		    strcmp(msg->credentials.realm, server->config.realm) != 0) {
+			JLOG_DEBUG("Answering STUN stale nonce error response");
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                438,   // Stale nonce
+			                                NULL); // No username
+		}
+
+		timestamp_t now = current_timestamp();
+		if (msg->credentials.enable_userhash) {
+			juice_credentials_list_t *node = server->credentials;
+			while (node) {
+				if ((!node->timestamp || node->timestamp > now) &&
+				    const_time_memcmp(node->userhash, msg->credentials.userhash, USERHASH_SIZE) ==
+				        0) {
+					credentials = &node->credentials;
+				}
+				node = node->next;
+			}
+
+			if (credentials)
+				snprintf(msg->credentials.username, STUN_MAX_USERNAME_LEN, "%s",
+				         credentials->username);
+			else
+				JLOG_WARN("No credentials for userhash");
+
+		} else {
+			juice_credentials_list_t *node = server->credentials;
+			while (node) {
+				if ((!node->timestamp || node->timestamp > now) &&
+				    const_time_strcmp(node->credentials.username, msg->credentials.username) == 0) {
+					credentials = &node->credentials;
+				}
+				node = node->next;
+			}
+
+			if (!credentials)
+				JLOG_WARN("No credentials for username \"%s\"", msg->credentials.username);
+		}
+		if (!credentials) {
+			server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                         401,   // Unauthorized
+			                         NULL); // No username
+			return -1;
+		}
+
+		// Check credentials
+		if (!stun_check_integrity(buf, size, msg, credentials->password)) {
+			JLOG_WARN("STUN authentication failed for username \"%s\"", msg->credentials.username);
+			server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                         401,   // Unauthorized
+			                         NULL); // No username
+			return -1;
+		}
+	}
+
+	switch (msg->msg_method) {
+	case STUN_METHOD_BINDING:
+		return server_process_stun_binding(server, msg, src);
+
+	case STUN_METHOD_ALLOCATE:
+	case STUN_METHOD_REFRESH:
+		return server_process_turn_allocate(server, msg, src, credentials);
+
+	case STUN_METHOD_CREATE_PERMISSION:
+		return server_process_turn_create_permission(server, msg, src, credentials);
+
+	case STUN_METHOD_CHANNEL_BIND:
+		return server_process_turn_channel_bind(server, msg, src, credentials);
+
+	case STUN_METHOD_SEND:
+		return server_process_turn_send(server, msg, src);
+
+	default:
+		JLOG_WARN("Unknown STUN method 0x%X, ignoring", msg->msg_method);
+		return -1;
+	}
+}
+
+int server_answer_stun_binding(juice_server_t *server, const uint8_t *transaction_id,
+                               const addr_record_t *src) {
+	JLOG_DEBUG("Answering STUN Binding request");
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	ans.msg_class = STUN_CLASS_RESP_SUCCESS;
+	ans.msg_method = STUN_METHOD_BINDING;
+	ans.mapped = *src;
+	memcpy(ans.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	char buffer[BUFFER_SIZE];
+	int size = stun_write(buffer, BUFFER_SIZE, &ans, NULL);
+	if (size <= 0) {
+		JLOG_ERROR("STUN message write failed");
+		return -1;
+	}
+
+	if (server_send(server, src, buffer, size) < 0) {
+		JLOG_WARN("STUN message send failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	return 0;
+}
+
+int server_answer_stun_error(juice_server_t *server, const uint8_t *transaction_id,
+                             const addr_record_t *src, stun_method_t method, unsigned int code,
+                             const juice_server_credentials_t *credentials) {
+	JLOG_DEBUG("Answering STUN error response with code %u", code);
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	ans.msg_class = STUN_CLASS_RESP_ERROR;
+	ans.msg_method = method;
+	ans.error_code = code;
+	memcpy(ans.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	if (method != STUN_METHOD_BINDING)
+		server_prepare_credentials(server, src, credentials, &ans);
+
+	return server_stun_send(server, src, &ans, credentials ? credentials->password : NULL);
+}
+
+int server_process_stun_binding(juice_server_t *server, const stun_message_t *msg,
+                                const addr_record_t *src) {
+	if (JLOG_INFO_ENABLED) {
+		char src_str[ADDR_MAX_STRING_LEN];
+		addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+		JLOG_INFO("Got STUN binding from client %s", src_str);
+	}
+
+	return server_answer_stun_binding(server, msg->transaction_id, src);
+}
+
+int server_process_turn_allocate(juice_server_t *server, const stun_message_t *msg,
+                                 const addr_record_t *src,
+                                 juice_server_credentials_t *credentials) {
+	if (msg->msg_class != STUN_CLASS_REQUEST)
+		return -1;
+
+	if (msg->msg_method != STUN_METHOD_ALLOCATE && msg->msg_method != STUN_METHOD_REFRESH)
+		return -1;
+
+	JLOG_DEBUG("Processing TURN Allocate request");
+
+	server_turn_alloc_t *alloc = find_allocation(server->allocs, server->allocs_count, src, true);
+	if (!alloc) {
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                486, // Allocation quota reached
+		                                credentials);
+	}
+
+	if (alloc->state == SERVER_TURN_ALLOC_FULL) {
+		// Allocation exists
+		if (msg->msg_method == STUN_METHOD_ALLOCATE &&
+		    memcmp(alloc->transaction_id, msg->transaction_id, STUN_TRANSACTION_ID_SIZE) != 0) {
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                437, // Allocation mismatch
+			                                credentials);
+		}
+
+		if (alloc->credentials != credentials) {
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                441, // Wrong credentials
+			                                credentials);
+		}
+	} else {
+		// Allocation does not exist
+		if (msg->msg_method == STUN_METHOD_REFRESH) {
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                437, // Allocation mismatch
+			                                credentials);
+		}
+
+		if (credentials->allocations_quota <= 0) {
+			return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+			                                486, // Allocation quota reached
+			                                credentials);
+		}
+
+		udp_socket_config_t socket_config;
+		memset(&socket_config, 0, sizeof(socket_config));
+		socket_config.bind_address = server->config.bind_address;
+		socket_config.port_begin = server->config.relay_port_range_begin;
+		socket_config.port_end = server->config.relay_port_range_end;
+		alloc->sock = udp_create_socket(&socket_config);
+		if (alloc->sock == INVALID_SOCKET) {
+			server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method, 500,
+			                         credentials);
+			return -1;
+		}
+		if (turn_init_map(&alloc->map, server->config.max_peers) < 0) {
+			closesocket(alloc->sock);
+			alloc->sock = INVALID_SOCKET;
+			server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method, 500,
+			                         credentials);
+			return -1;
+		}
+
+		alloc->state = SERVER_TURN_ALLOC_FULL;
+		alloc->record = *src;
+		alloc->credentials = credentials;
+
+		--credentials->allocations_quota;
+	}
+
+	uint32_t lifetime = ALLOCATION_LIFETIME / 1000;
+	if (msg->lifetime_set && msg->lifetime < lifetime)
+		lifetime = msg->lifetime;
+
+	alloc->timestamp = current_timestamp() + lifetime * 1000;
+	memcpy(alloc->transaction_id, msg->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	addr_record_t records[MAX_RELAYED_RECORDS_COUNT];
+	const addr_record_t *relayed = NULL;
+	if (lifetime == 0) {
+		delete_allocation(alloc);
+
+	} else {
+		int count = 0;
+		if (server->config.external_address) {
+			char service[8];
+			snprintf(service, 8, "%hu", udp_get_port(alloc->sock));
+			count = addr_resolve(server->config.external_address, service, SOCK_DGRAM, records,
+			                     MAX_RELAYED_RECORDS_COUNT);
+			if (count <= 0) {
+				JLOG_ERROR("Specified external address is invalid");
+				goto error;
+			}
+		} else {
+			count = udp_get_addrs(alloc->sock, records, MAX_RELAYED_RECORDS_COUNT);
+			if (count <= 0) {
+				JLOG_ERROR("No local address found");
+				goto error;
+			}
+		}
+
+		if (count > MAX_RELAYED_RECORDS_COUNT)
+			count = MAX_RELAYED_RECORDS_COUNT;
+
+		for (int i = 0; i < count; ++i) {
+			const addr_record_t *record = records + i;
+			if (record->addr.ss_family == AF_INET || !relayed) {
+				relayed = record;
+				if (record->addr.ss_family == AF_INET)
+					break;
+			}
+		}
+
+		if (!relayed) {
+			JLOG_ERROR("No advertisable relayed address found");
+			goto error;
+		}
+
+		if (JLOG_INFO_ENABLED) {
+			char src_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(src, src_str, ADDR_MAX_STRING_LEN);
+			char relayed_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(relayed, relayed_str, ADDR_MAX_STRING_LEN);
+			JLOG_INFO("Allocated TURN relayed address %s for client %s", relayed_str, src_str);
+		}
+	}
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	ans.msg_class = STUN_CLASS_RESP_SUCCESS;
+	ans.msg_method = msg->msg_method;
+	ans.lifetime = lifetime;
+	ans.lifetime_set = true;
+	ans.mapped = *src;
+	if (relayed)
+		ans.relayed = *relayed;
+	memcpy(ans.transaction_id, msg->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	server_prepare_credentials(server, src, credentials, &ans);
+
+	return server_stun_send(server, src, &ans, credentials->password);
+
+error:
+	delete_allocation(alloc);
+	server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method, 500, credentials);
+	return -1;
+}
+
+int server_process_turn_create_permission(juice_server_t *server, const stun_message_t *msg,
+                                          const addr_record_t *src,
+                                          const juice_server_credentials_t *credentials) {
+	if (msg->msg_class != STUN_CLASS_REQUEST)
+		return -1;
+
+	JLOG_DEBUG("Processing STUN CreatePermission request");
+
+	// RFC 5766 9.2. Receiving a CreatePermission Request:
+	// The CreatePermission request MUST contain at least one XOR-PEER-ADDRESS attribute and MAY
+	// contain multiple such attributes. If no such attribute exists, or if any of these attributes
+	// are invalid, then a 400 (Bad Request) error is returned.
+	if (!msg->peers_size) {
+		JLOG_WARN("Missing peer address in TURN CreatePermission request");
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                400, // Bad request
+		                                credentials);
+	}
+
+	server_turn_alloc_t *alloc = find_allocation(server->allocs, server->allocs_count, src, false);
+	if (!alloc || alloc->state != SERVER_TURN_ALLOC_FULL) {
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                437, // Allocation mismatch
+		                                credentials);
+	}
+	if (alloc->credentials != credentials) {
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                441, // Wrong credentials
+		                                credentials);
+	}
+
+	for (size_t i = 0; i < msg->peers_size; ++i) {
+		const addr_record_t *peer = msg->peers + i;
+		if (!turn_set_permission(&alloc->map, msg->transaction_id, peer, PERMISSION_LIFETIME)) {
+			server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method, 500,
+			                         credentials);
+			return -1;
+		}
+	}
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	ans.msg_class = STUN_CLASS_RESP_SUCCESS;
+	ans.msg_method = STUN_METHOD_CREATE_PERMISSION;
+	memcpy(ans.transaction_id, msg->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	server_prepare_credentials(server, src, credentials, &ans);
+
+	return server_stun_send(server, src, &ans, credentials->password);
+}
+
+int server_process_turn_channel_bind(juice_server_t *server, const stun_message_t *msg,
+                                     const addr_record_t *src,
+                                     const juice_server_credentials_t *credentials) {
+	if (msg->msg_class != STUN_CLASS_REQUEST)
+		return -1;
+
+	JLOG_DEBUG("Processing STUN ChannelBind request");
+
+	if (!msg->peers_size) {
+		JLOG_WARN("Missing peer address in TURN ChannelBind request");
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                400, // Bad request
+		                                credentials);
+	}
+	if (!msg->channel_number) {
+		JLOG_WARN("Missing channel number in TURN ChannelBind request");
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                400, // Bad request
+		                                credentials);
+	}
+
+	server_turn_alloc_t *alloc = find_allocation(server->allocs, server->allocs_count, src, false);
+	if (!alloc || alloc->state != SERVER_TURN_ALLOC_FULL) {
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                437, // Allocation mismatch
+		                                credentials);
+	}
+	if (alloc->credentials != credentials) {
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                441, // Wrong credentials
+		                                credentials);
+	}
+
+	uint16_t channel = msg->channel_number;
+	if (!is_valid_channel(channel)) {
+		JLOG_WARN("TURN channel 0x%hX is invalid", channel);
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                400, // Bad request
+		                                credentials);
+	}
+
+	// RFC 5766 11.3. Receiving a ChannelBind Response
+	// When the client receives a ChannelBind success response, it updates its data structures to
+	// record that the channel binding is now active. It also updates its data structures to record
+	// that the corresponding permission has been installed or refreshed.
+	const addr_record_t *peer = msg->peers;
+	if (!turn_bind_channel(&alloc->map, peer, msg->transaction_id, channel, BIND_LIFETIME)) {
+		server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method, 500,
+		                         credentials);
+		return -1;
+	}
+	if (!turn_set_permission(&alloc->map, msg->transaction_id, peer, PERMISSION_LIFETIME)) {
+		server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method, 500,
+		                         credentials);
+		return -1;
+	}
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	ans.msg_class = STUN_CLASS_RESP_SUCCESS;
+	ans.msg_method = STUN_METHOD_CHANNEL_BIND;
+	memcpy(ans.transaction_id, msg->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	server_prepare_credentials(server, src, credentials, &ans);
+
+	return server_stun_send(server, src, &ans, credentials->password);
+}
+
+int server_process_turn_send(juice_server_t *server, const stun_message_t *msg,
+                             const addr_record_t *src) {
+	if (msg->msg_class != STUN_CLASS_INDICATION)
+		return -1;
+
+	JLOG_DEBUG("Processing STUN Send indication");
+
+	if (!msg->data) {
+		JLOG_WARN("Missing data in TURN Send indication");
+		return -1;
+	}
+	if (!msg->peers_size) {
+		JLOG_WARN("Missing peer address in TURN Send indication");
+		return -1;
+	}
+
+	server_turn_alloc_t *alloc = find_allocation(server->allocs, server->allocs_count, src, false);
+	if (!alloc || alloc->state != SERVER_TURN_ALLOC_FULL) {
+		JLOG_WARN("Allocation mismatch for TURN Send indication");
+		return -1;
+	}
+
+	const addr_record_t *peer = msg->peers;
+	if (!turn_has_permission(&alloc->map, peer)) {
+		if (JLOG_WARN_ENABLED) {
+			char peer_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(peer, peer_str, ADDR_MAX_STRING_LEN);
+			JLOG_WARN("No permission for peer address %s", peer_str);
+		}
+		return -1;
+	}
+
+	JLOG_VERBOSE("Forwarding datagram to peer, size=%zu", msg->data_size);
+
+	int ret = udp_sendto(alloc->sock, msg->data, msg->data_size, peer);
+	if (ret < 0 && sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK)
+		JLOG_WARN("Forwarding failed, errno=%d", sockerrno);
+
+	return ret;
+}
+
+int server_process_channel_data(juice_server_t *server, char *buf, size_t len,
+                                const addr_record_t *src) {
+	server_turn_alloc_t *alloc = find_allocation(server->allocs, server->allocs_count, src, false);
+	if (!alloc || alloc->state != SERVER_TURN_ALLOC_FULL) {
+		JLOG_WARN("Allocation mismatch for TURN Channel Data");
+		return -1;
+	}
+
+	if (len < sizeof(struct channel_data_header)) {
+		JLOG_WARN("ChannelData is too short");
+		return -1;
+	}
+
+	const struct channel_data_header *header = (const struct channel_data_header *)buf;
+	buf += sizeof(struct channel_data_header);
+	len -= sizeof(struct channel_data_header);
+	uint16_t channel = ntohs(header->channel_number);
+	uint16_t length = ntohs(header->length);
+	JLOG_VERBOSE("Received ChannelData, channel=0x%hX, length=%hu", channel, length);
+	if (length > len) {
+		JLOG_WARN("ChannelData has invalid length");
+		return -1;
+	}
+	len = length;
+
+	addr_record_t record;
+	if (!turn_find_bound_channel(&alloc->map, channel, &record)) {
+		JLOG_WARN("Channel 0x%hX is not bound", channel);
+		return -1;
+	}
+
+	JLOG_VERBOSE("Forwarding datagram to peer, size=%zu", len);
+
+	int ret = udp_sendto(alloc->sock, buf, len, &record);
+	if (ret < 0 && sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK)
+		JLOG_WARN("Send failed, errno=%d", sockerrno);
+
+	return 0;
+}
+
+#endif // ifndef NO_SERVER

--- a/Source/3rdParty/libjuice/src/server.h
+++ b/Source/3rdParty/libjuice/src/server.h
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_SERVER_H
+#define JUICE_SERVER_H
+
+#ifndef NO_SERVER
+
+#include "addr.h"
+#include "juice.h"
+#include "socket.h"
+#include "stun.h"
+#include "thread.h"
+#include "timestamp.h"
+#include "turn.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define SERVER_DEFAULT_REALM "libjuice"
+#define SERVER_DEFAULT_MAX_ALLOCATIONS 1000 // should be 1024-1 or less to be safe for poll()
+#define SERVER_DEFAULT_MAX_PEERS 16
+
+#define SERVER_NONCE_KEY_SIZE 32
+
+// RFC 8656: The server [...] SHOULD expire the nonce at least once every hour during the lifetime
+// of the allocation
+#define SERVER_NONCE_KEY_LIFETIME 600 * 1000 // 10 min
+
+typedef enum server_turn_alloc_state {
+	SERVER_TURN_ALLOC_EMPTY,
+	SERVER_TURN_ALLOC_DELETED,
+	SERVER_TURN_ALLOC_FULL
+} server_turn_alloc_state_t;
+
+typedef struct server_turn_alloc {
+	server_turn_alloc_state_t state;
+	addr_record_t record;
+	juice_server_credentials_t *credentials;
+	uint8_t transaction_id[STUN_TRANSACTION_ID_SIZE];
+	timestamp_t timestamp;
+	socket_t sock;
+	turn_map_t map;
+} server_turn_alloc_t;
+
+typedef struct juice_credentials_list {
+	struct juice_credentials_list *next;
+	juice_server_credentials_t credentials;
+	uint8_t userhash[USERHASH_SIZE];
+	timestamp_t timestamp;
+} juice_credentials_list_t;
+
+typedef struct juice_server {
+	juice_server_config_t config;          // Note config.credentials will be empty
+	juice_credentials_list_t *credentials; // Credentials are stored in this list
+	uint8_t nonce_key[SERVER_NONCE_KEY_SIZE];
+	timestamp_t nonce_key_timestamp;
+	socket_t sock;
+	thread_t thread;
+	mutex_t mutex;
+	bool thread_stopped;
+	server_turn_alloc_t *allocs;
+	int allocs_count;
+} juice_server_t;
+
+juice_server_t *server_create(const juice_server_config_t *config);
+void server_do_destroy(juice_server_t *server);
+void server_destroy(juice_server_t *server);
+
+uint16_t server_get_port(juice_server_t *server);
+int server_add_credentials(juice_server_t *server, const juice_server_credentials_t *credentials,
+                           timediff_t lifetime);
+
+juice_credentials_list_t *server_do_add_credentials(juice_server_t *server,
+                                                    const juice_server_credentials_t *credentials,
+                                                    timediff_t lifetime); // internal
+
+void server_run(juice_server_t *server);
+int server_send(juice_server_t *agent, const addr_record_t *dst, const char *data, size_t size);
+int server_stun_send(juice_server_t *server, const addr_record_t *dst, const stun_message_t *msg,
+                     const char *password // password may be NULL
+);
+int server_recv(juice_server_t *server);
+int server_forward(juice_server_t *server, server_turn_alloc_t *alloc);
+int server_input(juice_server_t *agent, char *buf, size_t len, const addr_record_t *src);
+int server_interrupt(juice_server_t *server);
+int server_bookkeeping(juice_server_t *agent, timestamp_t *next_timestamp);
+
+void server_get_nonce(juice_server_t *server, const addr_record_t *src, char *nonce);
+void server_prepare_credentials(juice_server_t *server, const addr_record_t *src,
+                                const juice_server_credentials_t *credentials, stun_message_t *msg);
+
+int server_dispatch_stun(juice_server_t *server, void *buf, size_t size, stun_message_t *msg,
+                         const addr_record_t *src);
+int server_answer_stun_binding(juice_server_t *server, const uint8_t *transaction_id,
+                               const addr_record_t *src);
+int server_answer_stun_error(juice_server_t *server, const uint8_t *transaction_id,
+                             const addr_record_t *src, stun_method_t method, unsigned int code,
+                             const juice_server_credentials_t *credentials);
+
+int server_process_stun_binding(juice_server_t *server, const stun_message_t *msg,
+                                const addr_record_t *src);
+int server_process_turn_allocate(juice_server_t *server, const stun_message_t *msg,
+                                 const addr_record_t *src, juice_server_credentials_t *credentials);
+int server_process_turn_create_permission(juice_server_t *server, const stun_message_t *msg,
+                                          const addr_record_t *src,
+                                          const juice_server_credentials_t *credentials);
+int server_process_turn_channel_bind(juice_server_t *server, const stun_message_t *msg,
+                                     const addr_record_t *src,
+                                     const juice_server_credentials_t *credentials);
+int server_process_turn_send(juice_server_t *server, const stun_message_t *msg,
+                             const addr_record_t *src);
+int server_process_channel_data(juice_server_t *server, char *buf, size_t len,
+                                const addr_record_t *src);
+
+#endif // ifndef NO_SERVER
+
+#endif

--- a/Source/3rdParty/libjuice/src/socket.h
+++ b/Source/3rdParty/libjuice/src/socket.h
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_SOCKET_H
+#define JUICE_SOCKET_H
+
+#ifdef _WIN32
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601 // Windows 7
+#endif
+#ifndef __MSVCRT_VERSION__
+#define __MSVCRT_VERSION__ 0x0601
+#endif
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+//
+#include <iphlpapi.h>
+#include <windows.h>
+
+#ifdef __MINGW32__
+#include <sys/stat.h>
+#include <sys/time.h>
+#ifndef IPV6_V6ONLY
+#define IPV6_V6ONLY 27
+#endif
+#endif
+
+#define NO_IFADDRS
+#define NO_PMTUDISC
+
+typedef SOCKET socket_t;
+typedef SOCKADDR sockaddr;
+typedef ULONG ctl_t;
+typedef DWORD sockopt_t;
+#define sockerrno ((int)WSAGetLastError())
+#define IP_DONTFRAG IP_DONTFRAGMENT
+#define HOST_NAME_MAX 256
+
+#define poll WSAPoll
+typedef ULONG nfds_t;
+
+#define SEADDRINUSE WSAEADDRINUSE
+#define SEINTR WSAEINTR
+#define SEAGAIN WSAEWOULDBLOCK
+#define SEACCES WSAEACCES
+#define SEWOULDBLOCK WSAEWOULDBLOCK
+#define SEINPROGRESS WSAEINPROGRESS
+#define SECONNREFUSED WSAECONNREFUSED
+#define SECONNRESET WSAECONNRESET
+#define SENETRESET WSAENETRESET
+#define SEMSGSIZE WSAEMSGSIZE
+#define SENETUNREACH WSAENETUNREACH
+
+#else // assume POSIX
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <net/if.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef __linux__
+#define NO_PMTUDISC
+#endif
+
+#ifdef __ANDROID__
+#define NO_IFADDRS
+#else
+#include <ifaddrs.h>
+#endif
+
+typedef int socket_t;
+typedef int ctl_t;
+typedef int sockopt_t;
+#define sockerrno errno
+#define INVALID_SOCKET -1
+#define ioctlsocket ioctl
+#define closesocket close
+
+#define SEADDRINUSE EADDRINUSE
+#define SEINTR EINTR
+#define SEAGAIN EAGAIN
+#define SEACCES EACCES
+#define SEWOULDBLOCK EWOULDBLOCK
+#define SEINPROGRESS EINPROGRESS
+#define SECONNREFUSED ECONNREFUSED
+#define SECONNRESET ECONNRESET
+#define SENETRESET ENETRESET
+#define SEMSGSIZE EMSGSIZE
+#define SENETUNREACH ENETUNREACH
+
+#endif // _WIN32
+
+#ifndef IN6_IS_ADDR_LOOPBACK
+#define IN6_IS_ADDR_LOOPBACK(a)                                                                    \
+	(((const uint32_t *)(a))[0] == 0 && ((const uint32_t *)(a))[1] == 0 &&                         \
+	 ((const uint32_t *)(a))[2] == 0 && ((const uint32_t *)(a))[3] == htonl(1))
+#endif
+
+#ifndef IN6_IS_ADDR_LINKLOCAL
+#define IN6_IS_ADDR_LINKLOCAL(a)                                                                   \
+	((((const uint32_t *)(a))[0] & htonl(0xffc00000)) == htonl(0xfe800000))
+#endif
+
+#ifndef IN6_IS_ADDR_SITELOCAL
+#define IN6_IS_ADDR_SITELOCAL(a)                                                                   \
+	((((const uint32_t *)(a))[0] & htonl(0xffc00000)) == htonl(0xfec00000))
+#endif
+
+#ifndef IN6_IS_ADDR_V4MAPPED
+#define IN6_IS_ADDR_V4MAPPED(a)                                                                    \
+	((((const uint32_t *)(a))[0] == 0) && (((const uint32_t *)(a))[1] == 0) &&                     \
+	 (((const uint32_t *)(a))[2] == htonl(0xFFFF)))
+#endif
+
+#endif // JUICE_SOCKET_H

--- a/Source/3rdParty/libjuice/src/stun.c
+++ b/Source/3rdParty/libjuice/src/stun.c
@@ -1,0 +1,1256 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "stun.h"
+#include "base64.h"
+#include "const_time.h"
+#include "crc32.h"
+#include "juice.h"
+#include "log.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define STUN_MAGIC 0x2112A442
+#define STUN_FINGERPRINT_XOR 0x5354554E // "STUN"
+#define STUN_ATTR_SIZE sizeof(struct stun_attr)
+
+// STUN_MAX_PASSWORD_LEN > HASH_SHA256_SIZE > HASH_MD5_SIZE
+#define MAX_HMAC_KEY_LEN STUN_MAX_PASSWORD_LEN
+
+#define MAX_HMAC_INPUT_LEN (STUN_MAX_USERNAME_LEN + STUN_MAX_REALM_LEN + STUN_MAX_PASSWORD_LEN + 2)
+
+#define MAX_USERHASH_INPUT_LEN (STUN_MAX_USERNAME_LEN + STUN_MAX_REALM_LEN + 1)
+
+#ifndef htonll
+#define htonll(x)                                                                                  \
+	((uint64_t)(((uint64_t)htonl((uint32_t)(x))) << 32) | (uint64_t)htonl((uint32_t)((x) >> 32)))
+#endif
+#ifndef ntohll
+#define ntohll(x) htonll(x)
+#endif
+
+static size_t align32(size_t len) {
+	while (len & 0x03)
+		++len;
+	return len;
+}
+
+static void generate_mask(const uint8_t *transaction_id, uint8_t *mask) {
+	// mask is 16 bytes
+	const uint32_t magic = htonl(STUN_MAGIC);
+	memcpy(mask, (const uint8_t*)&magic, 4);
+	memcpy(mask + 4, transaction_id, 12);
+}
+
+static size_t generate_hmac_key(const stun_message_t *msg, const char *password, void *key) {
+	if (*msg->credentials.realm != '\0') {
+		// long-term credentials
+		if (*msg->credentials.username == '\0')
+			JLOG_WARN("Generating HMAC key for long-term credentials with empty STUN username");
+
+		char input[MAX_HMAC_INPUT_LEN];
+		int input_len = snprintf(input, MAX_HMAC_INPUT_LEN, "%s:%s:%s", msg->credentials.username,
+		                         msg->credentials.realm, password ? password : "");
+		if (input_len < 0)
+			return 0;
+
+		if (input_len >= MAX_HMAC_INPUT_LEN)
+			input_len = MAX_HMAC_INPUT_LEN - 1;
+
+		switch (msg->credentials.password_algorithm) {
+		case STUN_PASSWORD_ALGORITHM_SHA256:
+			juice_hash_sha256(input, input_len, key);
+			return HASH_SHA256_SIZE;
+		default:
+			juice_hash_md5(input, input_len, key);
+			return HASH_MD5_SIZE;
+		}
+	} else {
+		// short-term credentials
+		int key_len = snprintf((char *)key, MAX_HMAC_KEY_LEN, "%s", password ? password : "");
+		if (key_len < 0)
+			return 0;
+
+		if (key_len >= MAX_HMAC_KEY_LEN)
+			key_len = MAX_HMAC_KEY_LEN - 1;
+
+		return key_len;
+	}
+}
+
+static size_t generate_password_algorithms_attr(uint8_t *attr) {
+	// attr size must be at least STUN_PASSWORD_ALGORITHMS_ATTR_MAX_SIZE
+	struct stun_value_password_algorithm *pwa = (struct stun_value_password_algorithm *)attr;
+	pwa->algorithm = htons(STUN_PASSWORD_ALGORITHM_SHA256);
+	pwa->parameters_length = 0;
+	++pwa;
+	pwa->algorithm = htons(STUN_PASSWORD_ALGORITHM_MD5);
+	pwa->parameters_length = 0;
+	++pwa;
+	return (uint8_t *)pwa - attr;
+}
+
+int stun_write(void *buf, size_t size, const stun_message_t *msg, const char *password) {
+	uint8_t *begin = buf;
+	uint8_t *pos = begin;
+	uint8_t *end = begin + size;
+
+	JLOG_VERBOSE("Writing STUN message, class=0x%X, method=0x%X", (unsigned int)msg->msg_class,
+	             (unsigned int)msg->msg_method);
+
+	size_t len =
+	    stun_write_header(pos, end - pos, msg->msg_class, msg->msg_method, msg->transaction_id);
+	if (len <= 0)
+		goto overflow;
+	pos += len;
+	uint8_t *attr_begin = pos;
+
+	if (msg->error_code) {
+		const char *reason = stun_get_error_reason(msg->error_code);
+		char buffer[sizeof(struct stun_value_error_code) + STUN_MAX_ERROR_REASON_LEN + 1];
+		struct stun_value_error_code *error = (struct stun_value_error_code *)buffer;
+		memset(error, 0, sizeof(*error));
+		error->code_class = (msg->error_code / 100) & 0x07;
+		error->code_number = msg->error_code % 100;
+		strcpy((char *)error->reason, reason);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_ERROR_CODE, error,
+		                      sizeof(struct stun_value_error_code) + strlen(reason));
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->mapped.len) {
+		JLOG_VERBOSE("Writing XOR mapped address");
+		uint8_t value[32];
+		uint8_t mask[16];
+		generate_mask(msg->transaction_id, mask);
+		int value_len = stun_write_value_mapped_address(
+		    value, 32, (const struct sockaddr *)&msg->mapped.addr, msg->mapped.len, mask);
+		if (value_len > 0) {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_XOR_MAPPED_ADDRESS, value, value_len);
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+	}
+	if (msg->priority) {
+		uint32_t priority = htonl(msg->priority);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_PRIORITY, &priority, 4);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->use_candidate) {
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_USE_CANDIDATE, NULL, 0);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->ice_controlling) {
+		uint64_t ice_controlling = htonll(msg->ice_controlling);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_ICE_CONTROLLING, &ice_controlling, 8);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->ice_controlled) {
+		uint64_t ice_controlled = htonll(msg->ice_controlled);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_ICE_CONTROLLED, &ice_controlled, 8);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->channel_number) {
+		struct stun_value_channel_number channel_number;
+		memset(&channel_number, 0, sizeof(channel_number));
+		channel_number.channel_number = htons(msg->channel_number);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_CHANNEL_NUMBER, &channel_number,
+		                      sizeof(channel_number));
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->lifetime_set || msg->lifetime) {
+		uint32_t lifetime = htonl(msg->lifetime);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_LIFETIME, &lifetime, 4);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	for (size_t i = 0; i < msg->peers_size; ++i) {
+		const addr_record_t *peer = msg->peers + i;
+		if (peer->len) {
+			JLOG_VERBOSE("Writing XOR peer address");
+			uint8_t value[32];
+			uint8_t mask[16];
+			generate_mask(msg->transaction_id, mask);
+			int value_len = stun_write_value_mapped_address(
+			    value, 32, (const struct sockaddr *)&peer->addr, peer->len, mask);
+			if (value_len > 0) {
+				len = stun_write_attr(pos, end - pos, STUN_ATTR_XOR_PEER_ADDRESS, value, value_len);
+				if (len <= 0)
+					goto overflow;
+				pos += len;
+			}
+		}
+	}
+	if (msg->relayed.len) {
+		JLOG_VERBOSE("Writing XOR relay address");
+		uint8_t value[32];
+		uint8_t mask[16];
+		generate_mask(msg->transaction_id, mask);
+		int value_len = stun_write_value_mapped_address(
+		    value, 32, (const struct sockaddr *)&msg->relayed.addr, msg->relayed.len, mask);
+		if (value_len > 0) {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_XOR_RELAYED_ADDRESS, value, value_len);
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+	}
+	if (msg->data) {
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_DATA, (const uint8_t *)msg->data,
+		                      msg->data_size);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->even_port) {
+		struct stun_value_even_port even_port;
+		memset(&even_port, 0, sizeof(even_port));
+		if (msg->next_port)
+			even_port.r |= 0x80;
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_CHANNEL_NUMBER, &even_port,
+		                      sizeof(even_port));
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->requested_transport) {
+		struct stun_value_requested_transport requested_transport;
+		memset(&requested_transport, 0, sizeof(requested_transport));
+		requested_transport.protocol = 17;
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_REQUESTED_TRANSPORT, &requested_transport,
+		                      sizeof(requested_transport));
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->dont_fragment) {
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_DONT_FRAGMENT, NULL, 0);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->reservation_token) {
+		uint64_t reservation_token = htonll(msg->reservation_token);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_RESERVATION_TOKEN, &reservation_token, 8);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+
+	const char *software = "libjuice";
+	len = stun_write_attr(pos, end - pos, STUN_ATTR_SOFTWARE, software, strlen(software));
+	if (len <= 0)
+		goto overflow;
+	pos += len;
+
+	if (msg->msg_class == STUN_CLASS_REQUEST) {
+		if (msg->credentials.enable_userhash) {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_USERHASH, msg->credentials.userhash,
+			                      USERHASH_SIZE);
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+
+		} else if (*msg->credentials.username != '\0') {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_USERNAME, msg->credentials.username,
+			                      strlen(msg->credentials.username));
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+	}
+	if (msg->msg_class == STUN_CLASS_REQUEST ||
+	    (msg->msg_class == STUN_CLASS_RESP_ERROR &&
+	     (msg->error_code == 401 || msg->error_code == 438) // Unauthenticated or Stale Nonce
+	     )) {
+		if (*msg->credentials.realm != '\0') {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_REALM, msg->credentials.realm,
+			                      strlen(msg->credentials.realm));
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+		if (*msg->credentials.nonce != '\0') {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_NONCE, msg->credentials.nonce,
+			                      strlen(msg->credentials.nonce));
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+
+			if (msg->credentials.password_algorithm > 0) {
+				len = stun_write_attr(pos, end - pos, STUN_ATTR_PASSWORD_ALGORITHMS,
+				                      msg->credentials.password_algorithms_value,
+				                      msg->credentials.password_algorithms_value_size);
+				if (len <= 0)
+					goto overflow;
+				pos += len;
+
+			} else if (msg->msg_class != STUN_CLASS_REQUEST) {
+				uint8_t pwa_value[STUN_MAX_PASSWORD_ALGORITHMS_VALUE_SIZE];
+				size_t pwa_size = generate_password_algorithms_attr(pwa_value);
+				len = stun_write_attr(pos, end - pos, STUN_ATTR_PASSWORD_ALGORITHMS, pwa_value,
+				                      pwa_size);
+				if (len <= 0)
+					goto overflow;
+				pos += len;
+			}
+
+			if (msg->msg_class == STUN_CLASS_REQUEST &&
+			    msg->credentials.password_algorithm != STUN_PASSWORD_ALGORITHM_UNSET) {
+				struct stun_value_password_algorithm pwa;
+				pwa.algorithm = htons(msg->credentials.password_algorithm);
+				len = stun_write_attr(pos, end - pos, STUN_ATTR_PASSWORD_ALGORITHM, &pwa,
+				                      sizeof(pwa));
+				if (len <= 0)
+					goto overflow;
+				pos += len;
+			}
+		}
+	}
+	if (msg->msg_class != STUN_CLASS_INDICATION && password) {
+		uint8_t key[MAX_HMAC_KEY_LEN];
+		size_t key_len = generate_hmac_key(msg, password, key);
+
+		size_t tmp_length = pos - attr_begin + STUN_ATTR_SIZE + HMAC_SHA1_SIZE;
+		stun_update_header_length(begin, tmp_length);
+
+		uint8_t hmac[HMAC_SHA1_SIZE];
+		hmac_sha1(begin, pos - begin, key, key_len, hmac);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_MESSAGE_INTEGRITY, hmac, HMAC_SHA1_SIZE);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+
+		// According to RFC 8489, the agent must include both MESSAGE-INTEGRITY and
+		// MESSAGE-INTEGRITY-SHA256. However, this makes legacy agents and servers fail with error
+		// 420 Unknown Attribute. Therefore, unless the password algorithm SHA-256 is enabled, only
+		// MESSAGE-INTEGRITY is included in the message for compatibility.
+		if (msg->credentials.password_algorithm != STUN_PASSWORD_ALGORITHM_UNSET) {
+			// If the response contains a PASSWORD-ALGORITHMS attribute, all the
+			// subsequent requests MUST be authenticated using MESSAGE-INTEGRITY-
+			// SHA256 only.
+			size_t tmp_length = pos - attr_begin + STUN_ATTR_SIZE + HMAC_SHA256_SIZE;
+			stun_update_header_length(begin, tmp_length);
+
+			uint8_t hmac[HMAC_SHA256_SIZE];
+			hmac_sha256(begin, pos - begin, key, key_len, hmac);
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_MESSAGE_INTEGRITY_SHA256, hmac,
+			                      HMAC_SHA256_SIZE);
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+	}
+
+	size_t length = pos - attr_begin + STUN_ATTR_SIZE + 4;
+	if (length & 0x03) {
+		JLOG_ERROR("Written STUN message length is not multiple of 4, length=%zu", length);
+		return -1;
+	}
+	stun_update_header_length(begin, length);
+
+	uint32_t fingerprint = htonl(CRC32(buf, pos - begin) ^ STUN_FINGERPRINT_XOR);
+	len = stun_write_attr(pos, end - pos, STUN_ATTR_FINGERPRINT, &fingerprint, 4);
+	if (len <= 0)
+		goto overflow;
+	pos += len;
+
+	return (int)(pos - begin);
+
+overflow:
+	JLOG_ERROR("Not enough space in buffer for STUN message, size=%zu", size);
+	return -1;
+}
+
+int stun_write_header(void *buf, size_t size, stun_class_t class, stun_method_t method,
+                      const uint8_t *transaction_id) {
+	if (size < sizeof(struct stun_header))
+		return -1;
+
+	uint16_t type = (uint16_t) class | (uint16_t)method;
+
+	struct stun_header *header = buf;
+	header->type = htons(type);
+	header->length = htons(0);
+	header->magic = htonl(STUN_MAGIC);
+	memcpy(header->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	return sizeof(struct stun_header);
+}
+
+size_t stun_update_header_length(void *buf, size_t length) {
+	struct stun_header *header = buf;
+	size_t previous = ntohs(header->length);
+	header->length = htons((uint16_t)length);
+	return previous;
+}
+
+int stun_write_attr(void *buf, size_t size, uint16_t type, const void *value, size_t length) {
+	JLOG_VERBOSE("Writing STUN attribute type 0x%X, length=%zu", (unsigned int)type, length);
+
+	if (size < sizeof(struct stun_attr) + length)
+		return -1;
+
+	struct stun_attr *attr = buf;
+	attr->type = htons(type);
+	attr->length = htons((uint16_t)length);
+
+	if (length > 0) {
+		memcpy(attr->value, value, length);
+
+		// Pad to align on 4 bytes
+		while (length & 0x03)
+			attr->value[length++] = 0;
+	}
+
+	return (int)(sizeof(struct stun_attr) + length);
+}
+
+int stun_write_value_mapped_address(void *buf, size_t size, const struct sockaddr *addr,
+                                    socklen_t addrlen, const uint8_t *mask) {
+	if (size < sizeof(struct stun_value_mapped_address))
+		return -1;
+
+	struct stun_value_mapped_address *value = buf;
+	value->padding = 0;
+	switch (addr->sa_family) {
+	case AF_INET: {
+		value->family = STUN_ADDRESS_FAMILY_IPV4;
+		if (size < sizeof(struct stun_value_mapped_address) + 4)
+			return -1;
+		if (addrlen < (socklen_t)sizeof(struct sockaddr_in))
+			return -1;
+		JLOG_VERBOSE("Writing IPv4 address");
+		const struct sockaddr_in *sin = (const struct sockaddr_in *)addr;
+		value->port = sin->sin_port ^ *((uint16_t *)mask);
+		const uint8_t *bytes = (const uint8_t *)&sin->sin_addr;
+		for (int i = 0; i < 4; ++i)
+			value->address[i] = bytes[i] ^ mask[i];
+		return sizeof(struct stun_value_mapped_address) + 4;
+	}
+	case AF_INET6: {
+		value->family = STUN_ADDRESS_FAMILY_IPV6;
+		if (size < sizeof(struct stun_value_mapped_address) + 16)
+			return -1;
+		if (addrlen < (socklen_t)sizeof(struct sockaddr_in6))
+			return -1;
+		JLOG_VERBOSE("Writing IPv6 address");
+		const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)addr;
+		value->port = sin6->sin6_port ^ *((uint16_t *)mask);
+		const uint8_t *bytes = (const uint8_t *)&sin6->sin6_addr;
+		for (int i = 0; i < 16; ++i)
+			value->address[i] = bytes[i] ^ mask[i];
+		return sizeof(struct stun_value_mapped_address) + 16;
+	}
+	default: {
+		JLOG_DEBUG("Unknown address family %u", (unsigned int)addr->sa_family);
+		return -1;
+	}
+	}
+}
+
+bool is_stun_datagram(const void *data, size_t size) {
+	// RFC 8489: The most significant 2 bits of every STUN message MUST be zeroes. This can be used
+	// to differentiate STUN packets from other protocols when STUN is multiplexed with other
+	// protocols on the same port.
+	if (!size || *((uint8_t *)data) & 0xC0) {
+		JLOG_VERBOSE("Not a STUN message: first 2 bits are not zeroes");
+		return false;
+	}
+
+	if (size < sizeof(struct stun_header)) {
+		JLOG_VERBOSE("Not a STUN message: message too short, size=%zu", size);
+		return false;
+	}
+
+	const struct stun_header *header = data;
+	if (ntohl(header->magic) != STUN_MAGIC) {
+		JLOG_VERBOSE("Not a STUN message: magic number invalid");
+		return false;
+	}
+
+	// RFC 8489: The message length MUST contain the size of the message in bytes, not including the
+	// 20-byte STUN header.  Since all STUN attributes are padded to a multiple of 4 bytes, the last
+	// 2 bits of this field are always zero.  This provides another way to distinguish STUN packets
+	// from packets of other protocols.
+	const size_t length = ntohs(header->length);
+	if (length & 0x03) {
+		JLOG_VERBOSE("Not a STUN message: invalid length %zu not multiple of 4", length);
+		return false;
+	}
+	if (size != sizeof(struct stun_header) + length) {
+		JLOG_VERBOSE("Not a STUN message: invalid length %zu while expecting %zu", length,
+		             size - sizeof(struct stun_header));
+		return false;
+	}
+
+	return true;
+}
+
+int stun_read(void *data, size_t size, stun_message_t *msg) {
+	memset(msg, 0, sizeof(*msg));
+
+	if (size < sizeof(struct stun_header)) {
+		JLOG_ERROR("STUN message too short, size=%zu", size);
+		return -1;
+	}
+
+	const struct stun_header *header = data;
+	const size_t length = ntohs(header->length);
+	if (size < sizeof(struct stun_header) + length) {
+		JLOG_ERROR("Invalid STUN message length, length=%zu, available=%zu", length,
+		           size - sizeof(struct stun_header));
+		return -1;
+	}
+
+	uint16_t type = ntohs(header->type);
+	msg->msg_class = (stun_class_t)(type & STUN_CLASS_MASK);
+	msg->msg_method = (stun_method_t)(type & ~STUN_CLASS_MASK);
+	memcpy(msg->transaction_id, header->transaction_id, STUN_TRANSACTION_ID_SIZE);
+	JLOG_VERBOSE("Reading STUN message, class=0x%X, method=0x%X", (unsigned int)msg->msg_class,
+	             (unsigned int)msg->msg_method);
+
+	uint32_t security_bits = 0;
+
+	uint8_t *begin = data;
+	uint8_t *attr_begin = begin + sizeof(struct stun_header);
+	uint8_t *end = attr_begin + length;
+	const uint8_t *pos = attr_begin;
+	while (pos < end) {
+		int ret = stun_read_attr(pos, end - pos, msg, begin, attr_begin, &security_bits);
+		if (ret <= 0) {
+			JLOG_DEBUG("Reading STUN attribute failed");
+			return -1;
+		}
+		pos += ret;
+	}
+
+	JLOG_VERBOSE("Finished reading STUN attributes");
+
+	stun_credentials_t *credentials = &msg->credentials;
+
+	// RFC 8489: If the response is an error response with an error code of 401 (Unauthenticated) or
+	// 438 (Stale Nonce), the client MUST test if the NONCE attribute value starts with the "nonce
+	// cookie". If so and the "nonce cookie" has the STUN Security Feature "Password algorithms"
+	// bit set to 1 but no PASSWORD-ALGORITHMS attribute is present, then the client MUST NOT retry
+	// the request with a new transaction. See
+	// https://www.rfc-editor.org/rfc/rfc8489.html#section-9.2.5
+	if (msg->msg_class == STUN_CLASS_RESP_ERROR &&
+	    (msg->error_code == 401 || msg->error_code == 438) &&
+	    security_bits & STUN_SECURITY_PASSWORD_ALGORITHMS_BIT &&
+	    credentials->password_algorithms_value_size == 0) {
+		JLOG_INFO("STUN Security Feature \"Password algorithms\" bit is set in %u error response "
+		          "but the corresponding attribute is missing",
+		          msg->error_code);
+		msg->error_code = STUN_ERROR_INTERNAL_VALIDATION_FAILED; // so the agent will give up
+	}
+
+	// RFC 8489: If the request contains neither the PASSWORD-ALGORITHMS nor the
+	// PASSWORD-ALGORITHM algorithm, then the request is processed as though
+	// PASSWORD-ALGORITHM were MD5.
+	// Otherwise, unless (1) PASSWORD-ALGORITHM and PASSWORD-ALGORITHMS are both
+	// present, (2) PASSWORD-ALGORITHMS  matches the value sent in the response that sent
+	// this NONCE, and (3) PASSWORD-ALGORITHM matches one of the entries in
+	// PASSWORD-ALGORITHMS, the server MUST generate an error response with an error code of
+	// 400 (Bad Request). See https://www.rfc-editor.org/rfc/rfc8489.html#section-9.2.4
+	if (!STUN_IS_RESPONSE(msg->msg_class)) {
+		if (credentials->password_algorithms_value_size == 0 &&
+		    credentials->password_algorithm == STUN_PASSWORD_ALGORITHM_UNSET) {
+			credentials->password_algorithm = STUN_PASSWORD_ALGORITHM_MD5;
+
+		} else if (credentials->password_algorithm == STUN_PASSWORD_ALGORITHM_UNSET) {
+			JLOG_INFO("No suitable password algorithm in STUN request");
+			msg->error_code = STUN_ERROR_INTERNAL_VALIDATION_FAILED;
+
+		} else if (credentials->password_algorithms_value_size == 0) {
+			JLOG_INFO("Missing password algorithms list in STUN request");
+			msg->error_code = STUN_ERROR_INTERNAL_VALIDATION_FAILED;
+
+		} else {
+			uint8_t pwa_value[STUN_MAX_PASSWORD_ALGORITHMS_VALUE_SIZE];
+			size_t pwa_size = generate_password_algorithms_attr(pwa_value);
+			if (pwa_size != credentials->password_algorithms_value_size ||
+			    memcmp(credentials->password_algorithms_value, pwa_value, pwa_size) != 0) {
+				JLOG_INFO("Password algorithms list is invalid in STUN request");
+				msg->error_code = STUN_ERROR_INTERNAL_VALIDATION_FAILED;
+			}
+		}
+	}
+
+	if (security_bits & STUN_SECURITY_USERNAME_ANONYMITY_BIT) {
+		JLOG_DEBUG("Remote agent supports user anonymity");
+		credentials->enable_userhash = true;
+	}
+
+	return (int)(sizeof(struct stun_header) + length);
+}
+
+int stun_read_attr(const void *data, size_t size, stun_message_t *msg, uint8_t *begin,
+                   uint8_t *attr_begin, uint32_t *security_bits) {
+	// RFC 8489: When present, the FINGERPRINT attribute MUST be the last attribute in the
+	// message and thus will appear after MESSAGE-INTEGRITY and MESSAGE-INTEGRITY-SHA256.
+	if (msg->has_fingerprint) {
+		JLOG_DEBUG("Invalid STUN attribute after fingerprint");
+		return -1;
+	}
+
+	if (size < sizeof(struct stun_attr)) {
+		JLOG_VERBOSE("STUN attribute too short");
+		return -1;
+	}
+
+	const struct stun_attr *attr = data;
+	size_t length = ntohs(attr->length);
+	stun_attr_type_t type = (stun_attr_type_t)ntohs(attr->type);
+	JLOG_VERBOSE("Reading attribute 0x%X, length=%zu", (unsigned int)type, length);
+	if (size < sizeof(struct stun_attr) + length) {
+		JLOG_DEBUG("STUN attribute length invalid, length=%zu, available=%zu", length,
+		           size - sizeof(struct stun_attr));
+		return -1;
+	}
+
+	// RFC 8489: Note that agents MUST ignore all attributes that follow MESSAGE-INTEGRITY, with
+	// the exception of the MESSAGE-INTEGRITY-SHA256 and FINGERPRINT attributes.
+	if (msg->has_integrity && type != STUN_ATTR_MESSAGE_INTEGRITY &&
+	    type != STUN_ATTR_MESSAGE_INTEGRITY_SHA256 && type != STUN_ATTR_FINGERPRINT) {
+		JLOG_DEBUG("Ignoring STUN attribute 0x%X after message integrity", (unsigned int)type);
+		while (length & 0x03)
+			++length; // attributes are aligned on 4 bytes
+		return (int)(sizeof(struct stun_attr) + length);
+	}
+
+	switch (type) {
+	case STUN_ATTR_MAPPED_ADDRESS: {
+		JLOG_VERBOSE("Reading mapped address");
+		uint8_t zero_mask[16] = {0};
+		if (stun_read_value_mapped_address(attr->value, length, &msg->mapped, zero_mask) < 0)
+			return -1;
+		break;
+	}
+	case STUN_ATTR_XOR_MAPPED_ADDRESS: {
+		JLOG_VERBOSE("Reading XOR mapped address");
+		uint8_t mask[16];
+		generate_mask(msg->transaction_id, mask);
+		if (stun_read_value_mapped_address(attr->value, length, &msg->mapped, mask) < 0)
+			return -1;
+		break;
+	}
+	case STUN_ATTR_ALTERNATE_SERVER: {
+		JLOG_VERBOSE("Reading alternate server");
+		uint8_t zero_mask[16] = {0};
+		if (stun_read_value_mapped_address(attr->value, length, &msg->alternate_server, zero_mask) <
+		    0)
+			return -1;
+		break;
+	}
+	case STUN_ATTR_ERROR_CODE: {
+		JLOG_VERBOSE("Reading error code");
+		if (length < sizeof(struct stun_value_error_code)) {
+			JLOG_DEBUG("STUN error code value too short, length=%zu", length);
+			return -1;
+		}
+		const struct stun_value_error_code *error =
+		    (const struct stun_value_error_code *)attr->value;
+		msg->error_code = (error->code_class & 0x07) * 100 + error->code_number;
+
+		if (msg->error_code == 401 || msg->error_code == 438) { // Unauthenticated or Stale Nonce
+			JLOG_DEBUG("Got STUN error code %u", msg->error_code);
+
+		} else if (JLOG_INFO_ENABLED) {
+			size_t reason_length = length - sizeof(struct stun_value_error_code);
+			if (reason_length >= STUN_MAX_ERROR_REASON_LEN)
+				reason_length = STUN_MAX_ERROR_REASON_LEN - 1;
+
+			char buffer[STUN_MAX_ERROR_REASON_LEN];
+			memcpy(buffer, (const char *)error->reason, reason_length);
+			buffer[reason_length] = '\0';
+
+			JLOG_INFO("Got STUN error code %u, reason \"%s\"", msg->error_code, buffer);
+		}
+		break;
+	}
+	case STUN_ATTR_UNKNOWN_ATTRIBUTES: {
+		JLOG_VERBOSE("Reading STUN unknown attributes");
+		const uint16_t *attributes = (const uint16_t *)attr->value;
+		for (int i = 0; i < (int)ntohs(attr->length) / 2; ++i) {
+			stun_attr_type_t type = (stun_attr_type_t)ntohs(attributes[i]);
+			JLOG_INFO("Got unknown attribute response for attribute 0x%X", (unsigned int)type);
+		}
+		break;
+	}
+	case STUN_ATTR_USERNAME: {
+		JLOG_VERBOSE("Reading username");
+		if (length + 1 > STUN_MAX_USERNAME_LEN) {
+			JLOG_WARN("STUN username attribute value too long, length=%zu", length);
+			return -1;
+		}
+		memcpy(msg->credentials.username, (const char *)attr->value, length);
+		msg->credentials.username[length] = '\0';
+		JLOG_VERBOSE("Got username: %s", msg->credentials.username);
+		break;
+	}
+	case STUN_ATTR_MESSAGE_INTEGRITY: {
+		JLOG_VERBOSE("Reading message integrity");
+		if (length != HMAC_SHA1_SIZE) {
+			JLOG_DEBUG("STUN message integrity length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->has_integrity = true;
+		break;
+	}
+	case STUN_ATTR_MESSAGE_INTEGRITY_SHA256: {
+		JLOG_VERBOSE("Reading message integrity SHA256");
+		if (length != HMAC_SHA256_SIZE) {
+			JLOG_DEBUG("STUN message integrity SHA256 length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->has_integrity = true;
+		break;
+	}
+	case STUN_ATTR_FINGERPRINT: {
+		JLOG_VERBOSE("Reading fingerprint");
+		if (length != 4) {
+			JLOG_DEBUG("STUN fingerprint length invalid, length=%zu", length);
+			return -1;
+		}
+		size_t tmp_length = (uint8_t *)data - attr_begin + STUN_ATTR_SIZE + 4;
+		size_t prev_length = stun_update_header_length(begin, tmp_length);
+		uint32_t expected = CRC32(begin, (uint8_t *)data - begin) ^ STUN_FINGERPRINT_XOR;
+		stun_update_header_length(begin, prev_length);
+
+		uint32_t fingerprint = ntohl(*((uint32_t *)attr->value));
+		if (fingerprint != expected) {
+			JLOG_ERROR("STUN fingerprint check failed, expected=%lX, actual=%lX",
+			           (unsigned long)expected, (unsigned long)fingerprint);
+			return -1;
+		}
+		JLOG_VERBOSE("STUN fingerprint check succeeded");
+		msg->has_fingerprint = true;
+		break;
+	}
+	case STUN_ATTR_REALM: {
+		JLOG_VERBOSE("Reading realm");
+		if (length + 1 > STUN_MAX_REALM_LEN) {
+			JLOG_WARN("STUN realm attribute value too long, length=%zu", length);
+			return -1;
+		}
+		memcpy(msg->credentials.realm, (const char *)attr->value, length);
+		msg->credentials.realm[length] = '\0';
+		JLOG_VERBOSE("Got realm: %s", msg->credentials.realm);
+		break;
+	}
+	case STUN_ATTR_NONCE: {
+		JLOG_VERBOSE("Reading nonce");
+		if (length + 1 > STUN_MAX_NONCE_LEN) {
+			JLOG_WARN("STUN nonce attribute value too long, length=%zu", length);
+			return -1;
+		}
+		memcpy(msg->credentials.nonce, (const char *)attr->value, length);
+		msg->credentials.nonce[length] = '\0';
+		JLOG_VERBOSE("Got nonce: %s", msg->credentials.nonce);
+
+		// If the nonce of a response starts with the nonce cookie, decode the Security Feature bits
+		// See https://www.rfc-editor.org/rfc/rfc8489.html#section-9.2
+		if (STUN_IS_RESPONSE(msg->msg_class) &&
+		    strlen(msg->credentials.nonce) > STUN_NONCE_COOKIE_LEN + 4 &&
+		    strncmp(msg->credentials.nonce, STUN_NONCE_COOKIE, STUN_NONCE_COOKIE_LEN) == 0) {
+			char encoded_security_bits[5];
+			memcpy(encoded_security_bits, msg->credentials.nonce + STUN_NONCE_COOKIE_LEN, 4);
+			encoded_security_bits[4] = '\0';
+
+			uint8_t bytes[4];
+			bytes[0] = 0;
+			int len = BASE64_DECODE(encoded_security_bits, bytes + 1, 3);
+			if (len == 3) {
+				*security_bits = ntohl(*((uint32_t *)bytes));
+				JLOG_VERBOSE("Nonce has cookie, Security Feature bits are 0x%lX",
+				             (unsigned long)*security_bits);
+			} else {
+				JLOG_WARN("Nonce has cookie, but the encoded Security Feature bits field \"%s\" is "
+				          "invalid",
+				          encoded_security_bits);
+				security_bits = 0;
+			}
+		} else if (msg->msg_class == STUN_CLASS_RESP_ERROR) {
+			JLOG_DEBUG("Remote agent does not support RFC 8489");
+		}
+		break;
+	}
+	case STUN_ATTR_PASSWORD_ALGORITHM: {
+		JLOG_VERBOSE("Reading password algorithm");
+		if (length < sizeof(struct stun_value_password_algorithm)) {
+			JLOG_WARN("STUN password algorithm value too short, length=%zu", length);
+			return -1;
+		}
+		if (!STUN_IS_RESPONSE(msg->msg_class)) {
+			const struct stun_value_password_algorithm *pwa =
+			    (const struct stun_value_password_algorithm *)attr->value;
+			stun_password_algorithm_t algorithm = ntohs(pwa->algorithm);
+			if (algorithm == STUN_PASSWORD_ALGORITHM_MD5 ||
+			    algorithm == STUN_PASSWORD_ALGORITHM_SHA256)
+				msg->credentials.password_algorithm = algorithm;
+			else
+				JLOG_WARN("Unknown password algorithm 0x%hX", algorithm);
+		} else {
+			JLOG_WARN("Found password algorithm in response, ignoring");
+		}
+		break;
+	}
+	case STUN_ATTR_PASSWORD_ALGORITHMS: {
+		JLOG_VERBOSE("Reading password algorithms list");
+		if (length < sizeof(struct stun_value_password_algorithm)) {
+			JLOG_WARN("STUN password algorithms list too short, length=%zu", length);
+			return -1;
+		}
+		if (length > STUN_MAX_PASSWORD_ALGORITHMS_VALUE_SIZE) {
+			JLOG_WARN("STUN password algorithms list too long, length=%zu", length);
+			return -1;
+		}
+
+		memcpy(msg->credentials.password_algorithms_value, attr->value, length);
+		msg->credentials.password_algorithms_value_size = length;
+
+		if (!STUN_IS_RESPONSE(msg->msg_class)) {
+			const uint8_t *pos = attr->value;
+			const uint8_t *end = pos + length;
+			while (pos < end) {
+				if ((size_t)(end - pos) < sizeof(struct stun_value_password_algorithm)) {
+					JLOG_WARN("STUN password algorithms list truncated, available=%zu", end - pos);
+					return -1;
+				}
+				const struct stun_value_password_algorithm *pwa =
+				    (const struct stun_value_password_algorithm *)pos;
+				stun_password_algorithm_t algorithm = ntohs(pwa->algorithm);
+				size_t parameters_length = ntohs(pwa->parameters_length);
+				size_t padded_length = align32(parameters_length);
+
+				pos += sizeof(struct stun_value_password_algorithm);
+
+				if ((size_t)(end - pos) < padded_length) {
+					JLOG_WARN(
+					    "STUN password algorithm parameters too long, length=%zu, padded=%zu, "
+					    "available=%zu",
+					    parameters_length, padded_length, end - pos);
+					return -1;
+				}
+
+				pos += padded_length;
+
+				if (algorithm == STUN_PASSWORD_ALGORITHM_MD5 ||
+				    algorithm == STUN_PASSWORD_ALGORITHM_SHA256) {
+					msg->credentials.password_algorithm = algorithm;
+					break;
+				}
+
+				JLOG_DEBUG("Unknown password algorithm 0x%hX", algorithm);
+			}
+		}
+		break;
+	}
+	case STUN_ATTR_USERHASH: {
+		JLOG_VERBOSE("Reading user hash");
+		if (length != USERHASH_SIZE) {
+			JLOG_WARN("STUN user hash value too long, length=%zu", length);
+			return -1;
+		}
+		memcpy(msg->credentials.userhash, attr->value, USERHASH_SIZE);
+		msg->credentials.enable_userhash = true;
+		break;
+	}
+	case STUN_ATTR_SOFTWARE: {
+		JLOG_VERBOSE("Reading software");
+		if (length + 1 > STUN_MAX_SOFTWARE_LEN) {
+			JLOG_WARN("STUN software attribute value too long, length=%zu", length);
+			return -1;
+		}
+		char buffer[STUN_MAX_SOFTWARE_LEN];
+		memcpy(buffer, (const char *)attr->value, length);
+		buffer[length] = '\0';
+		JLOG_VERBOSE("Remote agent is \"%s\"", buffer);
+		break;
+	}
+	case STUN_ATTR_PRIORITY: {
+		JLOG_VERBOSE("Reading priority");
+		if (length != 4) {
+			JLOG_DEBUG("STUN priority length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->priority = ntohl(*((uint32_t *)attr->value));
+		JLOG_VERBOSE("Got priority: %lu", (unsigned long)msg->priority);
+		break;
+	}
+	case STUN_ATTR_USE_CANDIDATE: {
+		JLOG_VERBOSE("Found use candidate flag");
+		msg->use_candidate = true;
+		break;
+	}
+	case STUN_ATTR_ICE_CONTROLLING: {
+		JLOG_VERBOSE("Found ICE controlling attribute");
+		if (length != 8) {
+			JLOG_DEBUG("STUN ICE controlling attribute length invalid, length=%zu", length);
+			return -1;
+		}
+		uint32_t *value32 = (uint32_t *)attr->value;
+		msg->ice_controlling = ((uint64_t)ntohl(value32[0]) << 32) | ntohl(value32[1]);
+		break;
+	}
+	case STUN_ATTR_ICE_CONTROLLED: {
+		JLOG_VERBOSE("Found ICE controlled attribute");
+		if (length != 8) {
+			JLOG_DEBUG("STUN ICE controlled attribute length invalid, length=%zu", length);
+			return -1;
+		}
+		uint32_t *value32 = (uint32_t *)attr->value;
+		msg->ice_controlled = ((uint64_t)ntohl(value32[0]) << 32) | ntohl(value32[1]);
+		break;
+	}
+	case STUN_ATTR_CHANNEL_NUMBER: {
+		JLOG_VERBOSE("Reading channel number attribute");
+		if (length < sizeof(struct stun_value_channel_number)) {
+			JLOG_DEBUG("STUN channel number attribute value too short, length=%zu", length);
+			return -1;
+		}
+		const struct stun_value_channel_number *channel_number =
+		    (const struct stun_value_channel_number *)attr->value;
+		msg->channel_number = ntohs(channel_number->channel_number);
+		break;
+	}
+	case STUN_ATTR_LIFETIME: {
+		JLOG_VERBOSE("Reading lifetime attribute");
+		if (length != 4) {
+			JLOG_DEBUG("STUN lifetime attribute length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->lifetime = ntohl(*((uint32_t *)attr->value));
+		msg->lifetime_set = true;
+		break;
+	}
+	case STUN_ATTR_XOR_PEER_ADDRESS: {
+		JLOG_VERBOSE("Reading XOR peer address");
+		if (msg->peers_size < STUN_MAX_PEER_ADDRESSES) {
+			uint8_t mask[16];
+			generate_mask(msg->transaction_id, mask);
+			addr_record_t *peer = msg->peers + msg->peers_size;
+			if (stun_read_value_mapped_address(attr->value, length, peer, mask) < 0)
+				return -1;
+			if (peer->len)
+				++msg->peers_size;
+		} else {
+			JLOG_WARN("Too many STUN XOR-PEER-ADDRESS attributes, ignoring");
+		}
+		break;
+	}
+	case STUN_ATTR_XOR_RELAYED_ADDRESS: {
+		JLOG_VERBOSE("Reading XOR relayed address");
+		uint8_t mask[16];
+		generate_mask(msg->transaction_id, mask);
+		if (stun_read_value_mapped_address(attr->value, length, &msg->relayed, mask) < 0)
+			return -1;
+		break;
+	}
+	case STUN_ATTR_DATA: {
+		JLOG_VERBOSE("Found data");
+		msg->data = (const char *)attr->value;
+		msg->data_size = length;
+		break;
+	}
+	case STUN_ATTR_EVEN_PORT: {
+		JLOG_VERBOSE("Found even port attribute");
+		if (length < 1) {
+			JLOG_DEBUG("STUN even port attribute length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->even_port = true;
+		msg->next_port = ((struct stun_value_even_port *)attr->value)->r & 0x80;
+		break;
+	}
+	case STUN_ATTR_REQUESTED_TRANSPORT: {
+		JLOG_VERBOSE("Found requested transport attribute");
+		if (length < sizeof(struct stun_value_requested_transport)) {
+			JLOG_DEBUG("STUN requested transport attribute length invalid, length=%zu", length);
+			return -1;
+		}
+		const struct stun_value_requested_transport *requested_transport =
+		    (const struct stun_value_requested_transport *)attr->value;
+		if (requested_transport->protocol != 17) { // UDP
+			JLOG_WARN("Unexpected requested transport protocol: %d",
+			          (int)requested_transport->protocol);
+			return -1;
+		}
+		msg->requested_transport = true;
+		break;
+	}
+	case STUN_ATTR_DONT_FRAGMENT: {
+		JLOG_VERBOSE("Found don't fragment attribute");
+		msg->dont_fragment = true;
+		break;
+	}
+	case STUN_ATTR_RESERVATION_TOKEN: {
+		JLOG_VERBOSE("Found reservation token");
+		if (length != 8) {
+			JLOG_DEBUG("STUN reservation token length invalid, length=%zu", length);
+			return -1;
+		}
+		uint32_t *value32 = (uint32_t *)attr->value;
+		msg->reservation_token = ((uint64_t)ntohl(value32[0]) << 32) | ntohl(value32[1]);
+		break;
+	}
+	default: {
+		// Ignore
+		if (STUN_IS_OPTIONAL_ATTR(type))
+			JLOG_DEBUG("Ignoring unknown optional STUN attribute type 0x%X", (unsigned int)type);
+		else
+			JLOG_WARN("Unknown STUN attribute type 0x%X, ignoring", (unsigned int)type);
+		break;
+	}
+	}
+	return (int)(sizeof(struct stun_attr) + align32(length));
+}
+
+int stun_read_value_mapped_address(const void *data, size_t size, addr_record_t *mapped,
+                                   const uint8_t *mask) {
+	size_t len = sizeof(struct stun_value_mapped_address);
+	if (size < len) {
+		JLOG_VERBOSE("STUN mapped address value too short, size=%zu", size);
+		return -1;
+	}
+	const struct stun_value_mapped_address *value = data;
+	stun_address_family_t family = (stun_address_family_t)value->family;
+	switch (family) {
+	case STUN_ADDRESS_FAMILY_IPV4: {
+		len += 4;
+		if (size < len) {
+			JLOG_DEBUG("IPv4 mapped address value too short, size=%zu", size);
+			return -1;
+		}
+		JLOG_VERBOSE("Reading IPv4 address");
+		mapped->len = sizeof(struct sockaddr_in);
+		mapped->socktype = SOCK_DGRAM;
+		struct sockaddr_in *sin = (struct sockaddr_in *)&mapped->addr;
+		sin->sin_family = AF_INET;
+		sin->sin_port = value->port ^ *((uint16_t *)mask);
+		uint8_t *bytes = (uint8_t *)&sin->sin_addr;
+		for (int i = 0; i < 4; ++i)
+			bytes[i] = value->address[i] ^ mask[i];
+		break;
+	}
+	case STUN_ADDRESS_FAMILY_IPV6: {
+		len += 16;
+		if (size < len) {
+			JLOG_DEBUG("IPv6 mapped address value too short, size=%zu", size);
+			return -1;
+		}
+		JLOG_VERBOSE("Reading IPv6 address");
+		mapped->len = sizeof(struct sockaddr_in6);
+		mapped->socktype = SOCK_DGRAM;
+		struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&mapped->addr;
+		sin6->sin6_family = AF_INET6;
+		sin6->sin6_port = value->port ^ *((uint16_t *)mask);
+		uint8_t *bytes = (uint8_t *)&sin6->sin6_addr;
+		for (int i = 0; i < 16; ++i)
+			bytes[i] = value->address[i] ^ mask[i];
+		break;
+	}
+	default: {
+		JLOG_DEBUG("Unknown STUN address family 0x%X", (unsigned int)family);
+		len = size;
+		break;
+	}
+	}
+	return (int)len;
+}
+
+bool stun_check_integrity(void *buf, size_t size, const stun_message_t *msg, const char *password) {
+	if (!msg->has_integrity)
+		return false;
+
+	const struct stun_header *header = buf;
+	const size_t length = ntohs(header->length);
+	if (size < sizeof(struct stun_header) + length)
+		return false;
+
+	uint8_t key[MAX_HMAC_KEY_LEN];
+	size_t key_len = generate_hmac_key(msg, password, key);
+
+	bool success = false;
+	uint8_t *begin = buf;
+	const uint8_t *attr_begin = begin + sizeof(struct stun_header);
+	const uint8_t *end = attr_begin + length;
+	const uint8_t *pos = attr_begin;
+	while (pos < end) {
+		const struct stun_attr *attr = (const struct stun_attr *)pos;
+		size_t attr_length = ntohs(attr->length);
+		if (size < sizeof(struct stun_attr) + attr_length)
+			return false;
+
+		stun_attr_type_t type = (stun_attr_type_t)ntohs(attr->type);
+		switch (type) {
+		case STUN_ATTR_MESSAGE_INTEGRITY: {
+			if (attr_length != HMAC_SHA1_SIZE)
+				return false;
+
+			size_t tmp_length = pos - attr_begin + STUN_ATTR_SIZE + HMAC_SHA1_SIZE;
+			size_t prev_length = stun_update_header_length(begin, tmp_length);
+			uint8_t hmac[HMAC_SHA1_SIZE];
+			hmac_sha1(begin, pos - begin, key, key_len, hmac);
+			stun_update_header_length(begin, prev_length);
+
+			const uint8_t *expected_hmac = attr->value;
+			if (const_time_memcmp(hmac, expected_hmac, HMAC_SHA1_SIZE) != 0) {
+				JLOG_DEBUG("STUN message integrity SHA1 check failed");
+				return false;
+			}
+
+			success = true;
+			break;
+		}
+		case STUN_ATTR_MESSAGE_INTEGRITY_SHA256: {
+			if (attr_length != HMAC_SHA256_SIZE)
+				return false;
+
+			size_t tmp_length = pos - attr_begin + STUN_ATTR_SIZE + HMAC_SHA256_SIZE;
+			size_t prev_length = stun_update_header_length(begin, tmp_length);
+			uint8_t hmac[HMAC_SHA256_SIZE];
+			hmac_sha256(begin, pos - begin, key, key_len, hmac);
+			stun_update_header_length(begin, prev_length);
+
+			const uint8_t *expected_hmac = attr->value;
+			if (const_time_memcmp(hmac, expected_hmac, HMAC_SHA256_SIZE) != 0) {
+				JLOG_DEBUG("STUN message integrity SHA256 check failed");
+				return false;
+			}
+
+			success = true;
+			break;
+		}
+		default:
+			// Ignore
+			break;
+		}
+
+		pos += sizeof(struct stun_attr) + align32(attr_length);
+	}
+
+	if (!success)
+		return false;
+
+	JLOG_VERBOSE("STUN message integrity check succeeded");
+	return true;
+}
+
+void stun_prepend_nonce_cookie(char *nonce) {
+	// RFC 8489: To indicate that it supports this specification, a server MUST prepend the
+	// NONCE attribute value with the character string composed of "obMatJos2" concatenated with
+	// the (4-character) base64 [RFC4648] encoding of the 24-bit STUN Security Features See
+	// https://www.rfc-editor.org/rfc/rfc8489.html#section-9.2
+	char copy[STUN_MAX_NONCE_LEN];
+	strcpy(copy, nonce);
+
+	char encoded_security_bits[5];
+	uint32_t security_bits =
+	    htonl(STUN_SECURITY_PASSWORD_ALGORITHMS_BIT | STUN_SECURITY_USERNAME_ANONYMITY_BIT);
+	BASE64_ENCODE((uint8_t *)&security_bits + 1, 3, encoded_security_bits, 5);
+
+	snprintf(nonce, STUN_MAX_NONCE_LEN, "%s%s%.*s", STUN_NONCE_COOKIE, encoded_security_bits,
+	         STUN_MAX_NONCE_LEN - (STUN_NONCE_COOKIE_LEN + 5), copy);
+}
+
+void stun_compute_userhash(const char *username, const char *realm, uint8_t *out) {
+	char input[MAX_USERHASH_INPUT_LEN];
+	int input_len = snprintf(input, MAX_USERHASH_INPUT_LEN, "%s:%s", username, realm);
+	if (input_len < 0)
+		return;
+
+	if (input_len >= MAX_USERHASH_INPUT_LEN)
+		input_len = MAX_USERHASH_INPUT_LEN - 1;
+
+	juice_hash_sha256(input, input_len, out);
+}
+
+void stun_process_credentials(const stun_credentials_t *credentials, stun_credentials_t *dst) {
+	char username[STUN_MAX_USERNAME_LEN];
+	strcpy(username, dst->username);
+	*dst = *credentials;
+	strcpy(dst->username, username);
+
+	if (credentials->enable_userhash)
+		stun_compute_userhash(username, credentials->realm, dst->userhash);
+}
+
+const char *stun_get_error_reason(unsigned int code) {
+	switch (code) {
+	case 0:
+		return "";
+	case 300:
+		return "Try Alternate";
+	case 400:
+		return "Bad Request";
+	case 401:
+		return "Unauthenticated";
+	case 403:
+		return "Forbidden";
+	case 420:
+		return "Unknown Attribute";
+	case 437:
+		return "Allocation Mismatch";
+	case 438:
+		return "Stale Nonce";
+	case 440:
+		return "Address Family not Supported";
+	case 441:
+		return "Wrong credentials";
+	case 442:
+		return "Unsupported Transport Protocol";
+	case 443:
+		return "Peer Address Family Mismatch";
+	case 486:
+		return "Allocation Quota Reached";
+	case 500:
+		return "Server Error";
+	case 508:
+		return "Insufficient Capacity";
+	default:
+		return "Error";
+	}
+}
+
+JUICE_EXPORT bool _juice_is_stun_datagram(const void *data, size_t size) {
+	return is_stun_datagram(data, size);
+}
+
+JUICE_EXPORT int _juice_stun_read(void *data, size_t size, stun_message_t *msg) {
+	return stun_read(data, size, msg);
+}
+
+JUICE_EXPORT bool _juice_stun_check_integrity(void *buf, size_t size, const stun_message_t *msg,
+                                              const char *password) {
+	return stun_check_integrity(buf, size, msg, password);
+}
+
+JUICE_EXPORT int _juice_stun_write(void *buf, size_t size, const stun_message_t *msg, const char *password) {
+	return stun_write(buf, size, msg, password);
+}

--- a/Source/3rdParty/libjuice/src/stun.h
+++ b/Source/3rdParty/libjuice/src/stun.h
@@ -1,0 +1,381 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_STUN_H
+#define JUICE_STUN_H
+
+#include "juice.h"
+
+#include "addr.h"
+#include "hash.h"
+#include "hmac.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#pragma pack(push, 1)
+/*
+ * STUN message header (20 bytes)
+ * See https://www.rfc-editor.org/rfc/rfc8489.html#section-5
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |0 0|     STUN Message Type     |         Message Length        |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                    Magic Cookie = 0x2112A442                  |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                                                               |
+ * |                     Transaction ID (96 bits)                  |
+ * |                                                               |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+#define STUN_TRANSACTION_ID_SIZE 12
+
+struct stun_header {
+	uint16_t type;
+	uint16_t length;
+	uint32_t magic;
+	uint8_t transaction_id[STUN_TRANSACTION_ID_SIZE];
+};
+
+/*
+ * Format of STUN Message Type Field
+ *
+ *  0                 1
+ *  2  3  4 5 6 7 8 9 0 1 2 3 4 5
+ * +--+--+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |M |M |M|M|M|C|M|M|M|C|M|M|M|M|
+ * |11|10|9|8|7|1|6|5|4|0|3|2|1|0|
+ * +--+--+-+-+-+-+-+-+-+-+-+-+-+-+
+ * Request:    C=b00
+ * Indication: C=b01
+ * Response:   C=b10 (success)
+ *             C=b11 (error)
+ */
+#define STUN_CLASS_MASK 0x0110
+
+typedef enum stun_class {
+	STUN_CLASS_REQUEST = 0x0000,
+	STUN_CLASS_INDICATION = 0x0010,
+	STUN_CLASS_RESP_SUCCESS = 0x0100,
+	STUN_CLASS_RESP_ERROR = 0x0110
+} stun_class_t;
+
+typedef enum stun_method {
+	STUN_METHOD_BINDING = 0x0001,
+
+	// Methods for TURN
+	// See https://www.rfc-editor.org/rfc/rfc8656.html#section-17
+	STUN_METHOD_ALLOCATE = 0x003,
+	STUN_METHOD_REFRESH = 0x004,
+	STUN_METHOD_SEND = 0x006,
+	STUN_METHOD_DATA = 0x007,
+	STUN_METHOD_CREATE_PERMISSION = 0x008,
+	STUN_METHOD_CHANNEL_BIND = 0x009
+} stun_method_t;
+
+#define STUN_IS_RESPONSE(msg_class) (msg_class & 0x0100)
+
+/*
+ * STUN attribute header
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |             Type              |            Length             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                        Value (variable)                     ...
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+struct stun_attr {
+	uint16_t type;
+	uint16_t length;
+	uint8_t value[];
+};
+
+typedef enum stun_attr_type {
+	// Comprehension-required
+	STUN_ATTR_MAPPED_ADDRESS = 0x0001,
+	STUN_ATTR_USERNAME = 0x0006,
+	STUN_ATTR_MESSAGE_INTEGRITY = 0x0008,
+	STUN_ATTR_ERROR_CODE = 0x0009,
+	STUN_ATTR_UNKNOWN_ATTRIBUTES = 0x000A,
+	STUN_ATTR_REALM = 0x0014,
+	STUN_ATTR_NONCE = 0x0015,
+	STUN_ATTR_MESSAGE_INTEGRITY_SHA256 = 0x001C,
+	STUN_ATTR_PASSWORD_ALGORITHM = 0x001D,
+	STUN_ATTR_USERHASH = 0x001E,
+	STUN_ATTR_XOR_MAPPED_ADDRESS = 0x0020,
+	STUN_ATTR_PRIORITY = 0x0024,
+	STUN_ATTR_USE_CANDIDATE = 0x0025,
+
+	// Comprehension-optional
+	STUN_ATTR_PASSWORD_ALGORITHMS = 0x8002,
+	STUN_ATTR_ALTERNATE_DOMAIN = 0x8003,
+	STUN_ATTR_SOFTWARE = 0x8022,
+	STUN_ATTR_ALTERNATE_SERVER = 0x8023,
+	STUN_ATTR_FINGERPRINT = 0x8028,
+	STUN_ATTR_ICE_CONTROLLED = 0x8029,
+	STUN_ATTR_ICE_CONTROLLING = 0x802A,
+
+	// Attributes for TURN
+	// See https://www.rfc-editor.org/rfc/rfc8656.html#section-18
+	STUN_ATTR_CHANNEL_NUMBER = 0x000C,
+	STUN_ATTR_LIFETIME = 0x000D,
+	STUN_ATTR_XOR_PEER_ADDRESS = 0x0012,
+	STUN_ATTR_DATA = 0x0013,
+	STUN_ATTR_XOR_RELAYED_ADDRESS = 0x0016,
+	STUN_ATTR_EVEN_PORT = 0x0018,
+	STUN_ATTR_REQUESTED_TRANSPORT = 0x0019,
+	STUN_ATTR_DONT_FRAGMENT = 0x001A,
+	STUN_ATTR_RESERVATION_TOKEN = 0x0022
+} stun_attr_type_t;
+
+#define STUN_IS_OPTIONAL_ATTR(attr_type) (attr_type & 0x8000)
+
+/*
+ * STUN attribute value for MAPPED-ADDRESS or XOR-MAPPED-ADDRESS
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |X X X X X X X X|    Family     |        Port or X-Port         |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                                                               |
+ * |           Address or X-Address (32 bits or 128 bits)          |
+ * |                                                               |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+struct stun_value_mapped_address {
+	uint8_t padding;
+	uint8_t family;
+	uint16_t port;
+	uint8_t address[];
+};
+
+typedef enum stun_address_family {
+	STUN_ADDRESS_FAMILY_IPV4 = 0x01,
+	STUN_ADDRESS_FAMILY_IPV6 = 0x02,
+} stun_address_family_t;
+
+/*
+ * STUN attribute value for ERROR-CODE
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |           Reserved, should be 0         |Class|     Number    |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |      Reason Phrase (variable)                               ...
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+struct stun_value_error_code {
+	uint16_t reserved;
+	uint8_t code_class; // lower 3 bits only, higher bits are reserved
+	uint8_t code_number;
+	uint8_t reason[];
+};
+
+#define STUN_ERROR_INTERNAL_VALIDATION_FAILED 599
+
+/*
+ * STUN attribute for CHANNEL-NUMBER
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |        Channel Number         |         RFFU = 0              |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+struct stun_value_channel_number {
+	uint16_t channel_number;
+	uint16_t reserved;
+};
+
+/*
+ * STUN attribute for EVEN-PORT
+ *
+ *  0
+ *  0 1 2 3 4 5 6 7
+ * +-+-+-+-+-+-+-+-+
+ * |R|    RFFU     |
+ * +-+-+-+-+-+-+-+-+
+ */
+struct stun_value_even_port {
+	uint8_t r;
+};
+
+/*
+ * STUN attribute for REQUESTED-TRANSPORT
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |    Protocol   |                    RFFU                       |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+struct stun_value_requested_transport {
+	uint8_t protocol;
+	uint8_t reserved1;
+	uint16_t reserved2;
+};
+
+/*
+ * STUN attribute value for PASSWORD-ALGORITHM and PASSWORD-ALGORITHMS
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |         Algorithm 1           | Algorithm 1 Parameters Length |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                    Algorithm 1 Parameters (variable)
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |         Algorithm 2           | Algorithm 2 Parameters Length |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                    Algorithm 2 Parameters (variable)
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                                                             ...
+ */
+struct stun_value_password_algorithm {
+	uint16_t algorithm;
+	uint16_t parameters_length;
+	uint8_t parameters[];
+};
+
+typedef enum stun_password_algorithm {
+	STUN_PASSWORD_ALGORITHM_UNSET = 0x0000,
+	STUN_PASSWORD_ALGORITHM_MD5 = 0x0001,
+	STUN_PASSWORD_ALGORITHM_SHA256 = 0x0002,
+} stun_password_algorithm_t;
+
+#pragma pack(pop)
+
+// The value of USERNAME is a variable-length value. It MUST contain a UTF-8 [RFC3629] encoded
+// sequence of less than 513 bytes [...]
+#define STUN_MAX_USERNAME_LEN 513 + 1
+
+// The REALM attribute [...] MUST be a UTF-8 [RFC3629] encoded sequence of less than 128 characters
+// (which can be as long as 763 bytes)
+#define STUN_MAX_REALM_LEN 763 + 1
+
+// The NONCE attribute may be present in requests and responses. It [...] MUST be less than 128
+// characters (which can be as long as 763 bytes)
+#define STUN_MAX_NONCE_LEN 763 + 1
+
+// The value of SOFTWARE is variable length. It MUST be a UTF-8 [RFC3629] encoded sequence of less
+// than 128 characters (which can be as long as 763 bytes)
+#define STUN_MAX_SOFTWARE_LEN 763 + 1
+
+// The reason phrase MUST be a UTF-8-encoded [RFC3629] sequence of fewer than 128 characters (which
+// can be as long as 509 bytes when encoding them or 763 bytes when decoding them).
+#define STUN_MAX_ERROR_REASON_LEN 763 + 1
+
+#define STUN_MAX_PASSWORD_LEN STUN_MAX_USERNAME_LEN
+
+// Nonce cookie prefix as specified in https://www.rfc-editor.org/rfc/rfc8489.html#section-9.2
+#define STUN_NONCE_COOKIE "obMatJos2"
+#define STUN_NONCE_COOKIE_LEN 9
+
+// USERHASH is a SHA256 digest
+#define USERHASH_SIZE HASH_SHA256_SIZE
+
+// STUN Security Feature bits as defined in https://www.rfc-editor.org/rfc/rfc8489.html#section-18.1
+// See errata about bit order: https://www.rfc-editor.org/errata_search.php?rfc=8489
+// Bits are assigned starting from the least significant side of the bit set, so Bit 0 is the rightmost bit, and Bit 23 is the leftmost bit.
+// Bit 0: Password algorithms
+// Bit 1: Username anonymity
+// Bit 2-23: Unassigned
+
+#define STUN_SECURITY_PASSWORD_ALGORITHMS_BIT 0x01
+#define STUN_SECURITY_USERNAME_ANONYMITY_BIT 0x02
+
+#define STUN_MAX_PASSWORD_ALGORITHMS_VALUE_SIZE 256
+
+// RFC 5766: When forming a CreatePermission request, the client MUST include at least one XOR-PEER-ADDRESS attribute, and MAY include more than one such attribute.
+#define STUN_MAX_PEER_ADDRESSES 8
+
+typedef struct stun_credentials {
+	char username[STUN_MAX_USERNAME_LEN];
+	char realm[STUN_MAX_REALM_LEN];
+	char nonce[STUN_MAX_NONCE_LEN];
+	uint8_t userhash[USERHASH_SIZE];
+	bool enable_userhash;
+	stun_password_algorithm_t password_algorithm;
+	uint8_t password_algorithms_value[STUN_MAX_PASSWORD_ALGORITHMS_VALUE_SIZE];
+	size_t password_algorithms_value_size;
+} stun_credentials_t;
+
+typedef struct stun_message {
+	stun_class_t msg_class;
+	stun_method_t msg_method;
+	uint8_t transaction_id[STUN_TRANSACTION_ID_SIZE];
+	unsigned int error_code;
+	uint32_t priority;
+	uint64_t ice_controlling;
+	uint64_t ice_controlled;
+	bool use_candidate;
+	addr_record_t mapped;
+
+	stun_credentials_t credentials;
+
+	// Only for reading
+	bool has_integrity;
+	bool has_fingerprint;
+
+	// TURN
+	addr_record_t peers[STUN_MAX_PEER_ADDRESSES];
+	size_t peers_size;
+	addr_record_t relayed;
+	addr_record_t alternate_server;
+	const char *data;
+	size_t data_size;
+	uint32_t lifetime;
+	uint16_t channel_number;
+	bool lifetime_set;
+	bool even_port;
+	bool next_port;
+	bool dont_fragment;
+	bool requested_transport;
+	uint64_t reservation_token;
+
+} stun_message_t;
+
+int stun_write(void *buf, size_t size, const stun_message_t *msg,
+               const char *password); // password may be NULL
+int stun_write_header(void *buf, size_t size, stun_class_t class, stun_method_t method,
+                      const uint8_t *transaction_id);
+size_t stun_update_header_length(void *buf, size_t length);
+int stun_write_attr(void *buf, size_t size, uint16_t type, const void *value, size_t length);
+int stun_write_value_mapped_address(void *buf, size_t size, const struct sockaddr *addr,
+                                    socklen_t addrlen, const uint8_t *mask);
+
+bool is_stun_datagram(const void *data, size_t size);
+
+int stun_read(void *data, size_t size, stun_message_t *msg);
+int stun_read_attr(const void *data, size_t size, stun_message_t *msg, uint8_t *begin,
+                   uint8_t *attr_begin, uint32_t *security_bits);
+int stun_read_value_mapped_address(const void *data, size_t size, addr_record_t *mapped,
+                                   const uint8_t *mask);
+
+bool stun_check_integrity(void *buf, size_t size, const stun_message_t *msg, const char *password);
+
+void stun_compute_userhash(const char *username, const char *realm, uint8_t *out);
+void stun_prepend_nonce_cookie(char *nonce);
+void stun_process_credentials(const stun_credentials_t *credentials, stun_credentials_t *dst);
+
+const char *stun_get_error_reason(unsigned int code);
+
+// Export for tests
+JUICE_EXPORT bool _juice_is_stun_datagram(const void *data, size_t size);
+JUICE_EXPORT int _juice_stun_read(void *data, size_t size, stun_message_t *msg);
+JUICE_EXPORT int _juice_stun_write(void *buf, size_t size, const stun_message_t *msg, const char *password);
+JUICE_EXPORT bool _juice_stun_check_integrity(void *buf, size_t size, const stun_message_t *msg,
+                                              const char *password);
+
+#endif

--- a/Source/3rdParty/libjuice/src/tcp.c
+++ b/Source/3rdParty/libjuice/src/tcp.c
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "tcp.h"
+#include "log.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#define BUFFER_SIZE 1024
+
+socket_t tcp_create_socket(const addr_record_t *dst) {
+	socket_t sock = socket(dst->addr.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	if (sock == INVALID_SOCKET) {
+		JLOG_WARN("TCP socket creation failed, errno=%d", sockerrno);
+		return INVALID_SOCKET;
+	}
+
+	ctl_t nbio = 1;
+	if (ioctlsocket(sock, FIONBIO, &nbio)) {
+		JLOG_ERROR("Setting non-blocking mode on TCP socket failed, errno=%d", sockerrno);
+		goto error;
+	}
+
+	int ret = connect(sock, (const struct sockaddr *)&dst->addr, dst->len);
+	if (ret != 0 && sockerrno != SEINPROGRESS && sockerrno != SEWOULDBLOCK) {
+		JLOG_WARN("TCP connection failed, errno=%d", sockerrno);
+		goto error;
+	}
+
+	return sock;
+
+error:
+	if (sock != INVALID_SOCKET)
+		closesocket(sock);
+
+	return INVALID_SOCKET;
+}
+
+// Write datagram to TCP socket with RFC4571 framing
+int tcp_ice_write(socket_t sock, const char *data, size_t size, tcp_ice_write_context_t *context) {
+#if defined(__APPLE__) || defined(_WIN32)
+	int flags = 0;
+#else
+	int flags = MSG_NOSIGNAL;
+#endif
+
+	if (data) {
+		if (context->pending)
+			return -SEAGAIN;
+
+		if (size > TCP_ICE_BUFFER_SIZE)
+			return -SEMSGSIZE;
+
+		memcpy(context->buffer, data, size);
+		context->length = (uint16_t)size;
+		context->bytes_written = 0;
+		context->pending = true;
+	}
+
+	while(context->pending && context->bytes_written < 2 + context->length) {
+		int len;
+		if (context->bytes_written < 2) {
+			uint16_t header = htons(context->length);
+			len = send(sock, (const char *)&header + context->bytes_written, 2 - context->bytes_written, flags);
+		} else { // bytes_written >= 2
+			len = send(sock, context->buffer + (context->bytes_written - 2), context->length - (context->bytes_written - 2), flags);
+		}
+
+		if (len < 0)
+			return len;
+
+		context->bytes_written += len;
+	}
+
+	context->pending = false;
+	return (int)context->length;
+}
+
+// Read datagram from TCP socket with RFC4571 framing (discard empty datagrams)
+int tcp_ice_read(socket_t sock, tcp_ice_read_context_t *context) {
+#if defined(__APPLE__) || defined(_WIN32)
+	int flags = 0;
+#else
+	int flags = MSG_NOSIGNAL;
+#endif
+
+	if (!context->pending) {
+		context->length = 0;
+		context->bytes_read = 0;
+		context->pending = true;
+	}
+
+	int len;
+	while (context->bytes_read < 2 + context->length) {
+		if (context->bytes_read < 2) {
+			len = recv(sock, (char *)&context->header + context->bytes_read, 2 - context->bytes_read, flags);
+		} else { // bytes_read >= 2
+			if (context->bytes_read < 2 + TCP_ICE_BUFFER_SIZE) {
+				uint16_t length = context->length;
+				if (length > TCP_ICE_BUFFER_SIZE)
+					length = TCP_ICE_BUFFER_SIZE;
+
+				len = recv(sock, context->buffer + (context->bytes_read - 2), length - (context->bytes_read - 2), flags);
+			} else {
+				char buffer[BUFFER_SIZE];
+				size_t size = context->length - (context->bytes_read - 2);
+				if (size > BUFFER_SIZE)
+					size = BUFFER_SIZE;
+
+				len = recv(sock, buffer, (socklen_t)size, flags);
+			}
+		}
+
+		if (len < 0) {
+			if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK)
+				JLOG_DEBUG("TCP recv failed, errno=%d", sockerrno);
+
+			return -sockerrno;
+		}
+
+		if (len == 0)
+			return 0; // closed
+
+		context->bytes_read += len;
+
+		if(context->bytes_read == 2)
+			context->length = ntohs(context->header);
+
+		if (context->length == 0)
+			context->bytes_read = 0; // discard empty datagram
+	}
+
+	context->pending = false;
+	assert(context->length > 0);
+	return (int)context->length;
+}
+
+JUICE_EXPORT int _juice_tcp_ice_write(socket_t sock, const char *data, size_t size, tcp_ice_write_context_t *context) {
+	return tcp_ice_write(sock, data, size, context);
+}
+
+JUICE_EXPORT int _juice_tcp_ice_read(socket_t sock, tcp_ice_read_context_t *context) {
+	return tcp_ice_read(sock, context);
+}
+

--- a/Source/3rdParty/libjuice/src/tcp.h
+++ b/Source/3rdParty/libjuice/src/tcp.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_TCP_H
+#define JUICE_TCP_H
+
+#include "addr.h"
+#include "juice.h"
+#include "socket.h"
+
+typedef enum tcp_state {
+	TCP_STATE_DISCONNECTED,
+	TCP_STATE_CONNECTING,
+	TCP_STATE_CONNECTED,
+	TCP_STATE_FAILED
+} tcp_state_t;
+
+socket_t tcp_create_socket(const addr_record_t *dst);
+
+#define TCP_ICE_BUFFER_SIZE 2048
+
+typedef struct tcp_ice_write_context {
+	char buffer[TCP_ICE_BUFFER_SIZE];
+	uint16_t length;
+	uint16_t bytes_written;
+	bool pending;
+} tcp_ice_write_context_t;
+
+typedef struct tcp_ice_read_context {
+	char buffer[TCP_ICE_BUFFER_SIZE];
+	uint16_t length;
+	uint16_t bytes_read; // 0 if finished
+	uint16_t header;
+	bool pending;
+} tcp_ice_read_context_t;
+
+int tcp_ice_write(socket_t sock, const char *data, size_t size, tcp_ice_write_context_t *context);
+int tcp_ice_read(socket_t sock, tcp_ice_read_context_t *context);
+
+// Export for tests
+JUICE_EXPORT int _juice_tcp_ice_write(socket_t sock, const char *data, size_t size, tcp_ice_write_context_t *context);
+JUICE_EXPORT int _juice_tcp_ice_read(socket_t sock, tcp_ice_read_context_t *context);
+
+#endif

--- a/Source/3rdParty/libjuice/src/thread.h
+++ b/Source/3rdParty/libjuice/src/thread.h
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_THREAD_H
+#define JUICE_THREAD_H
+
+#ifdef _WIN32
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601 // Windows 7
+#endif
+#ifndef __MSVCRT_VERSION__
+#define __MSVCRT_VERSION__ 0x0601
+#endif
+
+#include <windows.h>
+
+typedef HRESULT(WINAPI *pfnSetThreadDescription)(HANDLE, PCWSTR); // for thread_set_name_self()
+
+typedef HANDLE mutex_t;
+typedef HANDLE thread_t;
+typedef DWORD thread_return_t;
+#define THREAD_CALL __stdcall
+
+#define MUTEX_INITIALIZER NULL
+
+#define MUTEX_PLAIN 0x0
+#define MUTEX_RECURSIVE 0x0 // mutexes are recursive on Windows
+
+static inline int mutex_init_impl(mutex_t *m) {
+	return ((*(m) = CreateMutex(NULL, FALSE, NULL)) != NULL ? 0 : (int)GetLastError());
+}
+
+static inline int mutex_lock_impl(volatile mutex_t *m) {
+	// Atomically initialize the mutex on first lock
+	if (*(m) == NULL) {
+		HANDLE cm = CreateMutex(NULL, FALSE, NULL);
+		if (cm == NULL)
+			return (int)GetLastError();
+		if (InterlockedCompareExchangePointer(m, cm, NULL) != NULL)
+			CloseHandle(cm);
+	}
+	return WaitForSingleObject(*m, INFINITE) != WAIT_FAILED ? 0 : (int)GetLastError();
+}
+
+#define mutex_init(m, flags) mutex_init_impl(m)
+#define mutex_lock(m) mutex_lock_impl(m)
+#define mutex_unlock(m) (void)ReleaseMutex(*(m))
+#define mutex_destroy(m) (void)CloseHandle(*(m))
+
+static inline void thread_join_impl(thread_t t, thread_return_t *res) {
+	WaitForSingleObject(t, INFINITE);
+	if (res)
+		GetExitCodeThread(t, res);
+	CloseHandle(t);
+}
+
+#define thread_init(t, func, arg)                                                                  \
+	((*(t) = CreateThread(NULL, 0, func, arg, 0, NULL)) != NULL ? 0 : (int)GetLastError())
+#define thread_join(t, res) thread_join_impl(t, res)
+
+#else // POSIX
+
+#include <pthread.h>
+
+#if defined(__linux__)
+#include <sys/prctl.h> // for prctl(PR_SET_NAME)
+#endif
+#if defined(__FreeBSD__)
+#include <pthread_np.h> // for pthread_set_name_np
+#endif
+
+typedef pthread_mutex_t mutex_t;
+typedef pthread_t thread_t;
+typedef void *thread_return_t;
+#define THREAD_CALL
+
+#define MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
+#define MUTEX_PLAIN PTHREAD_MUTEX_NORMAL
+#define MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE
+
+static inline int mutex_init_impl(mutex_t *m, int flags) {
+	pthread_mutexattr_t mutexattr;
+	pthread_mutexattr_init(&mutexattr);
+	pthread_mutexattr_settype(&mutexattr, flags);
+	int ret = pthread_mutex_init(m, &mutexattr);
+	pthread_mutexattr_destroy(&mutexattr);
+	return ret;
+}
+
+#define mutex_init(m, flags) mutex_init_impl(m, flags)
+#define mutex_lock(m) pthread_mutex_lock(m)
+#define mutex_unlock(m) (void)pthread_mutex_unlock(m)
+#define mutex_destroy(m) (void)pthread_mutex_destroy(m)
+
+#define thread_init(t, func, arg) pthread_create(t, NULL, func, arg)
+#define thread_join(t, res) (void)pthread_join(t, res)
+
+#endif // ifdef _WIN32
+
+static inline void thread_set_name_self(const char *name) {
+#if defined(_WIN32)
+	wchar_t wname[256];
+	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name, -1, wname, 256) > 0) {
+		HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
+		if (kernel32) {
+			pfnSetThreadDescription pSetThreadDescription =
+			    (pfnSetThreadDescription)GetProcAddress(kernel32, "SetThreadDescription");
+			if (pSetThreadDescription) {
+				pSetThreadDescription(GetCurrentThread(), wname);
+			}
+		}
+	}
+#elif defined(__linux__)
+	prctl(PR_SET_NAME, name);
+#elif defined(__APPLE__)
+	pthread_setname_np(name);
+#elif defined(__FreeBSD__)
+	pthread_set_name_np(pthread_self(), name);
+#else
+	(void)name;
+#endif
+}
+
+#if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+
+#include <stdatomic.h>
+#define atomic(T) _Atomic(T)
+#define atomic_ptr(T) _Atomic(T *)
+
+#else // no atomics
+
+// Since we don't need compare-and-swap, just assume store and load are atomic
+#define atomic(T) volatile T
+#define atomic_ptr(T) T *volatile
+#define atomic_store(a, v) (void)(*(a) = (v))
+#define atomic_load(a) (*(a))
+
+#endif // if atomics
+
+#endif // JUICE_THREAD_H

--- a/Source/3rdParty/libjuice/src/timestamp.c
+++ b/Source/3rdParty/libjuice/src/timestamp.c
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "timestamp.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <time.h>
+
+// clock_gettime() is not implemented on older versions of OS X (< 10.12)
+#if defined(__APPLE__) && !defined(CLOCK_MONOTONIC)
+#include <sys/time.h>
+#define CLOCK_MONOTONIC 0
+int clock_gettime(int clk_id, struct timespec *t) {
+	(void)clk_id;
+
+	// gettimeofday() does not return monotonic time but it should be good enough.
+	struct timeval now;
+	if (gettimeofday(&now, NULL))
+		return -1;
+
+	t->tv_sec = now.tv_sec;
+	t->tv_nsec = now.tv_usec * 1000;
+	return 0;
+}
+#endif // defined(__APPLE__) && !defined(CLOCK_MONOTONIC)
+
+#endif
+
+timestamp_t current_timestamp() {
+#ifdef _WIN32
+	return (timestamp_t)GetTickCount();
+#else // POSIX
+	struct timespec ts;
+	if (clock_gettime(CLOCK_MONOTONIC, &ts))
+		return 0;
+	return (timestamp_t)ts.tv_sec * 1000 + (timestamp_t)ts.tv_nsec / 1000000;
+#endif
+}

--- a/Source/3rdParty/libjuice/src/timestamp.h
+++ b/Source/3rdParty/libjuice/src/timestamp.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_TIMESTAMP_H
+#define JUICE_TIMESTAMP_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int64_t timestamp_t;
+typedef timestamp_t timediff_t;
+
+timestamp_t current_timestamp();
+
+#endif

--- a/Source/3rdParty/libjuice/src/turn.c
+++ b/Source/3rdParty/libjuice/src/turn.c
@@ -1,0 +1,514 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "turn.h"
+#include "log.h"
+#include "random.h"
+#include "socket.h"
+
+#include <string.h>
+
+static bool memory_is_zero(const void *data, size_t size) {
+	const char *d = data;
+	for (size_t i = 0; i < size; ++i)
+		if (d[i])
+			return false;
+
+	return true;
+}
+
+static uint16_t random_channel_number() {
+	/*
+	 * RFC 8656 12. Channels
+	 * The ChannelData message (see Section 12.4) starts with a two-byte
+	 * field that carries the channel number.  The values of this field are
+	 * allocated as follows:
+	 *
+	 *   +------------------------+--------------------------------------+
+	 *   | 0x0000 through 0x3FFF: | These values can never be used for   |
+	 *   |                        | channel numbers.                     |
+	 *   +------------------------+--------------------------------------+
+	 *   | 0x4000 through 0x4FFF: | These values are the allowed channel |
+	 *   |                        | numbers (4096 possible values).      |
+	 *   +------------------------+--------------------------------------+
+	 *   | 0x5000 through 0xFFFF: | Reserved (For DTLS-SRTP multiplexing |
+	 *   |                        | collision avoidance, see [RFC7983]). |
+	 *   +------------------------+--------------------------------------+
+	 */
+	uint16_t r;
+	juice_random(&r, 2);
+	return 0x4000 | (r & 0x0FFF);
+}
+
+bool is_channel_data(const void *data, size_t size) {
+	// According RFC 8656, first byte in [64..79] is TURN Channel
+	if (size == 0)
+		return false;
+	uint8_t b = *((const uint8_t *)data);
+	return b >= 64 && b <= 79;
+}
+
+bool is_valid_channel(uint16_t channel) { return channel >= 0x4000; }
+
+int turn_wrap_channel_data(char *buffer, size_t size, const char *data, size_t data_size,
+                           uint16_t channel) {
+	if (!is_valid_channel(channel)) {
+		JLOG_WARN("Invalid channel number: 0x%hX", channel);
+		return -1;
+	}
+	if (data_size >= 65536) {
+		JLOG_WARN("ChannelData is too long, size=%zu", size);
+		return -1;
+	}
+	if (size < sizeof(struct channel_data_header) + data_size) {
+		JLOG_WARN("Buffer is too small to add ChannelData header, size=%zu, needed=%zu", size,
+		          sizeof(struct channel_data_header) + data_size);
+		return -1;
+	}
+
+	memmove(buffer + sizeof(struct channel_data_header), data, data_size);
+	struct channel_data_header *header = (struct channel_data_header *)buffer;
+	header->channel_number = htons((uint16_t)channel);
+	header->length = htons((uint16_t)data_size);
+	return (int)(sizeof(struct channel_data_header) + data_size);
+}
+
+static int find_ordered_channel_rec(turn_entry_t *const ordered_channels[], uint16_t channel,
+                                    int begin, int end) {
+	int d = end - begin;
+	if (d <= 0)
+		return begin;
+
+	int pivot = begin + d / 2;
+	const turn_entry_t *entry = ordered_channels[pivot];
+	if (channel < entry->channel)
+		return find_ordered_channel_rec(ordered_channels, channel, begin, pivot);
+	else if (channel > entry->channel)
+		return find_ordered_channel_rec(ordered_channels, channel, pivot + 1, end);
+	else
+		return pivot;
+}
+
+static int find_ordered_channel(const turn_map_t *map, uint16_t channel) {
+	return find_ordered_channel_rec(map->ordered_channels, channel, 0, map->channels_count);
+}
+
+static int find_ordered_transaction_id_rec(turn_entry_t *const ordered_transaction_ids[],
+                                           const uint8_t *transaction_id, int begin, int end) {
+	int d = end - begin;
+	if (d <= 0)
+		return begin;
+
+	int pivot = begin + d / 2;
+	const turn_entry_t *entry = ordered_transaction_ids[pivot];
+	int ret = memcmp(transaction_id, entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+	if (ret < 0)
+		return find_ordered_transaction_id_rec(ordered_transaction_ids, transaction_id, begin,
+		                                       pivot);
+	else if (ret > 0)
+		return find_ordered_transaction_id_rec(ordered_transaction_ids, transaction_id, pivot + 1,
+		                                       end);
+	else
+		return pivot;
+}
+
+static int find_ordered_transaction_id(const turn_map_t *map, const uint8_t *transaction_id) {
+	return find_ordered_transaction_id_rec(map->ordered_transaction_ids, transaction_id, 0,
+	                                       map->transaction_ids_count);
+}
+
+static void remove_ordered_transaction_id(turn_map_t *map, const uint8_t *transaction_id) {
+	int pos = find_ordered_transaction_id(map, transaction_id);
+	if (pos < map->transaction_ids_count) {
+		memmove(map->ordered_transaction_ids + pos, map->ordered_transaction_ids + pos + 1,
+		        (map->transaction_ids_count - (pos + 1)) * sizeof(turn_entry_t *));
+		map->transaction_ids_count--;
+	}
+}
+/*
+static void remove_ordered_channel(turn_map_t *map, uint16_t channel) {
+    int pos = find_ordered_channel(map, channel);
+    if (pos < map->channels_count) {
+        memmove(map->ordered_channels + pos, map->ordered_channels + pos + 1,
+                (map->channels_count - (pos + 1)) * sizeof(turn_entry_t *));
+        map->channels_count--;
+    }
+}
+
+static void delete_entry(turn_map_t *map, turn_entry_t *entry) {
+    if (entry->type == TURN_ENTRY_TYPE_EMPTY || entry->type == TURN_ENTRY_TYPE_DELETED)
+        return;
+
+    if (!memory_is_zero(entry->transaction_id, STUN_TRANSACTION_ID_SIZE))
+        remove_ordered_transaction_id(map, entry->transaction_id);
+
+    if (entry->type == TURN_ENTRY_TYPE_CHANNEL && entry->channel)
+        remove_ordered_channel(map, entry->channel);
+
+    memset(entry, 0, sizeof(*entry));
+    entry->type = TURN_ENTRY_TYPE_DELETED;
+}
+*/
+static turn_entry_t *find_entry(turn_map_t *map, const addr_record_t *record,
+                                turn_entry_type_t type, bool allow_deleted) {
+	// RFC 5766: (For permissions) only addresses are compared and port numbers are not considered
+	bool with_port = (type != TURN_ENTRY_TYPE_PERMISSION);
+	unsigned long key = addr_record_hash(record, with_port) % map->map_size;
+	unsigned long pos = key;
+	while (true) {
+		turn_entry_t *entry = map->map + pos;
+		if (entry->type == TURN_ENTRY_TYPE_EMPTY ||
+		    (entry->type == type &&
+		     addr_record_is_equal(&entry->record, record, with_port)))
+			break;
+
+		if (allow_deleted && entry->type == TURN_ENTRY_TYPE_DELETED)
+			break;
+
+		pos = (pos + 1) % map->map_size;
+		if (pos == key) {
+			JLOG_VERBOSE("TURN map is full");
+			return NULL;
+		}
+	}
+	return map->map + pos;
+}
+
+static bool update_timestamp(turn_map_t *map, turn_entry_type_t type, const uint8_t *transaction_id,
+                             const addr_record_t *record, timediff_t duration) {
+	turn_entry_t *entry;
+	if (record) {
+		entry = find_entry(map, record, type, true);
+		if (!entry)
+			return false;
+
+		if (entry->type == type) {
+			if (memcmp(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE) == 0)
+				return true;
+		} else {
+			entry->type = type;
+			entry->record = *record;
+		}
+
+		if (!memory_is_zero(entry->transaction_id, STUN_TRANSACTION_ID_SIZE))
+			remove_ordered_transaction_id(map, entry->transaction_id);
+
+		memcpy(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	} else {
+		int pos = find_ordered_transaction_id(map, transaction_id);
+		if (pos == map->transaction_ids_count)
+			return false;
+
+		entry = map->ordered_transaction_ids[pos];
+		if (entry->type != type ||
+		    memcmp(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE) != 0)
+			return false;
+	}
+
+	entry->timestamp = current_timestamp() + duration;
+	entry->fresh_transaction_id = false;
+	return true;
+}
+
+int turn_init_map(turn_map_t *map, int size) {
+	memset(map, 0, sizeof(*map));
+
+	map->map_size = size * 2;
+	map->channels_count = 0;
+	map->transaction_ids_count = 0;
+
+	map->map = calloc(map->map_size, sizeof(turn_entry_t));
+	map->ordered_channels = calloc(map->map_size, sizeof(turn_entry_t *));
+	map->ordered_transaction_ids = calloc(map->map_size, sizeof(turn_entry_t *));
+
+	if (!map->map || !map->ordered_channels || !map->ordered_transaction_ids) {
+		JLOG_ERROR("Failed to allocate TURN map of size %d", size);
+		turn_destroy_map(map);
+		return -1;
+	}
+
+	return 0;
+}
+
+void turn_destroy_map(turn_map_t *map) {
+	free(map->map);
+	free(map->ordered_channels);
+	free(map->ordered_transaction_ids);
+}
+
+bool turn_set_permission(turn_map_t *map, const uint8_t *transaction_id,
+                         const addr_record_t *record, timediff_t duration) {
+	if (record) {
+		if (JLOG_DEBUG_ENABLED) {
+			char record_str[ADDR_MAX_STRING_LEN];
+			addr_record_to_string(record, record_str, ADDR_MAX_STRING_LEN);
+			JLOG_DEBUG("Updating TURN permission for address %s", record_str);
+		}
+	}
+	return update_timestamp(map, TURN_ENTRY_TYPE_PERMISSION, transaction_id, record, duration);
+}
+
+bool turn_has_permission(turn_map_t *map, const addr_record_t *record) {
+	turn_entry_t *entry = find_entry(map, record, TURN_ENTRY_TYPE_PERMISSION, false);
+	if (!entry || entry->type != TURN_ENTRY_TYPE_PERMISSION)
+		return false;
+
+	return current_timestamp() < entry->timestamp;
+}
+
+bool turn_bind_channel(turn_map_t *map, const addr_record_t *record, const uint8_t *transaction_id,
+                       uint16_t channel, timediff_t duration) {
+	if(!record)
+		return false;
+
+	if (JLOG_DEBUG_ENABLED) {
+		char record_str[ADDR_MAX_STRING_LEN];
+		addr_record_to_string(record, record_str, ADDR_MAX_STRING_LEN);
+		JLOG_DEBUG("Binding TURN channel %hu to address %s", channel, record_str);
+	}
+
+	if (!is_valid_channel(channel)) {
+		JLOG_ERROR("Invalid channel number: 0x%hX", channel);
+		return false;
+	}
+
+	turn_entry_t *entry = find_entry(map, record, TURN_ENTRY_TYPE_CHANNEL, true);
+	if (!entry)
+		return false;
+
+	if (entry->type == TURN_ENTRY_TYPE_CHANNEL && entry->channel) {
+		if (entry->channel != channel) {
+			JLOG_WARN("The record is already bound to a channel");
+			return false;
+		}
+
+		entry->timestamp = current_timestamp() + duration;
+		return true;
+	}
+
+	int pos = find_ordered_channel(map, channel);
+	if (pos < map->channels_count) {
+		const turn_entry_t *other_entry = map->ordered_channels[pos];
+		if (other_entry->channel == channel) {
+			JLOG_WARN("The channel is already bound to a record");
+			return false;
+		}
+	}
+
+	if (entry->type != TURN_ENTRY_TYPE_CHANNEL) {
+		entry->type = TURN_ENTRY_TYPE_CHANNEL;
+		entry->record = *record;
+	}
+
+	memmove(map->ordered_channels + pos + 1, map->ordered_channels + pos,
+	        (map->channels_count - pos) * sizeof(turn_entry_t *));
+	map->ordered_channels[pos] = entry;
+	map->channels_count++;
+
+	entry->channel = channel;
+	entry->timestamp = current_timestamp() + duration;
+
+	if (transaction_id) {
+		memcpy(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+		entry->fresh_transaction_id = true;
+	}
+
+	return true;
+}
+
+bool turn_bind_random_channel(turn_map_t *map, const addr_record_t *record, uint16_t *channel,
+                              timediff_t duration) {
+	uint16_t c;
+	do {
+		c = random_channel_number();
+	} while (turn_find_channel(map, c, NULL));
+
+	if (!turn_bind_channel(map, record, NULL, c, duration))
+		return false;
+
+	if (channel)
+		*channel = c;
+
+	return true;
+}
+
+bool turn_bind_current_channel(turn_map_t *map, const uint8_t *transaction_id,
+                               const addr_record_t *record, timediff_t duration) {
+	return update_timestamp(map, TURN_ENTRY_TYPE_CHANNEL, transaction_id, record, duration);
+}
+
+bool turn_get_channel(turn_map_t *map, const addr_record_t *record, uint16_t *channel) {
+	turn_entry_t *entry = find_entry(map, record, TURN_ENTRY_TYPE_CHANNEL, false);
+	if (!entry || entry->type != TURN_ENTRY_TYPE_CHANNEL)
+		return false;
+
+	if (channel)
+		*channel = entry->channel;
+
+	return true;
+}
+
+bool turn_get_bound_channel(turn_map_t *map, const addr_record_t *record, uint16_t *channel) {
+	turn_entry_t *entry = find_entry(map, record, TURN_ENTRY_TYPE_CHANNEL, false);
+	if (!entry || entry->type != TURN_ENTRY_TYPE_CHANNEL)
+		return false;
+
+	if (!entry->channel || current_timestamp() >= entry->timestamp)
+		return false;
+
+	if (channel)
+		*channel = entry->channel;
+
+	return true;
+}
+
+bool turn_find_channel(turn_map_t *map, uint16_t channel, addr_record_t *record) {
+	if (!is_valid_channel(channel)) {
+		JLOG_WARN("Invalid channel number: 0x%hX", channel);
+		return false;
+	}
+
+	int pos = find_ordered_channel(map, channel);
+	if (pos == map->channels_count)
+		return false;
+
+	const turn_entry_t *entry = map->ordered_channels[pos];
+	if (entry->channel != channel)
+		return false;
+
+	if (record)
+		*record = entry->record;
+
+	return true;
+}
+
+bool turn_find_bound_channel(turn_map_t *map, uint16_t channel, addr_record_t *record) {
+	if (!is_valid_channel(channel)) {
+		JLOG_WARN("Invalid channel number: 0x%hX", channel);
+		return false;
+	}
+
+	int pos = find_ordered_channel(map, channel);
+	if (pos == map->channels_count)
+		return false;
+
+	const turn_entry_t *entry = map->ordered_channels[pos];
+	if (entry->channel != channel || current_timestamp() >= entry->timestamp)
+		return false;
+
+	if (record)
+		*record = entry->record;
+
+	return true;
+}
+
+static bool set_transaction_id(turn_map_t *map, turn_entry_type_t type, const addr_record_t *record,
+                               const uint8_t *transaction_id) {
+	if (type != TURN_ENTRY_TYPE_PERMISSION && type != TURN_ENTRY_TYPE_CHANNEL)
+		return false;
+
+	turn_entry_t *entry = find_entry(map, record, type, true);
+	if (!entry)
+		return false;
+
+	if (entry->type == type && !memory_is_zero(entry->transaction_id, STUN_TRANSACTION_ID_SIZE))
+		remove_ordered_transaction_id(map, entry->transaction_id);
+
+	int pos = find_ordered_transaction_id(map, transaction_id);
+	memmove(map->ordered_transaction_ids + pos + 1, map->ordered_transaction_ids + pos,
+	        (map->transaction_ids_count - pos) * sizeof(turn_entry_t *));
+	map->ordered_transaction_ids[pos] = entry;
+	map->transaction_ids_count++;
+
+	if (entry->type != type) {
+		entry->type = type;
+		entry->record = *record;
+	}
+
+	memcpy(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+	entry->fresh_transaction_id = true;
+	return true;
+}
+
+static bool find_transaction_id(turn_map_t *map, const uint8_t *transaction_id,
+                                addr_record_t *record) {
+	int pos = find_ordered_transaction_id(map, transaction_id);
+	if (pos == map->transaction_ids_count)
+		return false;
+
+	const turn_entry_t *entry = map->ordered_transaction_ids[pos];
+	if (memcmp(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE) != 0)
+		return false;
+
+	if (record)
+		*record = entry->record;
+
+	return true;
+}
+
+static bool set_random_transaction_id(turn_map_t *map, turn_entry_type_t type,
+                                      const addr_record_t *record, uint8_t *transaction_id) {
+	turn_entry_t *entry = find_entry(map, record, type, false);
+	if (entry && entry->fresh_transaction_id) {
+		if (transaction_id)
+			memcpy(transaction_id, entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+		return true;
+	}
+
+	uint8_t tid[STUN_TRANSACTION_ID_SIZE];
+	do {
+		juice_random(tid, STUN_TRANSACTION_ID_SIZE);
+	} while (find_transaction_id(map, tid, NULL));
+
+	if (!set_transaction_id(map, type, record, tid))
+		return false;
+
+	if (transaction_id)
+		memcpy(transaction_id, tid, STUN_TRANSACTION_ID_SIZE);
+
+	return true;
+}
+
+bool turn_set_permission_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                        const uint8_t *transaction_id) {
+	return set_transaction_id(map, TURN_ENTRY_TYPE_PERMISSION, record, transaction_id);
+}
+
+bool turn_set_channel_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                     const uint8_t *transaction_id) {
+	return set_transaction_id(map, TURN_ENTRY_TYPE_CHANNEL, record, transaction_id);
+}
+
+bool turn_set_random_permission_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                               uint8_t *transaction_id) {
+	return set_random_transaction_id(map, TURN_ENTRY_TYPE_PERMISSION, record, transaction_id);
+}
+
+bool turn_set_random_channel_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                            uint8_t *transaction_id) {
+	return set_random_transaction_id(map, TURN_ENTRY_TYPE_CHANNEL, record, transaction_id);
+}
+
+bool turn_retrieve_transaction_id(turn_map_t *map, const uint8_t *transaction_id,
+                                  addr_record_t *record) {
+	int pos = find_ordered_transaction_id(map, transaction_id);
+	if (pos == map->transaction_ids_count)
+		return false;
+
+	turn_entry_t *entry = map->ordered_transaction_ids[pos];
+	if (memcmp(entry->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE) != 0)
+		return false;
+
+	if (record)
+		*record = entry->record;
+
+	entry->fresh_transaction_id = false;
+	return true;
+}

--- a/Source/3rdParty/libjuice/src/turn.h
+++ b/Source/3rdParty/libjuice/src/turn.h
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_TURN_H
+#define JUICE_TURN_H
+
+#include "addr.h"
+#include "ice.h"
+#include "juice.h"
+#include "log.h"
+#include "stun.h"
+#include "timestamp.h"
+
+#include <stdint.h>
+
+#pragma pack(push, 1)
+/*
+ * TURN ChannelData Message
+ * See https://www.rfc-editor.org/rfc/rfc8656.html#section-12.4
+ *
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |         Channel Number        |            Length             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                                                               |
+ * /                       Application Data                        /
+ * /                                                               /
+ * |                                                               |
+ * |                               +-------------------------------+
+ * |                               |
+ * +-------------------------------+
+ */
+
+struct channel_data_header {
+	uint16_t channel_number;
+	uint16_t length;
+};
+
+#pragma pack(pop)
+
+bool is_channel_data(const void *data, size_t size);
+bool is_valid_channel(uint16_t channel);
+
+int turn_wrap_channel_data(char *buffer, size_t size, const char *data, size_t data_size,
+                           uint16_t channel);
+
+// TURN state map
+
+typedef enum turn_entry_type {
+	TURN_ENTRY_TYPE_EMPTY = 0,
+	TURN_ENTRY_TYPE_DELETED,
+	TURN_ENTRY_TYPE_PERMISSION,
+	TURN_ENTRY_TYPE_CHANNEL
+} turn_entry_type_t;
+
+typedef struct turn_entry {
+	turn_entry_type_t type;
+	timestamp_t timestamp;
+	addr_record_t record;
+	uint8_t transaction_id[STUN_TRANSACTION_ID_SIZE];
+	uint16_t channel;
+	bool fresh_transaction_id;
+} turn_entry_t;
+
+typedef struct turn_map {
+	turn_entry_t *map;
+	turn_entry_t **ordered_channels;
+	turn_entry_t **ordered_transaction_ids;
+	int map_size;
+	int channels_count;
+	int transaction_ids_count;
+} turn_map_t;
+
+int turn_init_map(turn_map_t *map, int size);
+void turn_destroy_map(turn_map_t *map);
+
+bool turn_set_permission(turn_map_t *map, const uint8_t *transaction_id,
+                         const addr_record_t *record, // record may be NULL
+                         timediff_t duration);
+bool turn_has_permission(turn_map_t *map, const addr_record_t *record);
+
+bool turn_bind_channel(turn_map_t *map, const addr_record_t *record,
+                       const uint8_t *transaction_id, // transaction_id may be NULL
+                       uint16_t channel, timediff_t duration);
+bool turn_bind_random_channel(turn_map_t *map, const addr_record_t *record, uint16_t *channel,
+                              timediff_t duration);
+bool turn_bind_current_channel(turn_map_t *map, const uint8_t *transaction_id,
+                               const addr_record_t *record, // record may be NULL
+                               timediff_t duration);
+bool turn_get_channel(turn_map_t *map, const addr_record_t *record, uint16_t *channel);
+bool turn_get_bound_channel(turn_map_t *map, const addr_record_t *record, uint16_t *channel);
+bool turn_find_channel(turn_map_t *map, uint16_t channel, addr_record_t *record);
+bool turn_find_bound_channel(turn_map_t *map, uint16_t channel, addr_record_t *record);
+
+bool turn_set_permission_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                        const uint8_t *transaction_id);
+bool turn_set_channel_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                     const uint8_t *transaction_id);
+bool turn_set_random_permission_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                               uint8_t *transaction_id);
+bool turn_set_random_channel_transaction_id(turn_map_t *map, const addr_record_t *record,
+                                            uint8_t *transaction_id);
+bool turn_retrieve_transaction_id(turn_map_t *map, const uint8_t *transaction_id,
+                              addr_record_t *record);
+#endif

--- a/Source/3rdParty/libjuice/src/udp.c
+++ b/Source/3rdParty/libjuice/src/udp.c
@@ -1,0 +1,611 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "udp.h"
+#include "addr.h"
+#include "log.h"
+#include "random.h"
+#include "thread.h" // for mutexes
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+static struct addrinfo *find_family(struct addrinfo *ai_list, int family) {
+	struct addrinfo *ai = ai_list;
+	while (ai && ai->ai_family != family)
+		ai = ai->ai_next;
+	return ai;
+}
+
+static uint16_t get_next_port_in_range(uint16_t begin, uint16_t end) {
+	if (begin == 0)
+		begin = 1024;
+	if (end == 0)
+		end = 0xFFFF;
+	if (begin == end)
+		return begin;
+
+	static volatile uint32_t count = 0;
+	if (count == 0)
+		count = juice_rand32();
+
+	static mutex_t mutex = MUTEX_INITIALIZER;
+	mutex_lock(&mutex);
+	uint32_t diff = end > begin ? end - begin : 0;
+	uint16_t next = begin + count++ % (diff + 1);
+	mutex_unlock(&mutex);
+	return next;
+}
+
+static socket_t create_socket_for_addrinfo(const udp_socket_config_t *config,
+                                           const struct addrinfo *ai) {
+	// Create socket
+	socket_t sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+	if (sock == INVALID_SOCKET) {
+		JLOG_WARN("UDP socket creation failed, errno=%d", sockerrno);
+		return INVALID_SOCKET;
+	}
+
+	// Listen on both IPv6 and IPv4
+	const sockopt_t disabled = 0;
+	if (ai->ai_family == AF_INET6)
+		setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&disabled, sizeof(disabled));
+
+		// Set DF flag
+#ifndef NO_PMTUDISC
+	const sockopt_t val = IP_PMTUDISC_DO;
+	setsockopt(sock, IPPROTO_IP, IP_MTU_DISCOVER, (const char *)&val, sizeof(val));
+#ifdef IPV6_MTU_DISCOVER
+	if (ai->ai_family == AF_INET6)
+		setsockopt(sock, IPPROTO_IPV6, IPV6_MTU_DISCOVER, (const char *)&val, sizeof(val));
+#endif
+#else
+	// It seems Mac OS lacks a way to set the DF flag...
+	const sockopt_t enabled = 1;
+#ifdef IP_DONTFRAG
+	setsockopt(sock, IPPROTO_IP, IP_DONTFRAG, (const char *)&enabled, sizeof(enabled));
+#endif
+#ifdef IPV6_DONTFRAG
+	if (ai->ai_family == AF_INET6)
+		setsockopt(sock, IPPROTO_IPV6, IPV6_DONTFRAG, (const char *)&enabled, sizeof(enabled));
+#endif
+#endif
+
+	// Set buffer size up to 1 MiB for performance
+	const sockopt_t buffer_size = 1 * 1024 * 1024;
+	setsockopt(sock, SOL_SOCKET, SO_RCVBUF, (const char *)&buffer_size, sizeof(buffer_size));
+	setsockopt(sock, SOL_SOCKET, SO_SNDBUF, (const char *)&buffer_size, sizeof(buffer_size));
+
+	ctl_t nbio = 1;
+	if (ioctlsocket(sock, FIONBIO, &nbio)) {
+		JLOG_ERROR("Setting non-blocking mode on UDP socket failed, errno=%d", sockerrno);
+		goto error;
+	}
+
+	// Bind it
+	if (config->port_begin == 0 && config->port_end == 0) {
+		if (bind(sock, ai->ai_addr, (socklen_t)ai->ai_addrlen) == 0) {
+			JLOG_DEBUG("UDP socket bound to %s:%hu",
+			           config->bind_address ? config->bind_address : "any", udp_get_port(sock));
+			return sock;
+		}
+
+		JLOG_WARN("UDP socket binding failed, errno=%d", sockerrno);
+
+	} else if (config->port_begin == config->port_end) {
+		uint16_t port = config->port_begin;
+		struct sockaddr_storage addr;
+		socklen_t addrlen = (socklen_t)ai->ai_addrlen;
+		memcpy(&addr, ai->ai_addr, addrlen);
+		addr_set_port((struct sockaddr *)&addr, port);
+
+		if (bind(sock, (struct sockaddr *)&addr, addrlen) == 0) {
+			JLOG_DEBUG("UDP socket bound to %s:%hu",
+			           config->bind_address ? config->bind_address : "any", port);
+			return sock;
+		}
+
+		JLOG_WARN("UDP socket binding failed on port %hu, errno=%d", port, sockerrno);
+
+	} else {
+		struct sockaddr_storage addr;
+		socklen_t addrlen = (socklen_t)ai->ai_addrlen;
+		memcpy(&addr, ai->ai_addr, addrlen);
+
+		int retries = config->port_end - config->port_begin;
+		do {
+			uint16_t port = get_next_port_in_range(config->port_begin, config->port_end);
+			addr_set_port((struct sockaddr *)&addr, port);
+			if (bind(sock, (struct sockaddr *)&addr, addrlen) == 0) {
+				JLOG_DEBUG("UDP socket bound to %s:%hu",
+				           config->bind_address ? config->bind_address : "any", port);
+				return sock;
+			}
+		} while ((sockerrno == SEADDRINUSE || sockerrno == SEACCES) && retries-- > 0);
+
+		JLOG_WARN("UDP socket binding failed on port range %s:[%hu,%hu], errno=%d",
+		          config->bind_address ? config->bind_address : "any", config->port_begin,
+		          config->port_end, sockerrno);
+	}
+
+error:
+	if (sock != INVALID_SOCKET)
+		closesocket(sock);
+
+	return INVALID_SOCKET;
+}
+
+socket_t udp_create_socket(const udp_socket_config_t *config) {
+	// Obtain local Address
+	struct addrinfo *ai_list = NULL;
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_DGRAM;
+	hints.ai_protocol = IPPROTO_UDP;
+	hints.ai_flags = AI_PASSIVE | AI_NUMERICSERV;
+	if (getaddrinfo(config->bind_address, "0", &hints, &ai_list) != 0) {
+		JLOG_ERROR("getaddrinfo for binding address failed, errno=%d", sockerrno);
+		return INVALID_SOCKET;
+	}
+
+	const int families[2] = {AF_INET6, AF_INET}; // Prefer IPv6
+	const char *names[2] = {"IPv6", "IPv4"};
+	for (int i = 0; i < 2; ++i) {
+		const struct addrinfo *ai = find_family(ai_list, families[i]);
+		if (!ai)
+			continue;
+
+		JLOG_DEBUG("Opening UDP socket for %s family", names[i]);
+		socket_t sock = create_socket_for_addrinfo(config, ai);
+		if (sock != INVALID_SOCKET) {
+			freeaddrinfo(ai_list);
+			return sock;
+		}
+	}
+
+	JLOG_ERROR("UDP socket opening failed");
+	freeaddrinfo(ai_list);
+	return INVALID_SOCKET;
+}
+
+int udp_recvfrom(socket_t sock, char *buffer, size_t size, addr_record_t *src) {
+	while (true) {
+		src->len = sizeof(src->addr);
+		src->socktype = SOCK_DGRAM;
+		int len =
+		    recvfrom(sock, buffer, (socklen_t)size, 0, (struct sockaddr *)&src->addr, &src->len);
+		if (len >= 0) {
+			addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+
+		} else if (sockerrno == SECONNRESET || sockerrno == SENETRESET ||
+		           sockerrno == SECONNREFUSED) {
+			// On Windows, if a UDP socket receives an ICMP port unreachable response after
+			// sending a datagram, this error is stored, and the next call to recvfrom() returns
+			// WSAECONNRESET (port unreachable) or WSAENETRESET (TTL expired).
+			// Therefore, it may be ignored.
+			JLOG_DEBUG("Ignoring %s returned by recvfrom",
+			           sockerrno == SECONNRESET
+			               ? "ECONNRESET"
+			               : (sockerrno == SENETRESET ? "ENETRESET" : "ECONNREFUSED"));
+			continue;
+		}
+		return len;
+	}
+}
+
+int udp_sendto(socket_t sock, const char *data, size_t size, const addr_record_t *dst) {
+#ifndef __linux__
+	addr_record_t tmp = *dst;
+	addr_record_t name;
+	name.len = sizeof(name.addr);
+	name.socktype = SOCK_DGRAM;
+	if (getsockname(sock, (struct sockaddr *)&name.addr, &name.len) == 0) {
+		if (name.addr.ss_family == AF_INET6)
+			addr_map_inet6_v4mapped(&tmp.addr, &tmp.len);
+	} else {
+		JLOG_WARN("getsockname failed, errno=%d", sockerrno);
+	}
+	return sendto(sock, data, (socklen_t)size, 0, (const struct sockaddr *)&tmp.addr, tmp.len);
+#else
+	return sendto(sock, data, size, 0, (const struct sockaddr *)&dst->addr, dst->len);
+#endif
+}
+
+int udp_sendto_self(socket_t sock, const char *data, size_t size) {
+	addr_record_t local;
+	if (udp_get_local_addr(sock, AF_UNSPEC, &local) < 0)
+		return -1;
+
+	int ret;
+#ifndef __linux__
+	// We know local has the same address family as sock here
+	ret = sendto(sock, data, (socklen_t)size, 0, (const struct sockaddr *)&local.addr, local.len);
+#else
+	ret = sendto(sock, data, size, 0, (const struct sockaddr *)&local.addr, local.len);
+#endif
+	if (ret >= 0 || local.addr.ss_family != AF_INET6)
+		return ret;
+
+	// Fallback as IPv6 may be disabled on the loopback interface
+	if (udp_get_local_addr(sock, AF_INET, &local) < 0)
+		return -1;
+
+#ifndef __linux__
+	addr_map_inet6_v4mapped(&local.addr, &local.len);
+	return sendto(sock, data, (socklen_t)size, 0, (const struct sockaddr *)&local.addr, local.len);
+#else
+	return sendto(sock, data, size, 0, (const struct sockaddr *)&local.addr, local.len);
+#endif
+}
+
+int udp_set_diffserv(socket_t sock, int ds) {
+#ifdef _WIN32
+	// IP_TOS has been intentionally broken on Windows in favor of a convoluted proprietary
+	// mechanism called qWave. Thank you Microsoft!
+	// TODO: Investigate if DSCP can be still set directly without administrator flow configuration.
+	(void)sock;
+	(void)ds;
+	JLOG_INFO("IP Differentiated Services are not supported on Windows");
+	return -1;
+#else
+	addr_record_t name;
+	name.len = sizeof(name.addr);
+	name.socktype = SOCK_DGRAM;
+	if (getsockname(sock, (struct sockaddr *)&name.addr, &name.len) < 0) {
+		JLOG_WARN("getsockname failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	switch (name.addr.ss_family) {
+	case AF_INET:
+#ifdef IP_TOS
+		if (setsockopt(sock, IPPROTO_IP, IP_TOS, &ds, sizeof(ds)) < 0) {
+			JLOG_WARN("Setting IP ToS failed, errno=%d", sockerrno);
+			return -1;
+		}
+		return 0;
+#else
+		JLOG_INFO("Setting IP ToS is not supported");
+		return -1;
+#endif
+
+	case AF_INET6:
+#ifdef IPV6_TCLASS
+		if (setsockopt(sock, IPPROTO_IPV6, IPV6_TCLASS, &ds, sizeof(ds)) < 0) {
+			JLOG_WARN("Setting IPv6 traffic class failed, errno=%d", sockerrno);
+			return -1;
+		}
+#ifdef IP_TOS
+		// Attempt to also set IP_TOS for IPv4, in case the system requires it
+		setsockopt(sock, IPPROTO_IP, IP_TOS, &ds, sizeof(ds));
+#endif
+		return 0;
+#else
+		JLOG_INFO("Setting IPv6 traffic class is not supported");
+		return -1;
+#endif
+	default:
+		return -1;
+	}
+#endif
+}
+
+uint16_t udp_get_port(socket_t sock) {
+	addr_record_t record;
+	if (udp_get_bound_addr(sock, &record) < 0)
+		return 0;
+	return addr_get_port((struct sockaddr *)&record.addr);
+}
+
+int udp_get_bound_addr(socket_t sock, addr_record_t *record) {
+	record->len = sizeof(record->addr);
+	record->socktype = SOCK_DGRAM;
+	if (getsockname(sock, (struct sockaddr *)&record->addr, &record->len)) {
+		JLOG_WARN("getsockname failed, errno=%d", sockerrno);
+		return -1;
+	}
+	return 0;
+}
+
+int udp_get_local_addr(socket_t sock, int family_hint, addr_record_t *record) {
+	if (udp_get_bound_addr(sock, record) < 0)
+		return -1;
+
+	// If the socket is bound to a particular address, return it
+	if (!addr_is_any((struct sockaddr *)&record->addr)) {
+		if (record->addr.ss_family == AF_INET && family_hint == AF_INET6)
+			addr_map_inet6_v4mapped(&record->addr, &record->len);
+
+		return 0;
+	}
+
+	if (record->addr.ss_family == AF_INET6 && family_hint == AF_INET) {
+		// Generate an IPv4 instead (socket is listening to any IPv4 or IPv6)
+
+		uint16_t port = addr_get_port((struct sockaddr *)&record->addr);
+		if (port == 0)
+			return -1;
+
+		struct sockaddr_in *sin = (struct sockaddr_in *)&record->addr;
+		memset(sin, 0, sizeof(*sin));
+		sin->sin_family = AF_INET;
+		sin->sin_port = htons(port);
+		record->len = sizeof(*sin);
+		record->socktype = SOCK_DGRAM;
+	}
+
+	switch (record->addr.ss_family) {
+	case AF_INET: {
+		struct sockaddr_in *sin = (struct sockaddr_in *)&record->addr;
+		const uint8_t localhost[4] = {127, 0, 0, 1};
+		memcpy(&sin->sin_addr, localhost, 4);
+		break;
+	}
+	case AF_INET6: {
+		struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&record->addr;
+		uint8_t *b = (uint8_t *)&sin6->sin6_addr;
+		memset(b, 0, 15);
+		b[15] = 0x01; // localhost
+		break;
+	}
+	default:
+		// Ignore
+		break;
+	}
+
+	if (record->addr.ss_family == AF_INET && family_hint == AF_INET6)
+		addr_map_inet6_v4mapped(&record->addr, &record->len);
+
+	return 0;
+}
+
+// Helper function to check if a similar address already exists in records
+// This function ignores the port
+static int has_duplicate_addr(struct sockaddr *addr, const addr_record_t *records, size_t count) {
+	for (size_t i = 0; i < count; ++i) {
+		const addr_record_t *record = records + i;
+		if (record->addr.ss_family == addr->sa_family) {
+			switch (addr->sa_family) {
+			case AF_INET: {
+				// For IPv4, compare the whole address
+				const struct sockaddr_in *rsin = (const struct sockaddr_in *)&record->addr;
+				const struct sockaddr_in *asin = (const struct sockaddr_in *)addr;
+				if (memcmp(&rsin->sin_addr, &asin->sin_addr, 4) == 0)
+					return true;
+				break;
+			}
+			case AF_INET6: {
+				// For IPv6, compare the network part only
+				const struct sockaddr_in6 *rsin6 = (const struct sockaddr_in6 *)&record->addr;
+				const struct sockaddr_in6 *asin6 = (const struct sockaddr_in6 *)addr;
+				if (memcmp(&rsin6->sin6_addr, &asin6->sin6_addr, 8) == 0) // compare first 64 bits
+					return true;
+				break;
+			}
+			}
+		}
+	}
+	return false;
+}
+
+#if !defined(_WIN32) && defined(NO_IFADDRS)
+// Helper function to get the IPv6 address of the default interface
+static int get_local_default_inet6(uint16_t port, struct sockaddr_in6 *result) {
+	const char *dummy_host = "2001:db8::1"; // dummy public unreachable address
+	const uint16_t dummy_port = 9;          // discard port
+
+	struct sockaddr_in6 sin6;
+	memset(&sin6, 0, sizeof(sin6));
+	sin6.sin6_family = AF_INET6;
+	sin6.sin6_port = htons(dummy_port);
+	if (inet_pton(AF_INET6, dummy_host, &sin6.sin6_addr) != 1)
+		return -1;
+
+	socket_t sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+	if (sock == INVALID_SOCKET)
+		return -1;
+
+	if (connect(sock, (const struct sockaddr *)&sin6, sizeof(sin6)))
+		goto error;
+
+	socklen_t result_len = sizeof(*result);
+	if (getsockname(sock, (struct sockaddr *)result, &result_len))
+		goto error;
+
+	if (result_len != sizeof(*result))
+		goto error;
+
+	addr_set_port((struct sockaddr *)result, port);
+	closesocket(sock);
+	return 0;
+
+error:
+	closesocket(sock);
+	return -1;
+}
+#endif
+
+int udp_get_addrs(socket_t sock, addr_record_t *records, size_t count) {
+	addr_record_t bound;
+	if (udp_get_bound_addr(sock, &bound) < 0) {
+		JLOG_ERROR("Getting UDP bound address failed");
+		return -1;
+	}
+
+	if (!addr_is_any((struct sockaddr *)&bound.addr)) {
+		if (count > 0)
+			records[0] = bound;
+
+		return 1;
+	}
+
+	uint16_t port = addr_get_port((struct sockaddr *)&bound.addr);
+
+	// RFC 8445 5.1.1.1. Host Candidates:
+	// Addresses from a loopback interface MUST NOT be included in the candidate addresses.
+	// [...]
+	// If gathering one or more host candidates that correspond to an IPv6 address that was
+	// generated using a mechanism that prevents location tracking [RFC7721], host candidates
+	// that correspond to IPv6 addresses that do allow location tracking, are configured on the
+	// same interface, and are part of the same network prefix MUST NOT be gathered. Similarly,
+	// when host candidates corresponding to an IPv6 address generated using a mechanism that
+	// prevents location tracking are gathered, then host candidates corresponding to IPv6
+	// link-local addresses [RFC4291] MUST NOT be gathered. The IPv6 default address selection
+	// specification [RFC6724] specifies that temporary addresses [RFC4941] are to be preferred
+	// over permanent addresses.
+
+	// IPv6 IIDs generated by modern systems are opaque so there is no way to reliably differentiate
+	// privacy-enabled IPv6 addresses here. Therefore, we hope the preferred addresses are listed
+	// first, and we never list link-local addresses.
+
+	addr_record_t *current = records;
+	addr_record_t *end = records + count;
+	int ret = 0;
+
+#if defined(JUICE_ENABLE_LOCALHOST_ADDRESS) && JUICE_ENABLE_LOCALHOST_ADDRESS
+	// Add localhost for test purposes
+	addr_record_t local;
+	if (bound.addr.ss_family == AF_INET6 && udp_get_local_addr(sock, AF_INET6, &local) == 0) {
+		++ret;
+		if (current != end) {
+			*current = local;
+			++current;
+		}
+	}
+	if (udp_get_local_addr(sock, AF_INET, &local) == 0) {
+		++ret;
+		if (current != end) {
+			*current = local;
+			++current;
+		}
+	}
+#endif
+
+#ifdef _WIN32
+	char buf[4096];
+	DWORD len = 0;
+	if (WSAIoctl(sock, SIO_ADDRESS_LIST_QUERY, NULL, 0, buf, sizeof(buf), &len, NULL, NULL)) {
+		JLOG_ERROR("WSAIoctl with SIO_ADDRESS_LIST_QUERY failed, errno=%d", WSAGetLastError());
+		return -1;
+	}
+
+	SOCKET_ADDRESS_LIST *list = (SOCKET_ADDRESS_LIST *)buf;
+	for (int i = 0; i < list->iAddressCount; ++i) {
+		struct sockaddr *sa = list->Address[i].lpSockaddr;
+		socklen_t len = list->Address[i].iSockaddrLength;
+		if ((sa->sa_family == AF_INET ||
+		     (sa->sa_family == AF_INET6 && bound.addr.ss_family == AF_INET6)) &&
+		    !addr_is_local(sa)) {
+			if (!has_duplicate_addr(sa, records, current - records)) {
+				++ret;
+				if (current != end) {
+					memcpy(&current->addr, sa, len);
+					current->len = len;
+					current->socktype = SOCK_DGRAM;
+					addr_unmap_inet6_v4mapped((struct sockaddr *)&current->addr, &current->len);
+					addr_set_port((struct sockaddr *)&current->addr, port);
+					++current;
+				}
+			}
+		}
+	}
+#else // POSIX
+#ifndef NO_IFADDRS
+	struct ifaddrs *ifas;
+	if (getifaddrs(&ifas)) {
+		JLOG_ERROR("getifaddrs failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	for (struct ifaddrs *ifa = ifas; ifa; ifa = ifa->ifa_next) {
+		unsigned int flags = ifa->ifa_flags;
+		if (!(flags & IFF_UP) || (flags & IFF_LOOPBACK))
+			continue;
+		if (strcmp(ifa->ifa_name, "docker0") == 0)
+			continue;
+
+		struct sockaddr *sa = ifa->ifa_addr;
+		socklen_t len;
+		if (sa &&
+		    (sa->sa_family == AF_INET ||
+		     (sa->sa_family == AF_INET6 && bound.addr.ss_family == AF_INET6)) &&
+		    !addr_is_local(sa) && (len = addr_get_len(sa)) > 0) {
+			if (!has_duplicate_addr(sa, records, current - records)) {
+				++ret;
+				if (current != end) {
+					memcpy(&current->addr, sa, len);
+					current->len = len;
+					current->socktype = SOCK_DGRAM;
+					addr_set_port((struct sockaddr *)&current->addr, port);
+					++current;
+				}
+			}
+		}
+	}
+
+	freeifaddrs(ifas);
+
+#else // NO_IFADDRS defined
+	char buf[4096];
+	struct ifconf ifc;
+	memset(&ifc, 0, sizeof(ifc));
+	ifc.ifc_len = sizeof(buf);
+	ifc.ifc_buf = buf;
+
+	if (ioctlsocket(sock, SIOCGIFCONF, &ifc)) {
+		JLOG_ERROR("ioctl for SIOCGIFCONF failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	bool ifconf_has_inet6 = false;
+	int n = ifc.ifc_len / sizeof(struct ifreq);
+	for (int i = 0; i < n; ++i) {
+		struct ifreq *ifr = ifc.ifc_req + i;
+		struct sockaddr *sa = &ifr->ifr_addr;
+		if (sa->sa_family == AF_INET6)
+			ifconf_has_inet6 = true;
+
+		socklen_t len;
+		if ((sa->sa_family == AF_INET ||
+		     (sa->sa_family == AF_INET6 && bound.addr.ss_family == AF_INET6)) &&
+		    !addr_is_local(sa) && (len = addr_get_len(sa)) > 0) {
+			if (!has_duplicate_addr(sa, records, current - records)) {
+				++ret;
+				if (current != end) {
+					memcpy(&current->addr, sa, len);
+					current->len = len;
+					current->socktype = SOCK_DGRAM;
+					addr_set_port((struct sockaddr *)&current->addr, port);
+					++current;
+				}
+			}
+		}
+	}
+
+	if (!ifconf_has_inet6 && bound.addr.ss_family == AF_INET6) {
+		struct sockaddr_in6 sin6;
+		if (get_local_default_inet6(port, &sin6) == 0) {
+			if (!addr_is_local((const struct sockaddr *)&sin6)) {
+				++ret;
+				if (current != end) {
+					memcpy(&current->addr, &sin6, sizeof(sin6));
+					current->len = sizeof(sin6);
+					current->socktype = SOCK_DGRAM;
+					++current;
+				}
+			}
+		}
+	}
+#endif
+#endif
+
+	return ret;
+}

--- a/Source/3rdParty/libjuice/src/udp.h
+++ b/Source/3rdParty/libjuice/src/udp.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef JUICE_UDP_H
+#define JUICE_UDP_H
+
+#include "addr.h"
+#include "socket.h"
+
+#include <stdint.h>
+
+typedef struct udp_socket_config {
+	const char *bind_address;
+	uint16_t port_begin;
+	uint16_t port_end;
+} udp_socket_config_t;
+
+socket_t udp_create_socket(const udp_socket_config_t *config);
+int udp_recvfrom(socket_t sock, char *buffer, size_t size, addr_record_t *src);
+int udp_sendto(socket_t sock, const char *data, size_t size, const addr_record_t *dst);
+int udp_sendto_self(socket_t sock, const char *data, size_t size);
+int udp_set_diffserv(socket_t sock, int ds);
+uint16_t udp_get_port(socket_t sock);
+int udp_get_bound_addr(socket_t sock, addr_record_t *record);
+int udp_get_local_addr(socket_t sock, int family, addr_record_t *record); // family may be AF_UNSPEC
+int udp_get_addrs(socket_t sock, addr_record_t *records, size_t count);
+
+#endif // JUICE_UDP_H

--- a/Source/RMG-Core/CMakeLists.txt
+++ b/Source/RMG-Core/CMakeLists.txt
@@ -57,6 +57,7 @@ set(RMG_CORE_SOURCES
 
 if (NETPLAY)
     add_definitions(-DNETPLAY)
+    list(APPEND RMG_CORE_SOURCES LobbyIce.cpp)
 endif(NETPLAY)
 
 if (PORTABLE_INSTALL)
@@ -82,6 +83,10 @@ target_link_libraries(RMG-Core PRIVATE
     ${MINIZIP_LIBRARIES}
     lzma
 )
+
+if (NETPLAY)
+    target_link_libraries(RMG-Core PRIVATE LibJuice::LibJuiceStatic)
+endif()
 
 # Link n02 static library for Kaillera netplay support
 # PRIVATE prevents n02 from being transitively linked into RMG.exe,

--- a/Source/RMG-Core/Emulation.cpp
+++ b/Source/RMG-Core/Emulation.cpp
@@ -205,13 +205,21 @@ static bool parse_lobby_address(const std::string& address, int& frameDelay, int
         {
             peer.slot = std::stoi(tok.substr(0, firstComma));
             peer.ip = tok.substr(firstComma + 1, secondComma - firstComma - 1);
-            const int parsedPort = std::stoi(tok.substr(secondComma + 1));
-            if (parsedPort <= 0 || parsedPort > 65535 || peer.ip.empty() ||
-                peer.slot < 1 || peer.slot > 4)
+            if (peer.ip == "ice")
             {
-                return false;
+                peer.userId = std::stoull(tok.substr(secondComma + 1));
+                if (peer.userId == 0)
+                    return false;
             }
-            peer.port = static_cast<unsigned short>(parsedPort);
+            else
+            {
+                const int parsedPort = std::stoi(tok.substr(secondComma + 1));
+                if (parsedPort <= 0 || parsedPort > 65535 || peer.ip.empty())
+                    return false;
+                peer.port = static_cast<unsigned short>(parsedPort);
+            }
+            if (peer.slot < 1 || peer.slot > 4)
+                return false;
         }
         catch (...)
         {

--- a/Source/RMG-Core/LobbyIce.cpp
+++ b/Source/RMG-Core/LobbyIce.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <deque>
 #include <map>
 #include <memory>
@@ -25,6 +26,8 @@ struct Peer
     std::mutex agentMutex;
     std::atomic<LobbyIcePeerState> state{LobbyIcePeerState::Disconnected};
     std::atomic<bool> active{true};
+    std::mutex pingMutex;
+    std::map<std::uint64_t, std::uint64_t> pingSentAtUs;
     bool hasRemoteDescription = false;
     bool remoteGatheringDone = false;
     std::vector<std::string> pendingCandidates;
@@ -34,6 +37,7 @@ struct QueuedPacket
 {
     std::uint64_t peerUserId = 0;
     LobbyIceChannel channel = LobbyIceChannel::Gekko;
+    std::uint64_t roundTripUs = 0;
     std::vector<char> data;
 };
 
@@ -52,6 +56,20 @@ std::map<std::uint64_t, std::shared_ptr<Peer>> g_peers;
 std::map<std::uint64_t, std::vector<PendingRemoteSignal>> g_pendingRemoteSignals;
 std::deque<LobbyIceSignal> g_localSignals;
 std::deque<QueuedPacket> g_packets;
+
+std::uint64_t steady_now_us()
+{
+    return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+std::uint64_t read_be_u64(const char* data)
+{
+    std::uint64_t value = 0;
+    for (int i = 0; i < 8; ++i)
+        value = (value << 8) | static_cast<unsigned char>(data[i]);
+    return value;
+}
 
 LobbyIcePeerState translate_state(juice_state_t state)
 {
@@ -98,7 +116,7 @@ void on_gathering_done(juice_agent_t*, void* userPtr)
     g_localSignals.push_back({peer->userId, "gathering_done", {}});
 }
 
-void on_recv(juice_agent_t*, const char* data, size_t size, void* userPtr)
+void on_recv(juice_agent_t* agent, const char* data, size_t size, void* userPtr)
 {
     auto* peer = static_cast<Peer*>(userPtr);
     if (peer == nullptr || data == nullptr || size < 1 ||
@@ -114,9 +132,36 @@ void on_recv(juice_agent_t*, const char* data, size_t size, void* userPtr)
         return;
     }
 
+    // Ping payload: request/reply byte plus nonce. Echo requests directly from
+    // libjuice's receive callback so the 25 ms Qt queue-poll interval is not
+    // counted as network latency. The send timestamp is tracked privately per
+    // peer, keeping the on-wire packet compatible with the first ICE client.
+    if (channel == LobbyIceChannel::Ping && size == 10 && data[1] == 1)
+    {
+        std::vector<char> reply(data, data + size);
+        reply[1] = 2;
+        if (juice_send(agent, reply.data(), reply.size()) == JUICE_ERR_SUCCESS)
+            return;
+        // If the immediate send ever fails, queue it for the existing UI-side
+        // fallback and normal retry machinery.
+    }
+
     QueuedPacket packet;
     packet.peerUserId = peer->userId;
     packet.channel = channel;
+    if (channel == LobbyIceChannel::Ping && size == 10 && data[1] == 2)
+    {
+        const std::uint64_t nonce = read_be_u64(data + 2);
+        const std::uint64_t receivedAtUs = steady_now_us();
+        std::lock_guard<std::mutex> pingLock(peer->pingMutex);
+        const auto it = peer->pingSentAtUs.find(nonce);
+        if (it != peer->pingSentAtUs.end())
+        {
+            if (receivedAtUs >= it->second)
+                packet.roundTripUs = receivedAtUs - it->second;
+            peer->pingSentAtUs.erase(it);
+        }
+    }
     packet.data.assign(data + 1, data + size);
     std::lock_guard<std::mutex> lock(g_mutex);
     g_packets.push_back(std::move(packet));
@@ -428,8 +473,32 @@ bool LobbyIce::send(std::uint64_t peerUserId, LobbyIceChannel channel,
         std::copy_n(data, size, framed.data() + 1);
     }
     std::lock_guard<std::mutex> agentLock(peer->agentMutex);
-    return peer->agent != nullptr && peer->active.load(std::memory_order_relaxed) &&
-        juice_send(peer->agent, framed.data(), framed.size()) == JUICE_ERR_SUCCESS;
+    if (peer->agent == nullptr || !peer->active.load(std::memory_order_relaxed))
+        return false;
+
+    std::uint64_t pingNonce = 0;
+    std::uint64_t pingSentAtUs = 0;
+    if (channel == LobbyIceChannel::Ping && size == 9 && framed[1] == 1)
+    {
+        pingNonce = read_be_u64(framed.data() + 2);
+        pingSentAtUs = steady_now_us();
+        std::lock_guard<std::mutex> pingLock(peer->pingMutex);
+        const std::uint64_t cutoffUs = pingSentAtUs > 60'000'000
+            ? pingSentAtUs - 60'000'000 : 0;
+        std::erase_if(peer->pingSentAtUs, [cutoffUs](const auto& entry) {
+            return entry.second < cutoffUs;
+        });
+        peer->pingSentAtUs[pingNonce] = pingSentAtUs;
+    }
+    const bool sent = juice_send(peer->agent, framed.data(), framed.size()) == JUICE_ERR_SUCCESS;
+    if (!sent && pingSentAtUs != 0)
+    {
+        std::lock_guard<std::mutex> pingLock(peer->pingMutex);
+        const auto it = peer->pingSentAtUs.find(pingNonce);
+        if (it != peer->pingSentAtUs.end() && it->second == pingSentAtUs)
+            peer->pingSentAtUs.erase(it);
+    }
+    return sent;
 }
 
 std::vector<LobbyIcePacket> LobbyIce::take_packets(LobbyIceChannel channel)
@@ -440,7 +509,7 @@ std::vector<LobbyIcePacket> LobbyIce::take_packets(LobbyIceChannel channel)
     {
         if (it->channel == channel)
         {
-            out.push_back({it->peerUserId, std::move(it->data)});
+            out.push_back({it->peerUserId, it->roundTripUs, std::move(it->data)});
             it = g_packets.erase(it);
         }
         else

--- a/Source/RMG-Core/LobbyIce.cpp
+++ b/Source/RMG-Core/LobbyIce.cpp
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string_view>
 #include <utility>
 
 namespace
@@ -56,6 +57,10 @@ std::map<std::uint64_t, std::shared_ptr<Peer>> g_peers;
 std::map<std::uint64_t, std::vector<PendingRemoteSignal>> g_pendingRemoteSignals;
 std::deque<LobbyIceSignal> g_localSignals;
 std::deque<QueuedPacket> g_packets;
+std::atomic<bool> g_diagnosticsEnabled{false};
+std::vector<LobbyIceDiagnostic> g_diagnostics;
+std::size_t g_diagnosticsDropped = 0;
+constexpr std::size_t DIAGNOSTIC_QUEUE_CAP = 4096;
 
 std::uint64_t steady_now_us()
 {
@@ -69,6 +74,45 @@ std::uint64_t read_be_u64(const char* data)
     for (int i = 0; i < 8; ++i)
         value = (value << 8) | static_cast<unsigned char>(data[i]);
     return value;
+}
+
+const char* diagnostic_level_name(juice_log_level_t level)
+{
+    switch (level)
+    {
+    case JUICE_LOG_LEVEL_VERBOSE: return "verbose";
+    case JUICE_LOG_LEVEL_DEBUG: return "debug";
+    case JUICE_LOG_LEVEL_INFO: return "info";
+    case JUICE_LOG_LEVEL_WARN: return "warn";
+    case JUICE_LOG_LEVEL_ERROR: return "error";
+    case JUICE_LOG_LEVEL_FATAL: return "fatal";
+    case JUICE_LOG_LEVEL_NONE:
+    default: return "unknown";
+    }
+}
+
+void on_libjuice_log(juice_log_level_t level, const char* message)
+{
+    if (!g_diagnosticsEnabled.load(std::memory_order_relaxed) || message == nullptr)
+        return;
+
+    // DEBUG otherwise emits two lines for every gameplay datagram. Those say
+    // only that application traffic arrived, add no ICE diagnostic value, and
+    // would make an opt-in connection trace enormous during a match.
+    const std::string_view text(message);
+    if (text.find("Received non-STUN datagram") != std::string_view::npos ||
+        text.find("Received application datagram") != std::string_view::npos)
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_diagnostics.size() >= DIAGNOSTIC_QUEUE_CAP)
+    {
+        ++g_diagnosticsDropped;
+        return;
+    }
+    g_diagnostics.push_back({diagnostic_level_name(level), message});
 }
 
 LobbyIcePeerState translate_state(juice_state_t state)
@@ -225,6 +269,42 @@ bool apply_remote_signal(const std::shared_ptr<Peer>& peer,
     return false;
 }
 } // namespace
+
+void LobbyIce::set_diagnostics_enabled(bool enabled)
+{
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        g_diagnostics.clear();
+        g_diagnosticsDropped = 0;
+    }
+    g_diagnosticsEnabled.store(enabled, std::memory_order_relaxed);
+    if (enabled)
+    {
+        juice_set_log_handler(on_libjuice_log);
+        // DEBUG captures candidate gathering, STUN binding, pair checks, role
+        // conflicts, and timeouts without VERBOSE's per-datagram chatter.
+        juice_set_log_level(JUICE_LOG_LEVEL_DEBUG);
+    }
+    else
+    {
+        juice_set_log_level(JUICE_LOG_LEVEL_WARN);
+        juice_set_log_handler(nullptr);
+    }
+}
+
+std::vector<LobbyIceDiagnostic> LobbyIce::take_diagnostics()
+{
+    std::vector<LobbyIceDiagnostic> out;
+    std::lock_guard<std::mutex> lock(g_mutex);
+    out.swap(g_diagnostics);
+    if (g_diagnosticsDropped != 0)
+    {
+        out.push_back({"warn", "Diagnostic queue overflow: " +
+            std::to_string(g_diagnosticsDropped) + " libjuice messages dropped"});
+        g_diagnosticsDropped = 0;
+    }
+    return out;
+}
 
 bool LobbyIce::configure(std::uint64_t localUserId,
     const std::string& stunHost, std::uint16_t stunPort,

--- a/Source/RMG-Core/LobbyIce.cpp
+++ b/Source/RMG-Core/LobbyIce.cpp
@@ -1,0 +1,452 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3.
+ */
+#include "LobbyIce.hpp"
+
+#include <juice/juice.h>
+
+#include <algorithm>
+#include <atomic>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace
+{
+struct Peer
+{
+    std::uint64_t userId = 0;
+    juice_agent_t* agent = nullptr;
+    std::mutex agentMutex;
+    std::atomic<LobbyIcePeerState> state{LobbyIcePeerState::Disconnected};
+    std::atomic<bool> active{true};
+    bool hasRemoteDescription = false;
+    bool remoteGatheringDone = false;
+    std::vector<std::string> pendingCandidates;
+};
+
+struct QueuedPacket
+{
+    std::uint64_t peerUserId = 0;
+    LobbyIceChannel channel = LobbyIceChannel::Gekko;
+    std::vector<char> data;
+};
+
+struct PendingRemoteSignal
+{
+    std::string kind;
+    std::string value;
+};
+
+std::mutex g_mutex;
+std::uint64_t g_localUserId = 0;
+std::string g_stunHost;
+std::uint16_t g_stunPort = 0;
+std::vector<LobbyIceTurnServer> g_turnServers;
+std::map<std::uint64_t, std::shared_ptr<Peer>> g_peers;
+std::map<std::uint64_t, std::vector<PendingRemoteSignal>> g_pendingRemoteSignals;
+std::deque<LobbyIceSignal> g_localSignals;
+std::deque<QueuedPacket> g_packets;
+
+LobbyIcePeerState translate_state(juice_state_t state)
+{
+    switch (state)
+    {
+    case JUICE_STATE_GATHERING: return LobbyIcePeerState::Gathering;
+    case JUICE_STATE_CONNECTING: return LobbyIcePeerState::Connecting;
+    case JUICE_STATE_CONNECTED: return LobbyIcePeerState::Connected;
+    case JUICE_STATE_COMPLETED: return LobbyIcePeerState::Completed;
+    case JUICE_STATE_FAILED: return LobbyIcePeerState::Failed;
+    case JUICE_STATE_DISCONNECTED:
+    default: return LobbyIcePeerState::Disconnected;
+    }
+}
+
+void on_state_changed(juice_agent_t*, juice_state_t state, void* userPtr)
+{
+    auto* peer = static_cast<Peer*>(userPtr);
+    if (peer != nullptr && peer->active.load(std::memory_order_relaxed))
+    {
+        peer->state.store(translate_state(state), std::memory_order_relaxed);
+    }
+}
+
+void on_candidate(juice_agent_t*, const char* sdp, void* userPtr)
+{
+    auto* peer = static_cast<Peer*>(userPtr);
+    if (peer == nullptr || sdp == nullptr || !peer->active.load(std::memory_order_relaxed))
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_localSignals.push_back({peer->userId, "candidate", sdp});
+}
+
+void on_gathering_done(juice_agent_t*, void* userPtr)
+{
+    auto* peer = static_cast<Peer*>(userPtr);
+    if (peer == nullptr || !peer->active.load(std::memory_order_relaxed))
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_localSignals.push_back({peer->userId, "gathering_done", {}});
+}
+
+void on_recv(juice_agent_t*, const char* data, size_t size, void* userPtr)
+{
+    auto* peer = static_cast<Peer*>(userPtr);
+    if (peer == nullptr || data == nullptr || size < 1 ||
+        !peer->active.load(std::memory_order_relaxed))
+    {
+        return;
+    }
+
+    const auto channel = static_cast<LobbyIceChannel>(static_cast<std::uint8_t>(data[0]));
+    if (channel != LobbyIceChannel::Ping && channel != LobbyIceChannel::Prematch &&
+        channel != LobbyIceChannel::Gekko)
+    {
+        return;
+    }
+
+    QueuedPacket packet;
+    packet.peerUserId = peer->userId;
+    packet.channel = channel;
+    packet.data.assign(data + 1, data + size);
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_packets.push_back(std::move(packet));
+}
+
+std::shared_ptr<Peer> find_peer(std::uint64_t peerUserId)
+{
+    std::lock_guard<std::mutex> lock(g_mutex);
+    const auto it = g_peers.find(peerUserId);
+    return it == g_peers.end() ? nullptr : it->second;
+}
+
+bool apply_remote_signal(const std::shared_ptr<Peer>& peer,
+    const std::string& kind, const std::string& value)
+{
+    if (peer == nullptr)
+    {
+        return false;
+    }
+    std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+    if (peer->agent == nullptr || !peer->active.load(std::memory_order_relaxed))
+        return false;
+
+    if (kind == "description")
+    {
+        if (value.empty() || juice_set_remote_description(peer->agent, value.c_str()) != JUICE_ERR_SUCCESS)
+        {
+            return false;
+        }
+        peer->hasRemoteDescription = true;
+        for (const std::string& candidate : peer->pendingCandidates)
+        {
+            juice_add_remote_candidate(peer->agent, candidate.c_str());
+        }
+        peer->pendingCandidates.clear();
+        if (peer->remoteGatheringDone)
+        {
+            juice_set_remote_gathering_done(peer->agent);
+        }
+        return true;
+    }
+    if (kind == "candidate")
+    {
+        if (value.empty())
+        {
+            return false;
+        }
+        if (!peer->hasRemoteDescription)
+        {
+            peer->pendingCandidates.push_back(value);
+            return true;
+        }
+        return juice_add_remote_candidate(peer->agent, value.c_str()) == JUICE_ERR_SUCCESS;
+    }
+    if (kind == "gathering_done")
+    {
+        peer->remoteGatheringDone = true;
+        return !peer->hasRemoteDescription ||
+            juice_set_remote_gathering_done(peer->agent) == JUICE_ERR_SUCCESS;
+    }
+    return false;
+}
+} // namespace
+
+bool LobbyIce::configure(std::uint64_t localUserId,
+    const std::string& stunHost, std::uint16_t stunPort,
+    const std::vector<LobbyIceTurnServer>& turnServers)
+{
+    reset();
+    if (localUserId == 0 || stunHost.empty() || stunPort == 0)
+    {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_localUserId = localUserId;
+    g_stunHost = stunHost;
+    g_stunPort = stunPort;
+    g_turnServers = turnServers;
+    return true;
+}
+
+void LobbyIce::reset()
+{
+    std::vector<std::shared_ptr<Peer>> peers;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        for (auto& [id, peer] : g_peers)
+        {
+            (void)id;
+            peer->active.store(false, std::memory_order_relaxed);
+            peers.push_back(peer);
+        }
+        g_peers.clear();
+        g_pendingRemoteSignals.clear();
+        g_localSignals.clear();
+        g_packets.clear();
+        g_localUserId = 0;
+        g_stunHost.clear();
+        g_stunPort = 0;
+        g_turnServers.clear();
+    }
+    for (const auto& peer : peers)
+    {
+        std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+        if (peer->agent != nullptr)
+        {
+            juice_destroy(peer->agent);
+            peer->agent = nullptr;
+        }
+    }
+}
+
+bool LobbyIce::add_peer(std::uint64_t peerUserId)
+{
+    std::string stunHost;
+    std::uint16_t stunPort = 0;
+    std::vector<LobbyIceTurnServer> turnServers;
+    std::vector<PendingRemoteSignal> pending;
+    auto peer = std::make_shared<Peer>();
+    peer->userId = peerUserId;
+
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (peerUserId == 0 || peerUserId == g_localUserId || g_localUserId == 0 ||
+            g_stunHost.empty() || g_stunPort == 0)
+        {
+            return false;
+        }
+        if (g_peers.find(peerUserId) != g_peers.end())
+        {
+            return true;
+        }
+        stunHost = g_stunHost;
+        stunPort = g_stunPort;
+        turnServers = g_turnServers;
+        auto pendingIt = g_pendingRemoteSignals.find(peerUserId);
+        if (pendingIt != g_pendingRemoteSignals.end())
+        {
+            pending = std::move(pendingIt->second);
+            g_pendingRemoteSignals.erase(pendingIt);
+        }
+        g_peers.emplace(peerUserId, peer);
+    }
+
+    std::vector<juice_turn_server_t> juiceTurnServers;
+    juiceTurnServers.reserve(turnServers.size());
+    for (const LobbyIceTurnServer& server : turnServers)
+    {
+        juiceTurnServers.push_back({server.host.c_str(), server.username.c_str(),
+                                    server.password.c_str(), server.port});
+    }
+
+    juice_config_t config{};
+    config.concurrency_mode = JUICE_CONCURRENCY_MODE_POLL;
+    config.stun_server_host = stunHost.c_str();
+    config.stun_server_port = stunPort;
+    config.turn_servers = juiceTurnServers.empty() ? nullptr : juiceTurnServers.data();
+    config.turn_servers_count = static_cast<int>(juiceTurnServers.size());
+    config.cb_state_changed = on_state_changed;
+    config.cb_candidate = on_candidate;
+    config.cb_gathering_done = on_gathering_done;
+    config.cb_recv = on_recv;
+    config.user_ptr = peer.get();
+    {
+        std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+        peer->agent = juice_create(&config);
+    }
+    char description[JUICE_MAX_SDP_STRING_LEN]{};
+    bool haveDescription = false;
+    {
+        std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+        haveDescription = peer->agent != nullptr &&
+            juice_get_local_description(peer->agent, description, sizeof(description)) == JUICE_ERR_SUCCESS;
+    }
+    if (!haveDescription || description[0] == '\0')
+    {
+        remove_peer(peerUserId);
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        g_localSignals.push_back({peerUserId, "description", description});
+    }
+
+    for (const PendingRemoteSignal& signal : pending)
+    {
+        apply_remote_signal(peer, signal.kind, signal.value);
+    }
+    int gatherResult = JUICE_ERR_FAILED;
+    {
+        std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+        if (peer->agent != nullptr)
+            gatherResult = juice_gather_candidates(peer->agent);
+    }
+    if (gatherResult != JUICE_ERR_SUCCESS)
+    {
+        remove_peer(peerUserId);
+        return false;
+    }
+    return true;
+}
+
+void LobbyIce::remove_peer(std::uint64_t peerUserId)
+{
+    std::shared_ptr<Peer> peer;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        const auto it = g_peers.find(peerUserId);
+        if (it == g_peers.end())
+        {
+            return;
+        }
+        peer = it->second;
+        peer->active.store(false, std::memory_order_relaxed);
+        g_peers.erase(it);
+        std::erase_if(g_localSignals, [peerUserId](const LobbyIceSignal& signal) {
+            return signal.peerUserId == peerUserId;
+        });
+        std::erase_if(g_packets, [peerUserId](const QueuedPacket& packet) {
+            return packet.peerUserId == peerUserId;
+        });
+    }
+    {
+        std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+        if (peer->agent != nullptr)
+        {
+            juice_destroy(peer->agent);
+            peer->agent = nullptr;
+        }
+    }
+}
+
+bool LobbyIce::has_peer(std::uint64_t peerUserId)
+{
+    return find_peer(peerUserId) != nullptr;
+}
+
+LobbyIcePeerState LobbyIce::peer_state(std::uint64_t peerUserId)
+{
+    const auto peer = find_peer(peerUserId);
+    return peer == nullptr ? LobbyIcePeerState::Disconnected :
+        peer->state.load(std::memory_order_relaxed);
+}
+
+bool LobbyIce::peer_connected(std::uint64_t peerUserId)
+{
+    const LobbyIcePeerState state = peer_state(peerUserId);
+    return state == LobbyIcePeerState::Connected || state == LobbyIcePeerState::Completed;
+}
+
+std::string LobbyIce::peer_selected_addresses(std::uint64_t peerUserId)
+{
+    const auto peer = find_peer(peerUserId);
+    if (peer == nullptr || !peer_connected(peerUserId))
+    {
+        return {};
+    }
+    std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+    if (peer->agent == nullptr || !peer->active.load(std::memory_order_relaxed))
+        return {};
+    char local[JUICE_MAX_ADDRESS_STRING_LEN]{};
+    char remote[JUICE_MAX_ADDRESS_STRING_LEN]{};
+    if (juice_get_selected_addresses(peer->agent, local, sizeof(local), remote, sizeof(remote)) != JUICE_ERR_SUCCESS)
+    {
+        return {};
+    }
+    return std::string(local) + " -> " + remote;
+}
+
+std::vector<LobbyIceSignal> LobbyIce::take_local_signals()
+{
+    std::vector<LobbyIceSignal> out;
+    std::lock_guard<std::mutex> lock(g_mutex);
+    out.reserve(g_localSignals.size());
+    while (!g_localSignals.empty())
+    {
+        out.push_back(std::move(g_localSignals.front()));
+        g_localSignals.pop_front();
+    }
+    return out;
+}
+
+bool LobbyIce::handle_remote_signal(std::uint64_t peerUserId,
+    const std::string& kind, const std::string& value)
+{
+    const auto peer = find_peer(peerUserId);
+    if (peer == nullptr)
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        g_pendingRemoteSignals[peerUserId].push_back({kind, value});
+        return true;
+    }
+    return apply_remote_signal(peer, kind, value);
+}
+
+bool LobbyIce::send(std::uint64_t peerUserId, LobbyIceChannel channel,
+    const char* data, std::size_t size)
+{
+    const auto peer = find_peer(peerUserId);
+    if (peer == nullptr || !peer_connected(peerUserId) ||
+        (data == nullptr && size != 0) || size > 4000)
+    {
+        return false;
+    }
+    std::vector<char> framed(size + 1);
+    framed[0] = static_cast<char>(channel);
+    if (size > 0)
+    {
+        std::copy_n(data, size, framed.data() + 1);
+    }
+    std::lock_guard<std::mutex> agentLock(peer->agentMutex);
+    return peer->agent != nullptr && peer->active.load(std::memory_order_relaxed) &&
+        juice_send(peer->agent, framed.data(), framed.size()) == JUICE_ERR_SUCCESS;
+}
+
+std::vector<LobbyIcePacket> LobbyIce::take_packets(LobbyIceChannel channel)
+{
+    std::vector<LobbyIcePacket> out;
+    std::lock_guard<std::mutex> lock(g_mutex);
+    for (auto it = g_packets.begin(); it != g_packets.end();)
+    {
+        if (it->channel == channel)
+        {
+            out.push_back({it->peerUserId, std::move(it->data)});
+            it = g_packets.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+    return out;
+}

--- a/Source/RMG-Core/LobbyIce.cpp
+++ b/Source/RMG-Core/LobbyIce.cpp
@@ -101,7 +101,9 @@ void on_libjuice_log(juice_log_level_t level, const char* message)
     // would make an opt-in connection trace enormous during a match.
     const std::string_view text(message);
     if (text.find("Received non-STUN datagram") != std::string_view::npos ||
-        text.find("Received application datagram") != std::string_view::npos)
+        text.find("Received application datagram") != std::string_view::npos ||
+        text.find("STUN selected entry matching incoming address") != std::string_view::npos ||
+        text.find("STUN selected entry matching incoming relayed address") != std::string_view::npos)
     {
         return;
     }

--- a/Source/RMG-Core/LobbyIce.hpp
+++ b/Source/RMG-Core/LobbyIce.hpp
@@ -54,11 +54,22 @@ struct LobbyIcePacket
     std::vector<char> data;
 };
 
+struct LobbyIceDiagnostic
+{
+    std::string level;
+    std::string message;
+};
+
 // Process-wide room ICE mesh. Lobby signaling calls this API from the Qt UI
 // thread; GekkoNet consumes the same agents from the emulation thread.
 class LobbyIce
 {
   public:
+    // Route libjuice's native debug stream into a thread-safe queue consumed
+    // by the opt-in lobby diagnostics file.
+    static CORE_EXPORT void set_diagnostics_enabled(bool enabled);
+    static CORE_EXPORT std::vector<LobbyIceDiagnostic> take_diagnostics();
+
     static CORE_EXPORT bool configure(std::uint64_t localUserId,
         const std::string& stunHost, std::uint16_t stunPort,
         const std::vector<LobbyIceTurnServer>& turnServers = {});

--- a/Source/RMG-Core/LobbyIce.hpp
+++ b/Source/RMG-Core/LobbyIce.hpp
@@ -48,6 +48,9 @@ struct LobbyIceSignal
 struct LobbyIcePacket
 {
     std::uint64_t peerUserId = 0;
+    // Monotonic RTT measured inside the libjuice transport. Zero means this
+    // packet was not a locally tracked ping reply.
+    std::uint64_t roundTripUs = 0;
     std::vector<char> data;
 };
 

--- a/Source/RMG-Core/LobbyIce.hpp
+++ b/Source/RMG-Core/LobbyIce.hpp
@@ -1,0 +1,80 @@
+/*
+ * Rosalie's Mupen GUI - https://github.com/Rosalie241/RMG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3.
+ */
+#ifndef RMGK_LOBBY_ICE_HPP
+#define RMGK_LOBBY_ICE_HPP
+
+#include "Library.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+enum class LobbyIceChannel : std::uint8_t
+{
+    Ping = 1,
+    Prematch = 2,
+    Gekko = 3,
+};
+
+enum class LobbyIcePeerState
+{
+    Disconnected = 0,
+    Gathering,
+    Connecting,
+    Connected,
+    Completed,
+    Failed,
+};
+
+struct LobbyIceTurnServer
+{
+    std::string host;
+    std::uint16_t port = 3478;
+    std::string username;
+    std::string password;
+};
+
+struct LobbyIceSignal
+{
+    std::uint64_t peerUserId = 0;
+    std::string kind; // "description", "candidate", or "gathering_done"
+    std::string value;
+};
+
+struct LobbyIcePacket
+{
+    std::uint64_t peerUserId = 0;
+    std::vector<char> data;
+};
+
+// Process-wide room ICE mesh. Lobby signaling calls this API from the Qt UI
+// thread; GekkoNet consumes the same agents from the emulation thread.
+class LobbyIce
+{
+  public:
+    static CORE_EXPORT bool configure(std::uint64_t localUserId,
+        const std::string& stunHost, std::uint16_t stunPort,
+        const std::vector<LobbyIceTurnServer>& turnServers = {});
+    static CORE_EXPORT void reset();
+
+    static CORE_EXPORT bool add_peer(std::uint64_t peerUserId);
+    static CORE_EXPORT void remove_peer(std::uint64_t peerUserId);
+    static CORE_EXPORT bool has_peer(std::uint64_t peerUserId);
+    static CORE_EXPORT LobbyIcePeerState peer_state(std::uint64_t peerUserId);
+    static CORE_EXPORT bool peer_connected(std::uint64_t peerUserId);
+    static CORE_EXPORT std::string peer_selected_addresses(std::uint64_t peerUserId);
+
+    static CORE_EXPORT std::vector<LobbyIceSignal> take_local_signals();
+    static CORE_EXPORT bool handle_remote_signal(std::uint64_t peerUserId,
+        const std::string& kind, const std::string& value);
+
+    static CORE_EXPORT bool send(std::uint64_t peerUserId, LobbyIceChannel channel,
+        const char* data, std::size_t size);
+    static CORE_EXPORT std::vector<LobbyIcePacket> take_packets(LobbyIceChannel channel);
+};
+
+#endif // RMGK_LOBBY_ICE_HPP

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -85,8 +85,9 @@ constexpr long long kGekkoStallSnapshotIntervalMs = 250;
 
 // Symmetric ("aggressive") model — the default. Recomputes every frame and
 // pulls a drifting client back hard from either side: a single signed
-// strength*frames_ahead correction clamped to a wide scale window. Reacts fast,
-// at the cost of nudging the ahead player's framerate a touch more visibly.
+// strength*delay-balanced-error correction clamped to a wide scale window.
+// Reacts fast, at the cost of nudging the ahead player's framerate a touch more
+// visibly.
 constexpr float  kGekkoSymTimesyncDeadzone       = 0.20f;
 constexpr double kGekkoSymTimesyncStrength       = 0.015;
 constexpr double kGekkoSymTimesyncMinScale       = 0.97;
@@ -103,9 +104,10 @@ constexpr int    kGekkoSymTimesyncIntervalFrames = 1;
 // player close to full speed while still shrinking its speculative window, so
 // it sees fewer rollback "teleports" of the remote character.
 //
-// Slippi works in microseconds of clock offset; we work in gekko_frames_ahead()
-// (signed frames, +ve = local ahead), so the windows/deadzones below are the
-// frame-unit equivalents of Slippi's 8000us / -250us deadzone and 3-frame ramp.
+// Slippi works in microseconds of clock offset; gekko_frames_ahead() gives us a
+// signed delay-balanced error (+ve = local ahead of its delay-derived target),
+// so the windows/deadzones below are the frame-unit equivalents of Slippi's
+// 8000us / -250us deadzone and 3-frame ramp.
 constexpr float  kGekkoAsymTimesyncAheadDeadzone  = 0.48f;  // tolerate being ahead by ~half a frame
 constexpr float  kGekkoAsymTimesyncBehindDeadzone = 0.015f; // but correct almost immediately when behind
 constexpr double kGekkoAsymTimesyncSpeedUpWindow  = 3.0;    // frames behind to reach full speed-up
@@ -1617,8 +1619,10 @@ void append_peer_network_stats(std::ostringstream& stream)
 
 void apply_gekko_frame_pacing()
 {
-    // Read frames_ahead every call (cheap, just a member access in
-    // GekkoSession) but only recompute the target scale on sample frames. The
+    // Read the delay-balanced frame error every call (cheap, just a member
+    // access in GekkoSession) but only recompute the target scale on sample
+    // frames. With unequal local delays, zero intentionally means the
+    // lower-delay peer is numerically ahead by the delay difference. The
     // per-frame lerp below carries the speed scale toward the cached target
     // between samples. Both the sample cadence and the target computation depend
     // on the active pacing model (see GekkoPacingMode); the lerp tail is shared.

--- a/Source/RMG-Core/rmgk_gekko.cpp
+++ b/Source/RMG-Core/rmgk_gekko.cpp
@@ -27,6 +27,9 @@
 #include "Error.hpp"
 #include "Library.hpp"
 #include "Settings.hpp"
+#ifdef NETPLAY
+#include "LobbyIce.hpp"
+#endif
 
 #include "PreciseWait.hpp"
 
@@ -944,6 +947,7 @@ static std::atomic<ExtSocket> g_GekkoExternalSocket{kExtSocketNone};
 // True while the CURRENT session runs on the adopted socket (latched at
 // start_lobby_session so a mid-session clear can't strand the adapter).
 static bool g_GekkoUsingExternalSocket = false;
+static bool g_GekkoUsingIceAdapter = false;
 static std::vector<GekkoNetResult*> g_GekkoExtResults;
 
 static void ext_adapter_send(GekkoNetAddress* addr, const char* data, int length)
@@ -1050,6 +1054,82 @@ static GekkoNetAdapter g_GekkoExternalAdapter{
     ext_adapter_receive,
     ext_adapter_free
 };
+
+#ifdef NETPLAY
+static std::vector<GekkoNetResult*> g_GekkoIceResults;
+
+static std::uint64_t ice_user_id(const GekkoNetAddress* addr)
+{
+    if (addr == nullptr || addr->data == nullptr)
+        return 0;
+    const std::string value(reinterpret_cast<const char*>(addr->data), addr->size);
+    constexpr const char* prefix = "ice:";
+    if (value.rfind(prefix, 0) != 0)
+        return 0;
+    try
+    {
+        return std::stoull(value.substr(std::char_traits<char>::length(prefix)));
+    }
+    catch (...)
+    {
+        return 0;
+    }
+}
+
+static void ice_adapter_send(GekkoNetAddress* addr, const char* data, int length)
+{
+    const std::uint64_t userId = ice_user_id(addr);
+    if (userId == 0 || length < 0 ||
+        !LobbyIce::send(userId, LobbyIceChannel::Gekko, data, static_cast<std::size_t>(length)))
+    {
+        if (g_GekkoLogEnabled)
+            write_gekko_log("ice_adapter_send result=fail");
+    }
+}
+
+static GekkoNetResult** ice_adapter_receive(int* length)
+{
+    g_GekkoIceResults.clear();
+    if (length == nullptr)
+        return g_GekkoIceResults.data();
+
+    for (LobbyIcePacket& packet : LobbyIce::take_packets(LobbyIceChannel::Gekko))
+    {
+        const std::string endpoint = "ice:" + std::to_string(packet.peerUserId);
+        GekkoNetResult* result = static_cast<GekkoNetResult*>(std::malloc(sizeof(*result)));
+        if (result == nullptr)
+            break;
+        result->addr.data = std::malloc(endpoint.size());
+        result->data = std::malloc(packet.data.size());
+        if (result->addr.data == nullptr || (result->data == nullptr && !packet.data.empty()))
+        {
+            std::free(result->addr.data);
+            std::free(result->data);
+            std::free(result);
+            break;
+        }
+        result->addr.size = static_cast<unsigned int>(endpoint.size());
+        std::memcpy(result->addr.data, endpoint.data(), endpoint.size());
+        result->data_len = static_cast<unsigned int>(packet.data.size());
+        if (!packet.data.empty())
+            std::memcpy(result->data, packet.data.data(), packet.data.size());
+        g_GekkoIceResults.push_back(result);
+    }
+    *length = static_cast<int>(g_GekkoIceResults.size());
+    return g_GekkoIceResults.data();
+}
+
+static void ice_adapter_free(void* data)
+{
+    std::free(data);
+}
+
+static GekkoNetAdapter g_GekkoIceAdapter{
+    ice_adapter_send,
+    ice_adapter_receive,
+    ice_adapter_free
+};
+#endif
 
 const char* gekko_session_event_name(GekkoSessionEventType type)
 {
@@ -2419,20 +2499,48 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
         return false;
     }
 
-    // Validate per-remote endpoints and slot uniqueness before we touch GekkoNet.
+    // Validate per-remote ICE identities (or legacy endpoints) and slot
+    // uniqueness before we touch GekkoNet.
     bool slotSeen[5] = { false, false, false, false, false }; // index 1..4
     slotSeen[localPlayer] = true;
+    bool sawIce = false;
+    bool sawLegacyEndpoint = false;
     for (int i = 0; i < numRemotes; i++)
     {
         const LobbyRemotePeer& peer = remotes[i];
         if (peer.slot < 1 || peer.slot > players || peer.slot == localPlayer ||
-            peer.ip.empty() || peer.port == 0 || slotSeen[peer.slot])
+            slotSeen[peer.slot] ||
+            (peer.userId == 0 && (peer.ip.empty() || peer.port == 0)))
         {
             write_gekko_log("start_lobby_session result=fail reason=bad_remote_peer");
             return false;
         }
+        sawIce = sawIce || peer.userId != 0;
+        sawLegacyEndpoint = sawLegacyEndpoint || peer.userId == 0;
         slotSeen[peer.slot] = true;
     }
+    if (sawIce && sawLegacyEndpoint)
+    {
+        write_gekko_log("start_lobby_session result=fail reason=mixed_lobby_transports");
+        return false;
+    }
+    bool useIce = sawIce;
+#ifdef NETPLAY
+    if (useIce)
+    {
+        for (int i = 0; i < numRemotes; ++i)
+        {
+            if (!LobbyIce::peer_connected(remotes[i].userId))
+            {
+                CoreSetError("A rollback lobby ICE peer disconnected before emulation started.");
+                write_gekko_log("start_lobby_session result=fail reason=ice_peer_not_connected");
+                return false;
+            }
+        }
+    }
+#else
+    useIce = false;
+#endif
 
     if (!gekko_create(&g_GekkoSession, GekkoGameSession))
     {
@@ -2462,12 +2570,17 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
     config.check_distance = 10;
     gekko_start(g_GekkoSession, &config);
 
-    // Preferred transport: the lobby's own anchor socket, adopted whole
-    // (n02-style — one socket for lobby and game, so the port and every
-    // peer's NAT mapping to us survive the match boundary). Falls back to
-    // GekkoNet's built-in adapter binding localPort when no socket was lent
-    // (the old handoff model; the anchor was released before this call).
-    g_GekkoUsingExternalSocket = (g_GekkoExternalSocket.load() != kExtSocketNone);
+    g_GekkoUsingIceAdapter = useIce;
+    g_GekkoUsingExternalSocket = !useIce && (g_GekkoExternalSocket.load() != kExtSocketNone);
+#ifdef NETPLAY
+    if (g_GekkoUsingIceAdapter)
+    {
+        LobbyIce::take_packets(LobbyIceChannel::Gekko);
+        gekko_net_adapter_set(g_GekkoSession, &g_GekkoIceAdapter);
+        write_gekko_log("start_lobby_session transport=libjuice_ice");
+    }
+    else
+#endif
     if (g_GekkoUsingExternalSocket)
     {
         gekko_net_adapter_set(g_GekkoSession, &g_GekkoExternalAdapter);
@@ -2522,12 +2635,16 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
                << " clamped_local_delay=" << clampedLocalDelay
                << " prediction_window=" << predictionWindow
                << " clamped_prediction_window=" << clampedPredictionWindow
-               << " transport=gekko_default_udp"
+               << " transport=" << (useIce ? "libjuice_ice" :
+                    (g_GekkoUsingExternalSocket ? "shared_anchor_socket" : "gekko_default_udp"))
                << " num_remotes=" << numRemotes;
         for (int i = 0; i < numRemotes; i++)
         {
-            stream << " remote[" << i << "]=slot" << remotes[i].slot
-                   << "@" << remotes[i].ip << ":" << remotes[i].port;
+            stream << " remote[" << i << "]=slot" << remotes[i].slot;
+            if (remotes[i].userId != 0)
+                stream << "@ice:" << remotes[i].userId;
+            else
+                stream << "@" << remotes[i].ip << ":" << remotes[i].port;
         }
         write_gekko_log(stream.str());
     }
@@ -2537,7 +2654,9 @@ CORE_EXPORT bool rmgk_gekko::start_lobby_session(const char* gameName, int playe
     std::vector<std::string> remoteAddrStrings(static_cast<size_t>(numRemotes));
     for (int i = 0; i < numRemotes; i++)
     {
-        remoteAddrStrings[static_cast<size_t>(i)] = remotes[i].ip + ":" + std::to_string(remotes[i].port);
+        remoteAddrStrings[static_cast<size_t>(i)] = remotes[i].userId != 0
+            ? "ice:" + std::to_string(remotes[i].userId)
+            : remotes[i].ip + ":" + std::to_string(remotes[i].port);
     }
 
     for (int player = 1; player <= players; player++)
@@ -2765,14 +2884,19 @@ CORE_EXPORT void rmgk_gekko::close_session()
         gekko_destroy(&g_GekkoSession);
         // The adopted anchor socket is borrowed — the lobby client owns and
         // keeps it; only the default adapter's own socket is ours to destroy.
-        if (!g_GekkoUsingExternalSocket)
+        if (!g_GekkoUsingExternalSocket && !g_GekkoUsingIceAdapter)
         {
             gekko_default_adapter_destroy();
         }
     }
     g_GekkoUsingExternalSocket = false;
+    g_GekkoUsingIceAdapter = false;
     g_GekkoExternalSocket.store(kExtSocketNone);
     g_GekkoExtResults.clear();
+#ifdef NETPLAY
+    g_GekkoIceResults.clear();
+    LobbyIce::take_packets(LobbyIceChannel::Gekko);
+#endif
     g_GekkoSession = nullptr;
     g_GekkoPlayers = 0;
     g_GekkoActors = 0;

--- a/Source/RMG-Core/rmgk_gekko.hpp
+++ b/Source/RMG-Core/rmgk_gekko.hpp
@@ -24,6 +24,7 @@
 struct LobbyRemotePeer
 {
     int slot = 0;              // 1-indexed N64 controller slot
+    std::uint64_t userId = 0;  // lobby identity used by the ICE adapter
     std::string ip;            // IPv4 dotted quad
     unsigned short port = 0;
 };
@@ -36,10 +37,9 @@ class rmgk_gekko
 
     static bool start_p2p_session(const char* gameName, int players, int inputSize,
         int localPlayer, unsigned short localPort, const char* remoteIp, unsigned short remotePort, int localDelay, int predictionWindow);
-    // Lobby variant: uses GekkoNet's built-in UDP adapter directly instead of
-    // riding on n02's P2P socket. Takes an explicit list of remote peers
-    // (slot + endpoint) so 3-/4-player sessions can wire each remote actor
-    // to its own peer address.
+    // Lobby variant: uses the room's libjuice ICE mesh. It remains separate
+    // from the n02/connect-code transport and takes one lobby identity per
+    // remote controller slot.
     static bool start_lobby_session(const char* gameName, int players, int inputSize,
         int localPlayer, unsigned short localPort,
         const LobbyRemotePeer* remotes, int numRemotes,

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
@@ -69,10 +69,8 @@ void CreateRoomDialog::buildUi(const QString& defaultUsername, const QString& de
 
     root->addLayout(form);
 
-    // Rollback settings (delay / prediction) are no longer surfaced here —
-    // the host configures them from the in-room view via the settings row.
-    // We still send sensible defaults to the server at creation time; the
-    // host can adjust before clicking Start Game.
+    // Rollback settings are not surfaced here. Each player configures local
+    // delay in the room, and prediction is fixed at 9 frames.
 
     // Optional password (collapsed by default)
     auto* pwRow = new QHBoxLayout;
@@ -154,8 +152,7 @@ void CreateRoomDialog::validateInput()
 
 void CreateRoomDialog::onCreateClicked()
 {
-    // Capture form values. Delay/prediction stay at their loadDefaults()
-    // values (or the struct defaults 2/7) — host adjusts in-room.
+    // The legacy delay and fixed prediction stay at their loadDefaults() values.
     m_name = m_nameEdit->text().trimmed();
     // m_romName / m_romMd5 were set from the lobby picker in the constructor.
     m_romRegion  = ""; // baked into the ROM; resolved later via md5 lookup
@@ -191,10 +188,10 @@ void CreateRoomDialog::loadDefaults()
     QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     if (s.contains("MaxPlayers")) m_maxPlayersSpin->setValue(s.value("MaxPlayers").toInt());
-    // Seed the initial delay/prediction from the last in-room values the
-    // host configured. The in-room view writes to the same keys.
-    if (s.contains("Delay"))      m_delay = s.value("Delay").toInt();
-    if (s.contains("Prediction")) m_prediction = s.value("Prediction").toInt();
+    // Seed the legacy room delay from the last local value. Prediction is a
+    // fixed lobby rule and is never loaded from older user settings.
+    if (s.contains("Delay")) m_delay = s.value("Delay").toInt();
+    m_prediction = 9;
     s.endGroup();
 }
 
@@ -204,8 +201,7 @@ void CreateRoomDialog::saveDefaults()
     s.beginGroup("Lobby/CreateRoom");
     // The game selection is persisted by the lobby's shared picker, not here.
     s.setValue("MaxPlayers", m_maxPlayers);
-    // Delay/prediction persistence moves to the in-room view; CreateRoom
-    // only consumes those defaults, doesn't write them.
+    // Delay persistence lives in the room view; CreateRoom only consumes it.
     s.endGroup();
 }
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
@@ -72,7 +72,7 @@ private:
     void saveDefaults();
     void setFormEnabled(bool enabled);
 
-    // UI — delay/prediction spinners live in the in-room view now, not here.
+    // UI — local delay lives in the room view; prediction is fixed at 9.
     QLineEdit*   m_nameEdit       = nullptr;
     QLabel*      m_gameLabel      = nullptr;   // read-only game from the lobby picker
     QSpinBox*    m_maxPlayersSpin = nullptr;
@@ -89,7 +89,7 @@ private:
     QString m_romRegion;
     int     m_maxPlayers = 2;
     int     m_delay      = 2;
-    int     m_prediction = 7;
+    int     m_prediction = 9;
     QString m_password;
 };
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -24,6 +24,7 @@
 #include <RMG-Core/Cheats.hpp>
 #include <RMG-Core/Directories.hpp>
 #include <RMG-Core/Error.hpp>
+#include <RMG-Core/LobbyIce.hpp>
 #include <RMG-Core/Settings.hpp>
 #include <RMG-Core/Version.hpp>
 
@@ -41,14 +42,18 @@
 #include <QCoreApplication>
 #include <QtEndian>
 #include <QRandomGenerator>
+#include <QThread>
 #include <QDebug>
 #include <QSet>
 #include <QEvent>
 #include <QFile>
 #include <QDir>
 #include <cstring>
+#include <algorithm>
 #include <filesystem>
 #include <system_error>
+#include <utility>
+#include <vector>
 
 using namespace UserInterface::Dialog;
 
@@ -74,6 +79,7 @@ namespace
     constexpr quint8 ANCHOR_OP_PROBE_REPLY = 0x05; // peer → client: ping echo
     constexpr quint8 ANCHOR_OP_PREMATCH_MANIFEST = 0x06;
     constexpr quint8 ANCHOR_OP_PREMATCH_ACK      = 0x07;
+    constexpr quint8 ANCHOR_OP_PREMATCH_FRAGMENT = 0x08;
 
     // Burst size for NAT punch-through. Defends against single-packet loss
     // and brief mapping-creation latency on consumer routers — NOT against
@@ -189,6 +195,37 @@ namespace
         return true;
     }
 
+    void appendPrematchU16(QByteArray& data, quint16 value)
+    {
+        data.append(static_cast<char>(value & 0xffu));
+        data.append(static_cast<char>((value >> 8) & 0xffu));
+    }
+
+    void appendPrematchU32(QByteArray& data, quint32 value)
+    {
+        for (int i = 0; i < 4; ++i)
+            data.append(static_cast<char>((value >> (i * 8)) & 0xffu));
+    }
+
+    bool readPrematchU16(const QByteArray& data, int offset, quint16& value)
+    {
+        if (offset < 0 || data.size() < offset + 2)
+            return false;
+        value = static_cast<quint16>(static_cast<unsigned char>(data[offset])) |
+            (static_cast<quint16>(static_cast<unsigned char>(data[offset + 1])) << 8);
+        return true;
+    }
+
+    bool readPrematchU32(const QByteArray& data, int offset, quint32& value)
+    {
+        if (offset < 0 || data.size() < offset + 4)
+            return false;
+        value = 0;
+        for (int i = 0; i < 4; ++i)
+            value |= static_cast<quint32>(static_cast<unsigned char>(data[offset + i])) << (i * 8);
+        return true;
+    }
+
     bool buildPrematchManifest(const QString& romFile, std::string& manifest, uint64_t& manifestHash, size_t& cheatCount)
     {
         std::vector<CoreCheat> cheats;
@@ -262,6 +299,36 @@ namespace
         return readPrematchU64(packet, 13, manifestHash);
     }
 
+    QList<QByteArray> fragmentPrematchPacket(const QByteArray& packet,
+        quint64 senderUserId, uint64_t manifestHash)
+    {
+        constexpr int kPayloadBytes = 1000;
+        if (packet.size() <= kPayloadBytes)
+            return {packet};
+
+        const int count = (packet.size() + kPayloadBytes - 1) / kPayloadBytes;
+        if (count > 2048)
+            return {};
+        QList<QByteArray> fragments;
+        fragments.reserve(count);
+        for (int index = 0; index < count; ++index)
+        {
+            QByteArray fragment;
+            fragment.reserve(29 + kPayloadBytes);
+            fragment.append(ANCHOR_MAGIC, 4);
+            fragment.append(static_cast<char>(ANCHOR_OP_PREMATCH_FRAGMENT));
+            const quint64 senderBE = qToBigEndian(senderUserId);
+            fragment.append(reinterpret_cast<const char*>(&senderBE), sizeof(senderBE));
+            appendPrematchU64(fragment, manifestHash);
+            appendPrematchU16(fragment, static_cast<quint16>(index));
+            appendPrematchU16(fragment, static_cast<quint16>(count));
+            appendPrematchU32(fragment, static_cast<quint32>(packet.size()));
+            fragment.append(packet.mid(index * kPayloadBytes, kPayloadBytes));
+            fragments.append(std::move(fragment));
+        }
+        return fragments;
+    }
+
 
     QString detectLocalIPv4()
     {
@@ -329,6 +396,13 @@ LobbyClient::LobbyClient(QObject* parent)
     m_probeRetryTimer->setInterval(PROBE_RETRY_TICK_MS);
     connect(m_probeRetryTimer, &QTimer::timeout, this, &LobbyClient::onProbeRetryTimer);
     m_probeRetryTimer->start();
+
+    // libjuice callbacks run on its worker thread. Poll their thread-safe
+    // queues here so all WebSocket signaling and ping UI stays on Qt's thread.
+    m_iceTimer = new QTimer(this);
+    m_iceTimer->setInterval(25);
+    connect(m_iceTimer, &QTimer::timeout, this, &LobbyClient::flushIceEvents);
+    m_iceTimer->start();
 
     // Single-shot; each failed pinned-port bind schedules the next attempt.
     m_anchorRetryTimer = new QTimer(this);
@@ -412,6 +486,8 @@ void LobbyClient::disconnectFromServer()
     m_anchorRetryDeadlineMs = 0;
     m_heartbeatTimer->stop();
     m_udpKeepaliveTimer->stop();
+    resetIceMesh();
+    LobbyIce::reset();
     if (m_ws && m_ws->state() != QAbstractSocket::UnconnectedState)
     {
         m_ws->close();
@@ -514,6 +590,7 @@ void LobbyClient::onWsConnected()
     for (const auto& h : m_pendingRomHashes)
         romArr.append(h);
     data["romHashes"] = romArr;
+    data["iceSupported"] = true;
     if (!m_pendingLocalIp.isEmpty())
         data["localIp"] = m_pendingLocalIp;
 
@@ -523,6 +600,8 @@ void LobbyClient::onWsConnected()
 void LobbyClient::onWsDisconnected()
 {
     stopPingDiagnosticLog(QStringLiteral("connection_lost"));
+    resetIceMesh();
+    LobbyIce::reset();
     // Passive drops (server restart, network cut, server-side kick) never go
     // through disconnectFromServer, so the anchor socket used to stay bound —
     // and the next connect's pinned-port bind then failed against our own
@@ -599,6 +678,7 @@ void LobbyClient::handleEnvelope(const QJsonObject& env)
     else if (type == "CHAT_HISTORY_REPLY")   handleChatHistoryReply(data);
     else if (type == "PING_PROBE_REPLY")     handlePingProbeReply(data);
     else if (type == "PING_PROBE_INCOMING")  handlePingProbeIncoming(data);
+    else if (type == "ICE_SIGNAL")           handleIceSignal(data);
     else if (type == "MATCH_BEGIN")          handleMatchBegin(data);
     else if (type == "MATCH_PEER_LEFT")      handleMatchPeerLeft(data);
     else if (type == "QUICK_MATCH_STATUS")   handleQuickMatchStatus(data);
@@ -621,6 +701,36 @@ void LobbyClient::handleHelloOk(const QJsonObject& data)
     m_selfUserId  = static_cast<quint64>(data.value("userId").toDouble());
     m_observedIp  = data.value("observedIp").toString();
     m_region      = data.value("region").toString();
+
+    std::string stunHost = "stun.l.google.com";
+    quint16 stunPort = 19302;
+    std::vector<LobbyIceTurnServer> turnServers;
+    const QJsonObject ice = data.value("ice").toObject();
+    const QJsonObject stun = ice.value("stun").toObject();
+    if (!stun.value("host").toString().isEmpty())
+        stunHost = stun.value("host").toString().toStdString();
+    if (stun.value("port").toInt() > 0 && stun.value("port").toInt() <= 65535)
+        stunPort = static_cast<quint16>(stun.value("port").toInt());
+    for (const QJsonValue& value : ice.value("turn").toArray())
+    {
+        const QJsonObject object = value.toObject();
+        LobbyIceTurnServer server;
+        server.host = object.value("host").toString().toStdString();
+        const int port = object.value("port").toInt(3478);
+        if (port < 1 || port > 65535)
+            continue;
+        server.port = static_cast<quint16>(port);
+        server.username = object.value("username").toString().toStdString();
+        server.password = object.value("password").toString().toStdString();
+        if (!server.host.empty() && server.port != 0)
+            turnServers.push_back(std::move(server));
+    }
+    if (!LobbyIce::configure(m_selfUserId, stunHost, stunPort, turnServers))
+    {
+        emit connectError(QStringLiteral("Failed to initialize ICE transport."));
+        setState(ConnectionState::Failed);
+        return;
+    }
     qInfo() << "Rollback lobby authenticated" << "userId" << m_selfUserId
             << "observedIp" << m_observedIp << "region" << m_region;
 
@@ -645,7 +755,8 @@ void LobbyClient::handleHelloOk(const QJsonObject& data)
 
     setState(ConnectionState::Connected);
     m_heartbeatTimer->start();
-    initiateUdpAnchor();
+    // ICE owns the UDP sockets. The legacy lobby anchor is intentionally not
+    // opened by ICE-capable clients.
 }
 
 void LobbyClient::handleHelloFail(const QJsonObject& data)
@@ -736,16 +847,19 @@ void LobbyClient::handleRoomCreateFail(const QJsonObject& data)
 
 void LobbyClient::handleRoomLeft(const QJsonObject& data)
 {
+    resetIceMesh();
     emit roomLeft(data.value("reason").toString());
 }
 
 void LobbyClient::handleRoomState(const QJsonObject& data)
 {
+    reconcileIcePeers(data);
     emit roomStateChanged(data);
 }
 
 void LobbyClient::handleRoomJoinOk(const QJsonObject& data)
 {
+    reconcileIcePeers(data);
     emit roomJoinOk(static_cast<quint64>(data.value("id").toDouble()));
     emit roomStateChanged(data);
 }
@@ -753,6 +867,132 @@ void LobbyClient::handleRoomJoinOk(const QJsonObject& data)
 void LobbyClient::handleRoomJoinFail(const QJsonObject& data)
 {
     emit roomJoinFailed(data.value("reason").toString());
+}
+
+void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
+{
+    const quint64 roomId = static_cast<quint64>(roomState.value("id").toDouble());
+    if (roomId == 0)
+        return;
+    if (m_currentIceRoomId != 0 && m_currentIceRoomId != roomId)
+        resetIceMesh();
+    m_currentIceRoomId = roomId;
+
+    QSet<quint64> desired;
+    for (const QJsonValue& value : roomState.value("players").toArray())
+    {
+        const QJsonObject player = value.toObject();
+        const quint64 userId = static_cast<quint64>(player.value("userId").toDouble());
+        if (userId == 0 || userId == m_selfUserId)
+            continue;
+        if (!player.value("iceSupported").toBool())
+        {
+            qWarning() << "Rollback lobby peer does not support ICE" << userId;
+            continue;
+        }
+        desired.insert(userId);
+        if (!m_icePeerIds.contains(userId) && LobbyIce::add_peer(userId))
+        {
+            m_icePeerIds.insert(userId);
+            writePingDiagnostic(QStringLiteral("ICE_PEER_ADDED"),
+                                QStringLiteral("peer=%1 room=%2").arg(pingUserLabel(userId)).arg(roomId));
+        }
+    }
+
+    const QSet<quint64> stale = m_icePeerIds - desired;
+    for (quint64 userId : stale)
+    {
+        LobbyIce::remove_peer(userId);
+        m_icePeerIds.remove(userId);
+        m_lastIceStates.remove(userId);
+    }
+}
+
+void LobbyClient::resetIceMesh()
+{
+    for (quint64 userId : std::as_const(m_icePeerIds))
+        LobbyIce::remove_peer(userId);
+    m_icePeerIds.clear();
+    m_lastIceStates.clear();
+    m_currentIceRoomId = 0;
+    m_pendingProbes.clear();
+}
+
+void LobbyClient::handleIceSignal(const QJsonObject& data)
+{
+    const quint64 roomId = static_cast<quint64>(data.value("roomId").toDouble());
+    const quint64 fromUserId = static_cast<quint64>(data.value("fromUserId").toDouble());
+    const QString kind = data.value("kind").toString();
+    if (roomId == 0 || roomId != m_currentIceRoomId || fromUserId == 0 ||
+        fromUserId == m_selfUserId)
+        return;
+    LobbyIce::handle_remote_signal(fromUserId, kind.toStdString(),
+                                   data.value("value").toString().toStdString());
+}
+
+void LobbyClient::sendIcePing(quint64 userId, quint64 nonce, bool reply)
+{
+    QByteArray payload(1 + int(sizeof(quint64)), Qt::Uninitialized);
+    payload[0] = reply ? char(2) : char(1);
+    const quint64 nonceBE = qToBigEndian(nonce);
+    std::memcpy(payload.data() + 1, &nonceBE, sizeof(nonceBE));
+    LobbyIce::send(userId, LobbyIceChannel::Ping, payload.constData(), size_t(payload.size()));
+}
+
+void LobbyClient::flushIceEvents()
+{
+    if (m_ws && m_ws->state() == QAbstractSocket::ConnectedState && m_currentIceRoomId != 0)
+    {
+        for (LobbyIceSignal& signal : LobbyIce::take_local_signals())
+        {
+            QJsonObject data;
+            data["targetUserId"] = QJsonValue(qint64(signal.peerUserId));
+            data["roomId"] = QJsonValue(qint64(m_currentIceRoomId));
+            data["kind"] = QString::fromStdString(signal.kind);
+            if (!signal.value.empty())
+                data["value"] = QString::fromStdString(signal.value);
+            sendEnvelope("ICE_SIGNAL", data);
+        }
+    }
+
+    for (const LobbyIcePacket& packet : LobbyIce::take_packets(LobbyIceChannel::Ping))
+    {
+        if (packet.data.size() != 1 + sizeof(quint64))
+            continue;
+        quint64 nonceBE = 0;
+        std::memcpy(&nonceBE, packet.data.data() + 1, sizeof(nonceBE));
+        const quint64 nonce = qFromBigEndian(nonceBE);
+        if (packet.data[0] == 1)
+        {
+            sendIcePing(packet.peerUserId, nonce, true);
+            continue;
+        }
+        if (packet.data[0] != 2)
+            continue;
+        const auto it = m_pendingProbes.find(nonce);
+        if (it == m_pendingProbes.end() || it->targetUserId != packet.peerUserId)
+            continue;
+        const int rttMs = int(std::clamp<qint64>(
+            QDateTime::currentMSecsSinceEpoch() - it->attemptSendMs, 0, 65535));
+        m_pendingProbes.erase(it);
+        m_probeFailStreak[packet.peerUserId] = 0;
+        m_measuredPing[packet.peerUserId] = rttMs;
+        writePingDiagnostic(QStringLiteral("ICE_PING_REPLY"),
+                            QStringLiteral("peer=%1 rtt_ms=%2").arg(pingUserLabel(packet.peerUserId)).arg(rttMs));
+        emit pingProbeMeasured(packet.peerUserId, rttMs);
+    }
+
+    for (quint64 userId : std::as_const(m_icePeerIds))
+    {
+        const int state = static_cast<int>(LobbyIce::peer_state(userId));
+        if (m_lastIceStates.value(userId, -1) == state)
+            continue;
+        m_lastIceStates[userId] = state;
+        writePingDiagnostic(QStringLiteral("ICE_STATE"),
+                            QStringLiteral("peer=%1 state=%2 selected=%3")
+                                .arg(pingUserLabel(userId)).arg(state)
+                                .arg(QString::fromStdString(LobbyIce::peer_selected_addresses(userId))));
+    }
 }
 
 void LobbyClient::handleChatMsg(const QJsonObject& data)
@@ -1029,37 +1269,6 @@ void LobbyClient::sendProbeBurst(const QHostAddress& addr, quint16 port, quint64
 
 void LobbyClient::onProbeRetryTimer()
 {
-    // Poll the socket rather than trusting readyRead alone. Qt disables read
-    // notification for an unbuffered socket whose readyRead goes unserviced,
-    // and re-arms it on the next successful read — but during a match our slot
-    // deliberately reads nothing (GekkoNet's thread owns recvfrom), so the
-    // notification is off by the time the match ends. Whether it ever comes
-    // back then depends on there happening to be a datagram queued at that
-    // instant, which is precisely the coin-flip seen in the field: the client
-    // whose match-end drain found datagrams recovered, the one that found an
-    // empty buffer stayed deaf until the process restarted. A socket serviced
-    // from two threads can't rely on Qt's notifier bookkeeping, so poll it —
-    // this is the same discipline n02 uses. Cheap: a no-op when nothing is
-    // pending, and this timer already runs continuously. BoundState matters:
-    // this timer also ticks before connect and after disconnect, when the
-    // socket object exists but isn't bound, and hasPendingDatagrams() on an
-    // unbound socket emits a qWarning every call — ten a second, straight to
-    // the terminal on Linux.
-    if (m_udp && m_udp->state() == QAbstractSocket::BoundState &&
-        !m_anchorLent && !m_inPrematchSync)
-    {
-        m_drainedDatagrams = 0;
-        onUdpReadyRead();
-        if (m_drainedDatagrams > 0)
-        {
-            // The notifier missed these — readyRead would have drained them
-            // already. Logged because a run of these is the signature of the
-            // stall above, and their absence means it isn't happening.
-            writePingDiagnostic(QStringLiteral("POLL_DRAIN"),
-                                QStringLiteral("datagrams=%1").arg(m_drainedDatagrams));
-        }
-    }
-
     if (m_pendingProbes.isEmpty())
         return;
 
@@ -1078,20 +1287,10 @@ void LobbyClient::onProbeRetryTimer()
             // stale sweep so the room hears about it promptly.
             const quint64 uid = it->targetUserId;
             writePingDiagnostic(QStringLiteral("PROBE_FAILED"),
-                                QStringLiteral("peer=%1 attempts=%2 burst=%3 age_ms=%4")
+                                QStringLiteral("peer=%1 transport=ice attempts=%2 age_ms=%3")
                                     .arg(pingUserLabel(uid))
                                     .arg(PROBE_ATTEMPTS)
-                                    .arg(PROBE_BURST)
                                     .arg(nowMs - it->sendMs));
-            it = m_pendingProbes.erase(it);
-            noteProbeSeriesFailed(uid);
-            continue;
-        }
-
-        QHostAddress addr; quint16 port = 0;
-        if (!parseEndpoint(it->endpoint, addr, port))
-        {
-            const quint64 uid = it->targetUserId;
             it = m_pendingProbes.erase(it);
             noteProbeSeriesFailed(uid);
             continue;
@@ -1100,18 +1299,13 @@ void LobbyClient::onProbeRetryTimer()
         it->attempt      += 1;
         it->attemptSendMs = nowMs;
         it->nextAttemptMs = nowMs + PROBE_RETRY_INTERVAL_MS;
-        sendProbeBurst(addr, port, it.key());
-        QHostAddress altAddr; quint16 altPort = 0;
-        if (!it->altEndpoint.isEmpty() && parseEndpoint(it->altEndpoint, altAddr, altPort))
-            sendProbeBurst(altAddr, altPort, it.key());
+        sendIcePing(it->targetUserId, it.key(), false);
         writePingDiagnostic(QStringLiteral("PROBE_RETRY"),
-                            QStringLiteral("peer=%1 endpoint=%2 alt=%3 nonce=%4 attempt=%5/%6 burst=%7")
-                                .arg(pingUserLabel(it->targetUserId), it->endpoint,
-                                     it->altEndpoint.isEmpty() ? QStringLiteral("-") : it->altEndpoint)
+                            QStringLiteral("peer=%1 transport=ice nonce=%2 attempt=%3/%4")
+                                .arg(pingUserLabel(it->targetUserId))
                                 .arg(it.key())
                                 .arg(it->attempt)
-                                .arg(PROBE_ATTEMPTS)
-                                .arg(PROBE_BURST));
+                                .arg(PROBE_ATTEMPTS));
         emit pingProbeRetrying(it->targetUserId, it->attempt, PROBE_ATTEMPTS);
         ++it;
     }
@@ -1186,28 +1380,7 @@ void LobbyClient::handleMatchBegin(const QJsonObject& data)
         p.publicPort = static_cast<quint16>(o.value("publicPort").toInt());
         p.localIp    = o.value("localIp").toString();
         p.slot       = o.value("slot").toInt();
-
-        // Ping-proven route beats the server's directory entry. For a CGNAT
-        // peer the advertised endpoint is unreachable from here and the route
-        // their probes arrive from is the only one that works — splice it in
-        // before anything downstream (punch, prematch sync, GekkoNet) sees the
-        // peer list, so the whole match rides the route the pings proved.
-        const QString learned = freshLearnedRoute(p.userId);
-        QHostAddress learnedAddr; quint16 learnedPort = 0;
-        if (!learned.isEmpty() && parseEndpoint(learned, learnedAddr, learnedPort))
-        {
-            const QString advertised = QStringLiteral("%1:%2").arg(p.publicIp).arg(p.publicPort);
-            if (learned != advertised)
-            {
-                qInfo() << "Rollback lobby using learned route for" << p.username
-                        << learned << "over advertised" << advertised;
-                writePingDiagnostic(QStringLiteral("MATCH_ROUTE"),
-                                    QStringLiteral("peer=%1 learned=%2 advertised=%3")
-                                        .arg(pingUserLabel(p.userId), learned, advertised));
-                p.publicIp   = learnedAddr.toString();
-                p.publicPort = learnedPort;
-            }
-        }
+        p.iceSupported = o.value("iceSupported").toBool();
         peers.append(p);
     }
     emit matchBegin(matchId, peers);
@@ -1541,6 +1714,222 @@ void LobbyClient::punchPeerEndpoints(const QList<LobbyMatchPeer>& peers)
 bool LobbyClient::syncPrematchManifest(const QList<LobbyMatchPeer>& peers, int localSlot,
                                        quint64 hostUserId, const QString& romFile, QString& error)
 {
+    error.clear();
+    if (m_selfUserId == 0 || localSlot < 1)
+    {
+        error = "Pre-match sync failed: missing local identity";
+        return false;
+    }
+    if (romFile.isEmpty())
+    {
+        error = "Pre-match sync failed: local ROM path was not resolved";
+        return false;
+    }
+    if (!allIcePeersConnected(peers, &error))
+    {
+        error = QStringLiteral("Pre-match sync failed: %1").arg(error);
+        return false;
+    }
+
+    LobbyMatchPeer local{};
+    LobbyMatchPeer host{};
+    bool foundLocal = false;
+    bool foundHost = false;
+    const bool haveHostId = (hostUserId != 0);
+    for (const LobbyMatchPeer& peer : peers)
+    {
+        if (peer.userId == m_selfUserId)
+        {
+            local = peer;
+            foundLocal = true;
+        }
+        if (haveHostId ? (peer.userId == hostUserId) : (peer.slot == 1))
+        {
+            host = peer;
+            foundHost = true;
+        }
+    }
+    if (!foundLocal || !foundHost)
+    {
+        error = "Pre-match sync failed: incomplete peer list";
+        return false;
+    }
+
+    constexpr qint64 kPrematchSyncTimeoutMs = 10'000;
+    LobbyIce::take_packets(LobbyIceChannel::Prematch);
+
+    if (host.userId == m_selfUserId)
+    {
+        std::string manifest;
+        uint64_t manifestHash = 0;
+        size_t cheatCount = 0;
+        if (!buildPrematchManifest(romFile, manifest, manifestHash, cheatCount))
+        {
+            error = QString::fromStdString(CoreGetError().empty()
+                ? std::string("Pre-match sync failed: could not build manifest") : CoreGetError());
+            return false;
+        }
+
+        const QByteArray packet = buildPrematchPacket(
+            ANCHOR_OP_PREMATCH_MANIFEST, m_selfUserId, manifestHash, manifest);
+        const QList<QByteArray> outboundPackets = fragmentPrematchPacket(
+            packet, m_selfUserId, manifestHash);
+        if (outboundPackets.isEmpty())
+        {
+            error = QStringLiteral("Pre-match sync failed: settings manifest is too large.");
+            return false;
+        }
+        QSet<quint64> pendingAcks;
+        for (const LobbyMatchPeer& peer : peers)
+        {
+            if (peer.userId != m_selfUserId)
+                pendingAcks.insert(peer.userId);
+        }
+
+        const qint64 deadlineMs = QDateTime::currentMSecsSinceEpoch() + kPrematchSyncTimeoutMs;
+        qint64 nextSendMs = 0;
+        while (!pendingAcks.isEmpty())
+        {
+            const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+            if (nowMs > deadlineMs)
+            {
+                error = QStringLiteral("Pre-match sync timed out — a player's direct ICE connection stopped responding.");
+                return false;
+            }
+            if (nowMs >= nextSendMs)
+            {
+                for (quint64 userId : std::as_const(pendingAcks))
+                {
+                    for (const QByteArray& outbound : outboundPackets)
+                        LobbyIce::send(userId, LobbyIceChannel::Prematch,
+                                       outbound.constData(), size_t(outbound.size()));
+                }
+                nextSendMs = nowMs + 100;
+            }
+
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+            for (const LobbyIcePacket& icePacket : LobbyIce::take_packets(LobbyIceChannel::Prematch))
+            {
+                const QByteArray datagram(icePacket.data.data(), int(icePacket.data.size()));
+                if (datagram.size() < 5 || std::memcmp(datagram.constData(), ANCHOR_MAGIC, 4) != 0 ||
+                    static_cast<quint8>(datagram.at(4)) != ANCHOR_OP_PREMATCH_ACK)
+                    continue;
+                quint64 senderUserId = 0;
+                uint64_t ackHash = 0;
+                if (readPrematchSenderAndHash(datagram, senderUserId, ackHash) &&
+                    senderUserId == icePacket.peerUserId && ackHash == manifestHash)
+                    pendingAcks.remove(senderUserId);
+            }
+            QThread::msleep(10);
+        }
+
+        if (!applyPrematchManifest(manifest, manifestHash, cheatCount))
+        {
+            error = QString::fromStdString(CoreGetError());
+            return false;
+        }
+        qInfo() << "Rollback lobby ICE prematch host complete"
+                << "hash" << static_cast<qulonglong>(manifestHash)
+                << "cheats" << static_cast<qulonglong>(cheatCount);
+        return true;
+    }
+
+    const qint64 deadlineMs = QDateTime::currentMSecsSinceEpoch() + kPrematchSyncTimeoutMs;
+    uint64_t fragmentHash = 0;
+    int fragmentCount = 0;
+    quint32 fragmentTotalBytes = 0;
+    QList<QByteArray> fragmentParts;
+    while (QDateTime::currentMSecsSinceEpoch() <= deadlineMs)
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        for (const LobbyIcePacket& icePacket : LobbyIce::take_packets(LobbyIceChannel::Prematch))
+        {
+            if (icePacket.peerUserId != host.userId)
+                continue;
+            QByteArray datagram(icePacket.data.data(), int(icePacket.data.size()));
+            if (datagram.size() >= 29 && std::memcmp(datagram.constData(), ANCHOR_MAGIC, 4) == 0 &&
+                static_cast<quint8>(datagram.at(4)) == ANCHOR_OP_PREMATCH_FRAGMENT)
+            {
+                quint64 senderUserId = 0;
+                uint64_t incomingHash = 0;
+                quint16 index = 0;
+                quint16 count = 0;
+                quint32 totalBytes = 0;
+                if (!readPrematchSenderAndHash(datagram, senderUserId, incomingHash) ||
+                    senderUserId != host.userId ||
+                    !readPrematchU16(datagram, 21, index) ||
+                    !readPrematchU16(datagram, 23, count) ||
+                    !readPrematchU32(datagram, 25, totalBytes) ||
+                    count == 0 || count > 2048 || index >= count ||
+                    totalBytes == 0 || totalBytes > 2 * 1024 * 1024)
+                    continue;
+                if (fragmentHash != incomingHash || fragmentCount != count ||
+                    fragmentTotalBytes != totalBytes)
+                {
+                    fragmentHash = incomingHash;
+                    fragmentCount = count;
+                    fragmentTotalBytes = totalBytes;
+                    fragmentParts.clear();
+                    fragmentParts.resize(count);
+                }
+                fragmentParts[index] = datagram.mid(29);
+                bool complete = true;
+                for (const QByteArray& part : std::as_const(fragmentParts))
+                    complete = complete && !part.isEmpty();
+                if (!complete)
+                    continue;
+                datagram.clear();
+                datagram.reserve(int(fragmentTotalBytes));
+                for (const QByteArray& part : std::as_const(fragmentParts))
+                    datagram.append(part);
+                if (datagram.size() != int(fragmentTotalBytes))
+                    continue;
+            }
+            if (datagram.size() < 5 || std::memcmp(datagram.constData(), ANCHOR_MAGIC, 4) != 0 ||
+                static_cast<quint8>(datagram.at(4)) != ANCHOR_OP_PREMATCH_MANIFEST)
+                continue;
+
+            quint64 senderUserId = 0;
+            uint64_t manifestHash = 0;
+            if (!readPrematchSenderAndHash(datagram, senderUserId, manifestHash) ||
+                senderUserId != host.userId)
+                continue;
+            if (fragmentHash != 0 && manifestHash != fragmentHash)
+                continue;
+            const int manifestOffset = 4 + 1 + 8 + 8;
+            const std::string manifest(datagram.constData() + manifestOffset,
+                                       datagram.constData() + datagram.size());
+            if (prematchHashBytes(manifest) != manifestHash)
+            {
+                error = QStringLiteral("Pre-match sync failed: settings manifest was corrupted in transit.");
+                return false;
+            }
+            size_t cheatCount = 0;
+            if (!applyPrematchManifest(manifest, manifestHash, cheatCount))
+            {
+                error = QString::fromStdString(CoreGetError());
+                return false;
+            }
+
+            const QByteArray ack = buildPrematchPacket(
+                ANCHOR_OP_PREMATCH_ACK, m_selfUserId, manifestHash);
+            for (int i = 0; i < 8; ++i)
+            {
+                LobbyIce::send(host.userId, LobbyIceChannel::Prematch,
+                               ack.constData(), size_t(ack.size()));
+            }
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+            qInfo() << "Rollback lobby ICE prematch client complete"
+                    << "hash" << static_cast<qulonglong>(manifestHash)
+                    << "cheats" << static_cast<qulonglong>(cheatCount);
+            return true;
+        }
+        QThread::msleep(10);
+    }
+    error = QStringLiteral("Pre-match sync timed out — never heard from the host over ICE.");
+    return false;
+
+#if 0 // Retained temporarily for protocol archaeology; the rollback lobby uses ICE above.
     struct PrematchSyncGuard
     {
         LobbyClient& client;
@@ -1753,6 +2142,7 @@ bool LobbyClient::syncPrematchManifest(const QList<LobbyMatchPeer>& peers, int l
             return true;
         }
     }
+#endif
 }
 
 quint16 LobbyClient::localUdpPort() const
@@ -2018,6 +2408,32 @@ int LobbyClient::measuredPingMs(quint64 userId) const
     return it == m_measuredPing.constEnd() ? -1 : it.value();
 }
 
+bool LobbyClient::allIcePeersConnected(const QList<LobbyMatchPeer>& peers, QString* error) const
+{
+    for (const LobbyMatchPeer& peer : peers)
+    {
+        if (peer.userId == m_selfUserId)
+            continue;
+        if (!peer.iceSupported)
+        {
+            if (error)
+                *error = QStringLiteral("%1 is using a lobby client without ICE support.")
+                             .arg(peer.username.isEmpty() ? QString::number(peer.userId) : peer.username);
+            return false;
+        }
+        if (!LobbyIce::peer_connected(peer.userId))
+        {
+            if (error)
+                *error = QStringLiteral("Waiting for a direct ICE connection to %1.")
+                             .arg(peer.username.isEmpty() ? QString::number(peer.userId) : peer.username);
+            return false;
+        }
+    }
+    if (error)
+        error->clear();
+    return true;
+}
+
 // -------- Chat API --------
 
 void LobbyClient::sendChat(const QString& channel, const QString& message)
@@ -2155,20 +2571,29 @@ void LobbyClient::swapSeats(int slotA, int slotB)
 
 void LobbyClient::requestPingProbe(quint64 targetUserId)
 {
-    // While a match borrows the socket the probe could never complete
-    // (GekkoNet's filter eats the echo), so don't even ask the server —
-    // otherwise every tick spends a round-trip to arrive at a skip. The
-    // ANCHOR_LENT/ANCHOR_RECLAIMED pair already brackets the quiet stretch
-    // in the diagnostic log.
-    if (m_anchorLent)
+    if (targetUserId == 0 || targetUserId == m_selfUserId ||
+        !LobbyIce::peer_connected(targetUserId))
         return;
-    QJsonObject d;
-    d["targetUserId"] = QJsonValue(qint64(targetUserId));
-    sendEnvelope("PING_PROBE_REQUEST", d);
-    // A request with no matching PROBE_REPLY_RECV after it means the server
-    // dropped us on its flood budget.
+    for (auto it = m_pendingProbes.cbegin(); it != m_pendingProbes.cend(); ++it)
+    {
+        if (it->targetUserId == targetUserId)
+            return;
+    }
+
+    quint64 nonce = QRandomGenerator::global()->generate64();
+    while (nonce == 0 || m_pendingProbes.contains(nonce))
+        nonce = QRandomGenerator::global()->generate64();
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    ProbeInFlight probe;
+    probe.targetUserId = targetUserId;
+    probe.sendMs = nowMs;
+    probe.attemptSendMs = nowMs;
+    probe.nextAttemptMs = nowMs + PROBE_RETRY_INTERVAL_MS;
+    m_pendingProbes.insert(nonce, probe);
+    sendIcePing(targetUserId, nonce, false);
     writePingDiagnostic(QStringLiteral("PROBE_REQUEST"),
-                        QStringLiteral("peer=%1").arg(pingUserLabel(targetUserId)));
+                        QStringLiteral("peer=%1 transport=ice nonce=%2")
+                            .arg(pingUserLabel(targetUserId)).arg(nonce));
 }
 
 void LobbyClient::reportMatchConnected(quint64 matchId, quint64 peerUserId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -824,7 +824,8 @@ void LobbyClient::handleHelloOk(const QJsonObject& data)
 void LobbyClient::handleHelloFail(const QJsonObject& data)
 {
     const QString reason = data.value("reason").toString();
-    emit helloFailed(reason);
+    const QString message = data.value("message").toString();
+    emit helloFailed(message.isEmpty() ? reason : message);
     setState(ConnectionState::Failed);
     if (m_ws)
         m_ws->close();
@@ -2760,18 +2761,12 @@ void LobbyClient::startRoom()
     sendEnvelope("ROOM_START");
 }
 
-// Prediction and pacing remain authoritative room parameters. Delay is included
-// for compatibility with older clients, but current clients apply their own
-// local selection and ignore the echoed room delay.
-void LobbyClient::updateRoomSettings(int delay, int prediction, int pacing, bool delayAuto, bool predictionAuto)
+void LobbyClient::updateLocalFrameDelay(int delay, bool delayAuto)
 {
     QJsonObject d;
-    d["delay"]          = delay;
-    d["prediction"]     = prediction;
-    d["pacing"]         = pacing;
-    d["delayAuto"]      = delayAuto;
-    d["predictionAuto"] = predictionAuto;
-    sendEnvelope("ROOM_UPDATE_SETTINGS", d);
+    d["delay"] = delay;
+    d["delayAuto"] = delayAuto;
+    sendEnvelope("ROOM_UPDATE_DELAY", d);
 }
 
 void LobbyClient::kickFromRoom(quint64 userId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -999,6 +999,7 @@ void LobbyClient::flushIceEvents()
                             QStringLiteral("peer=%1 state=%2 selected=%3")
                                 .arg(pingUserLabel(userId)).arg(state)
                                 .arg(QString::fromStdString(LobbyIce::peer_selected_addresses(userId))));
+        emit icePeerConnectionChanged(userId, LobbyIce::peer_connected(userId));
     }
 }
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -2760,10 +2760,9 @@ void LobbyClient::startRoom()
     sendEnvelope("ROOM_START");
 }
 
-// Host-only: change the active room's rollback parameters. The server's
-// ROOM_UPDATE_SETTINGS handler validates (host, state == "waiting"), clamps,
-// and rebroadcasts ROOM_STATE with the new values + auto flags so every seated
-// client picks them up and the match starts on the resolved delay.
+// Prediction and pacing remain authoritative room parameters. Delay is included
+// for compatibility with older clients, but current clients apply their own
+// local selection and ignore the echoed room delay.
 void LobbyClient::updateRoomSettings(int delay, int prediction, int pacing, bool delayAuto, bool predictionAuto)
 {
     QJsonObject d;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -1164,7 +1164,8 @@ void LobbyClient::flushIceEvents()
                                 .arg(pingUserLabel(userId)).arg(state).arg(iceStateName(state))
                                 .arg(QString::fromStdString(LobbyIce::peer_selected_addresses(userId))));
         const bool connected = LobbyIce::peer_connected(userId);
-        emit icePeerConnectionChanged(userId, connected);
+        const bool failed = state == static_cast<int>(LobbyIcePeerState::Failed);
+        emit icePeerConnectionChanged(userId, connected, failed);
         if (connected && userId == m_currentIceHostUserId)
         {
             // A peer-to-peer measurement may have completed before our host

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -930,10 +930,10 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
                                    data.value("value").toString().toStdString());
 }
 
-void LobbyClient::sendIcePing(quint64 userId, quint64 nonce, bool reply)
+void LobbyClient::sendIcePing(quint64 userId, quint64 nonce)
 {
     QByteArray payload(1 + int(sizeof(quint64)), Qt::Uninitialized);
-    payload[0] = reply ? char(2) : char(1);
+    payload[0] = char(1);
     const quint64 nonceBE = qToBigEndian(nonce);
     std::memcpy(payload.data() + 1, &nonceBE, sizeof(nonceBE));
     LobbyIce::send(userId, LobbyIceChannel::Ping, payload.constData(), size_t(payload.size()));
@@ -964,7 +964,10 @@ void LobbyClient::flushIceEvents()
         const quint64 nonce = qFromBigEndian(nonceBE);
         if (packet.data[0] == 1)
         {
-            sendIcePing(packet.peerUserId, nonce, true);
+            std::vector<char> reply = packet.data;
+            reply[0] = 2;
+            LobbyIce::send(packet.peerUserId, LobbyIceChannel::Ping,
+                           reply.data(), reply.size());
             continue;
         }
         if (packet.data[0] != 2)
@@ -972,13 +975,17 @@ void LobbyClient::flushIceEvents()
         const auto it = m_pendingProbes.find(nonce);
         if (it == m_pendingProbes.end() || it->targetUserId != packet.peerUserId)
             continue;
-        const int rttMs = int(std::clamp<qint64>(
-            QDateTime::currentMSecsSinceEpoch() - it->attemptSendMs, 0, 65535));
+        const qint64 rttUs = packet.roundTripUs == 0 ? -1 : qint64(packet.roundTripUs);
+        const int rttMs = rttUs >= 0
+            ? int(std::clamp<qint64>((rttUs + 500) / 1000, 0, 65535))
+            : int(std::clamp<qint64>(
+                  QDateTime::currentMSecsSinceEpoch() - it->attemptSendMs, 0, 65535));
         m_pendingProbes.erase(it);
         m_probeFailStreak[packet.peerUserId] = 0;
         m_measuredPing[packet.peerUserId] = rttMs;
         writePingDiagnostic(QStringLiteral("ICE_PING_REPLY"),
-                            QStringLiteral("peer=%1 rtt_ms=%2").arg(pingUserLabel(packet.peerUserId)).arg(rttMs));
+                            QStringLiteral("peer=%1 rtt_ms=%2 rtt_us=%3")
+                                .arg(pingUserLabel(packet.peerUserId)).arg(rttMs).arg(rttUs));
         emit pingProbeMeasured(packet.peerUserId, rttMs);
     }
 
@@ -1299,7 +1306,7 @@ void LobbyClient::onProbeRetryTimer()
         it->attempt      += 1;
         it->attemptSendMs = nowMs;
         it->nextAttemptMs = nowMs + PROBE_RETRY_INTERVAL_MS;
-        sendIcePing(it->targetUserId, it.key(), false);
+        sendIcePing(it->targetUserId, it.key());
         writePingDiagnostic(QStringLiteral("PROBE_RETRY"),
                             QStringLiteral("peer=%1 transport=ice nonce=%2 attempt=%3/%4")
                                 .arg(pingUserLabel(it->targetUserId))
@@ -2590,7 +2597,7 @@ void LobbyClient::requestPingProbe(quint64 targetUserId)
     probe.attemptSendMs = nowMs;
     probe.nextAttemptMs = nowMs + PROBE_RETRY_INTERVAL_MS;
     m_pendingProbes.insert(nonce, probe);
-    sendIcePing(targetUserId, nonce, false);
+    sendIcePing(targetUserId, nonce);
     writePingDiagnostic(QStringLiteral("PROBE_REQUEST"),
                         QStringLiteral("peer=%1 transport=ice nonce=%2")
                             .arg(pingUserLabel(targetUserId)).arg(nonce));

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -48,6 +48,7 @@
 #include <QEvent>
 #include <QFile>
 #include <QDir>
+#include <QRegularExpression>
 #include <cstring>
 #include <algorithm>
 #include <filesystem>
@@ -110,6 +111,46 @@ namespace
     constexpr quint8 ICE_PING_OP_REPORT  = 3;
     constexpr int ICE_PING_PACKET_SIZE = 1 + int(sizeof(quint64));
     constexpr int ICE_PING_REPORT_SIZE = 1 + int(sizeof(quint64)) + int(sizeof(quint16));
+
+    QString iceStateName(int state)
+    {
+        switch (static_cast<LobbyIcePeerState>(state))
+        {
+        case LobbyIcePeerState::Disconnected: return QStringLiteral("disconnected");
+        case LobbyIcePeerState::Gathering: return QStringLiteral("gathering");
+        case LobbyIcePeerState::Connecting: return QStringLiteral("connecting");
+        case LobbyIcePeerState::Connected: return QStringLiteral("connected");
+        case LobbyIcePeerState::Completed: return QStringLiteral("completed");
+        case LobbyIcePeerState::Failed: return QStringLiteral("failed");
+        }
+        return QStringLiteral("unknown");
+    }
+
+    QString iceSignalSummary(const QString& kind, const QString& value)
+    {
+        if (kind == QStringLiteral("candidate"))
+            return QStringLiteral("candidate=%1").arg(value.trimmed());
+        if (kind == QStringLiteral("description"))
+        {
+            const int candidates = value.count(QStringLiteral("candidate:"), Qt::CaseInsensitive);
+            return QStringLiteral("bytes=%1 embedded_candidates=%2 credentials=<redacted>")
+                .arg(value.toUtf8().size()).arg(candidates);
+        }
+        if (kind == QStringLiteral("gathering_done"))
+            return QStringLiteral("complete=true");
+        return QStringLiteral("bytes=%1").arg(value.toUtf8().size());
+    }
+
+    QString redactLibjuiceMessage(QString message)
+    {
+        // DEBUG messages can contain short-lived ICE credentials. They are not
+        // useful for diagnosis and should not survive in a shareable log.
+        static const QRegularExpression secret(
+            QStringLiteral(R"((ufrag|pwd|password|username|expected|actual)=\"[^\"]*\")"),
+            QRegularExpression::CaseInsensitiveOption);
+        message.replace(secret, QStringLiteral("\\1=\"<redacted>\""));
+        return message;
+    }
 
     // How long a learned route stays trusted without fresh inbound traffic.
     // Seated peers refresh it every ~3s via the seat probe loop; 60s tolerates
@@ -731,6 +772,8 @@ void LobbyClient::handleHelloOk(const QJsonObject& data)
         if (!server.host.empty() && server.port != 0)
             turnServers.push_back(std::move(server));
     }
+    const bool iceDiagnostics = CoreSettingsGetBoolValue(SettingsID::Rollback_PingDiagnostics);
+    LobbyIce::set_diagnostics_enabled(iceDiagnostics);
     if (!LobbyIce::configure(m_selfUserId, stunHost, stunPort, turnServers))
     {
         emit connectError(QStringLiteral("Failed to initialize ICE transport."));
@@ -758,6 +801,19 @@ void LobbyClient::handleHelloOk(const QJsonObject& data)
                         QStringLiteral("observed_ip=%1 region=%2 anchor=%3:%4")
                             .arg(m_observedIp, m_region, m_udpAnchorHost)
                             .arg(m_udpAnchorPort));
+    QStringList turnEndpoints;
+    for (const LobbyIceTurnServer& server : turnServers)
+    {
+        turnEndpoints.append(QStringLiteral("%1:%2")
+                                 .arg(QString::fromStdString(server.host))
+                                 .arg(server.port));
+    }
+    writePingDiagnostic(QStringLiteral("ICE_CONFIG"),
+                        QStringLiteral("stun=%1:%2 turn_count=%3 turn=%4 libjuice_level=debug")
+                            .arg(QString::fromStdString(stunHost)).arg(stunPort)
+                            .arg(static_cast<qulonglong>(turnServers.size()))
+                            .arg(turnEndpoints.isEmpty() ? QStringLiteral("<none>")
+                                                         : turnEndpoints.join(QLatin1Char(','))));
 
     setState(ConnectionState::Connected);
     m_heartbeatTimer->start();
@@ -901,17 +957,30 @@ void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
             continue;
         }
         desired.insert(userId);
-        if (!m_icePeerIds.contains(userId) && LobbyIce::add_peer(userId))
+        if (!m_icePeerIds.contains(userId))
         {
-            m_icePeerIds.insert(userId);
-            writePingDiagnostic(QStringLiteral("ICE_PEER_ADDED"),
-                                QStringLiteral("peer=%1 room=%2").arg(pingUserLabel(userId)).arg(roomId));
+            if (LobbyIce::add_peer(userId))
+            {
+                m_icePeerIds.insert(userId);
+                writePingDiagnostic(QStringLiteral("ICE_PEER_ADDED"),
+                                    QStringLiteral("peer=%1 room=%2")
+                                        .arg(pingUserLabel(userId)).arg(roomId));
+            }
+            else
+            {
+                writePingDiagnostic(QStringLiteral("ICE_PEER_ADD_FAILED"),
+                                    QStringLiteral("peer=%1 room=%2")
+                                        .arg(pingUserLabel(userId)).arg(roomId));
+            }
         }
     }
 
     const QSet<quint64> stale = m_icePeerIds - desired;
     for (quint64 userId : stale)
     {
+        writePingDiagnostic(QStringLiteral("ICE_PEER_REMOVED"),
+                            QStringLiteral("peer=%1 room=%2 reason=not_in_room_state")
+                                .arg(pingUserLabel(userId)).arg(roomId));
         LobbyIce::remove_peer(userId);
         m_icePeerIds.remove(userId);
         m_lastIceStates.remove(userId);
@@ -940,9 +1009,22 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
     const QString kind = data.value("kind").toString();
     if (roomId == 0 || roomId != m_currentIceRoomId || fromUserId == 0 ||
         fromUserId == m_selfUserId)
+    {
+        writePingDiagnostic(QStringLiteral("ICE_SIGNAL_IN_DROPPED"),
+                            QStringLiteral("from_user=%1 signal_room=%2 current_room=%3 kind=%4 reason=scope_validation")
+                                .arg(fromUserId).arg(roomId).arg(m_currentIceRoomId).arg(kind));
         return;
-    LobbyIce::handle_remote_signal(fromUserId, kind.toStdString(),
-                                   data.value("value").toString().toStdString());
+    }
+    const QString value = data.value("value").toString();
+    const bool hadPeer = LobbyIce::has_peer(fromUserId);
+    const bool accepted = LobbyIce::handle_remote_signal(fromUserId, kind.toStdString(),
+                                                         value.toStdString());
+    writePingDiagnostic(QStringLiteral("ICE_SIGNAL_IN"),
+                        QStringLiteral("peer=%1 room=%2 kind=%3 disposition=%4 accepted=%5 %6")
+                            .arg(pingUserLabel(fromUserId)).arg(roomId).arg(kind)
+                            .arg(hadPeer ? QStringLiteral("applied") : QStringLiteral("queued"))
+                            .arg(accepted ? QStringLiteral("true") : QStringLiteral("false"))
+                            .arg(iceSignalSummary(kind, value)));
 }
 
 void LobbyClient::sendIcePing(quint64 userId, quint64 nonce)
@@ -978,6 +1060,15 @@ void LobbyClient::sendRoomPingReport(quint64 targetUserId, int rttMs)
 
 void LobbyClient::flushIceEvents()
 {
+    for (LobbyIceDiagnostic& diagnostic : LobbyIce::take_diagnostics())
+    {
+        writePingDiagnostic(QStringLiteral("LIBJUICE"),
+                            QStringLiteral("level=%1 message=%2")
+                                .arg(QString::fromStdString(diagnostic.level),
+                                     redactLibjuiceMessage(
+                                         QString::fromStdString(diagnostic.message))));
+    }
+
     if (m_ws && m_ws->state() == QAbstractSocket::ConnectedState && m_currentIceRoomId != 0)
     {
         for (LobbyIceSignal& signal : LobbyIce::take_local_signals())
@@ -988,6 +1079,13 @@ void LobbyClient::flushIceEvents()
             data["kind"] = QString::fromStdString(signal.kind);
             if (!signal.value.empty())
                 data["value"] = QString::fromStdString(signal.value);
+            const QString kind = QString::fromStdString(signal.kind);
+            const QString value = QString::fromStdString(signal.value);
+            writePingDiagnostic(QStringLiteral("ICE_SIGNAL_OUT"),
+                                QStringLiteral("peer=%1 room=%2 kind=%3 %4")
+                                    .arg(pingUserLabel(signal.peerUserId))
+                                    .arg(m_currentIceRoomId).arg(kind)
+                                    .arg(iceSignalSummary(kind, value)));
             sendEnvelope("ICE_SIGNAL", data);
         }
     }
@@ -1062,8 +1160,8 @@ void LobbyClient::flushIceEvents()
             continue;
         m_lastIceStates[userId] = state;
         writePingDiagnostic(QStringLiteral("ICE_STATE"),
-                            QStringLiteral("peer=%1 state=%2 selected=%3")
-                                .arg(pingUserLabel(userId)).arg(state)
+                            QStringLiteral("peer=%1 state=%2 state_name=%3 selected=%4")
+                                .arg(pingUserLabel(userId)).arg(state).arg(iceStateName(state))
                                 .arg(QString::fromStdString(LobbyIce::peer_selected_addresses(userId))));
         const bool connected = LobbyIce::peer_connected(userId);
         emit icePeerConnectionChanged(userId, connected);

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -105,6 +105,12 @@ namespace
     // outlive the echoes of one burst.
     constexpr int PROBE_MATCHED_NONCE_CAP = 64;
 
+    constexpr quint8 ICE_PING_OP_REQUEST = 1;
+    constexpr quint8 ICE_PING_OP_REPLY   = 2;
+    constexpr quint8 ICE_PING_OP_REPORT  = 3;
+    constexpr int ICE_PING_PACKET_SIZE = 1 + int(sizeof(quint64));
+    constexpr int ICE_PING_REPORT_SIZE = 1 + int(sizeof(quint64)) + int(sizeof(quint16));
+
     // How long a learned route stays trusted without fresh inbound traffic.
     // Seated peers refresh it every ~3s via the seat probe loop; 60s tolerates
     // a couple of missed cycles without trusting a mapping the peer's NAT has
@@ -877,6 +883,10 @@ void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
     if (m_currentIceRoomId != 0 && m_currentIceRoomId != roomId)
         resetIceMesh();
     m_currentIceRoomId = roomId;
+    const quint64 hostUserId = static_cast<quint64>(roomState.value("hostId").toDouble());
+    if (m_currentIceHostUserId != 0 && m_currentIceHostUserId != hostUserId)
+        m_roomPeerPings.clear();
+    m_currentIceHostUserId = hostUserId;
 
     QSet<quint64> desired;
     for (const QJsonValue& value : roomState.value("players").toArray())
@@ -905,6 +915,9 @@ void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
         LobbyIce::remove_peer(userId);
         m_icePeerIds.remove(userId);
         m_lastIceStates.remove(userId);
+        m_roomPeerPings.remove(userId);
+        for (auto it = m_roomPeerPings.begin(); it != m_roomPeerPings.end(); ++it)
+            it.value().remove(userId);
     }
 }
 
@@ -915,6 +928,8 @@ void LobbyClient::resetIceMesh()
     m_icePeerIds.clear();
     m_lastIceStates.clear();
     m_currentIceRoomId = 0;
+    m_currentIceHostUserId = 0;
+    m_roomPeerPings.clear();
     m_pendingProbes.clear();
 }
 
@@ -932,11 +947,33 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
 
 void LobbyClient::sendIcePing(quint64 userId, quint64 nonce)
 {
-    QByteArray payload(1 + int(sizeof(quint64)), Qt::Uninitialized);
-    payload[0] = char(1);
+    QByteArray payload(ICE_PING_PACKET_SIZE, Qt::Uninitialized);
+    payload[0] = char(ICE_PING_OP_REQUEST);
     const quint64 nonceBE = qToBigEndian(nonce);
     std::memcpy(payload.data() + 1, &nonceBE, sizeof(nonceBE));
     LobbyIce::send(userId, LobbyIceChannel::Ping, payload.constData(), size_t(payload.size()));
+}
+
+void LobbyClient::sendRoomPingReport(quint64 targetUserId, int rttMs)
+{
+    // The host already measures all of its own paths. For every non-host pair,
+    // the lower user id is the sole reporter, which makes one sample sufficient
+    // and avoids two clients racing to overwrite the same unordered path.
+    if (m_currentIceHostUserId == 0 || m_currentIceHostUserId == m_selfUserId ||
+        targetUserId == 0 || targetUserId == m_currentIceHostUserId ||
+        m_selfUserId >= targetUserId || !m_icePeerIds.contains(targetUserId))
+    {
+        return;
+    }
+
+    QByteArray payload(ICE_PING_REPORT_SIZE, Qt::Uninitialized);
+    payload[0] = char(ICE_PING_OP_REPORT);
+    const quint64 targetBE = qToBigEndian(targetUserId);
+    const quint16 rttBE = qToBigEndian(static_cast<quint16>(std::clamp(rttMs, 0, 65535)));
+    std::memcpy(payload.data() + 1, &targetBE, sizeof(targetBE));
+    std::memcpy(payload.data() + 1 + sizeof(targetBE), &rttBE, sizeof(rttBE));
+    LobbyIce::send(m_currentIceHostUserId, LobbyIceChannel::Ping,
+                   payload.constData(), size_t(payload.size()));
 }
 
 void LobbyClient::flushIceEvents()
@@ -957,20 +994,48 @@ void LobbyClient::flushIceEvents()
 
     for (const LobbyIcePacket& packet : LobbyIce::take_packets(LobbyIceChannel::Ping))
     {
-        if (packet.data.size() != 1 + sizeof(quint64))
+        if (packet.data.size() == ICE_PING_REPORT_SIZE &&
+            static_cast<quint8>(packet.data[0]) == ICE_PING_OP_REPORT)
+        {
+            quint64 targetBE = 0;
+            quint16 rttBE = 0;
+            std::memcpy(&targetBE, packet.data.data() + 1, sizeof(targetBE));
+            std::memcpy(&rttBE, packet.data.data() + 1 + sizeof(targetBE), sizeof(rttBE));
+            const quint64 targetUserId = qFromBigEndian(targetBE);
+            const int rttMs = int(qFromBigEndian(rttBE));
+
+            // Reports are meaningful only to the room host, from the canonical
+            // lower-id reporter, and for two current non-host room members.
+            if (m_selfUserId == m_currentIceHostUserId &&
+                m_icePeerIds.contains(packet.peerUserId) &&
+                m_icePeerIds.contains(targetUserId) &&
+                packet.peerUserId < targetUserId &&
+                m_roomPeerPings[packet.peerUserId].value(targetUserId, -1) != rttMs)
+            {
+                m_roomPeerPings[packet.peerUserId][targetUserId] = rttMs;
+                writePingDiagnostic(QStringLiteral("ICE_PING_REPORT"),
+                                    QStringLiteral("path=%1<->%2 rtt_ms=%3")
+                                        .arg(pingUserLabel(packet.peerUserId))
+                                        .arg(pingUserLabel(targetUserId)).arg(rttMs));
+                emit roomPingMeasurementsChanged();
+            }
+            continue;
+        }
+
+        if (packet.data.size() != ICE_PING_PACKET_SIZE)
             continue;
         quint64 nonceBE = 0;
         std::memcpy(&nonceBE, packet.data.data() + 1, sizeof(nonceBE));
         const quint64 nonce = qFromBigEndian(nonceBE);
-        if (packet.data[0] == 1)
+        if (static_cast<quint8>(packet.data[0]) == ICE_PING_OP_REQUEST)
         {
             std::vector<char> reply = packet.data;
-            reply[0] = 2;
+            reply[0] = char(ICE_PING_OP_REPLY);
             LobbyIce::send(packet.peerUserId, LobbyIceChannel::Ping,
                            reply.data(), reply.size());
             continue;
         }
-        if (packet.data[0] != 2)
+        if (static_cast<quint8>(packet.data[0]) != ICE_PING_OP_REPLY)
             continue;
         const auto it = m_pendingProbes.find(nonce);
         if (it == m_pendingProbes.end() || it->targetUserId != packet.peerUserId)
@@ -986,6 +1051,7 @@ void LobbyClient::flushIceEvents()
         writePingDiagnostic(QStringLiteral("ICE_PING_REPLY"),
                             QStringLiteral("peer=%1 rtt_ms=%2 rtt_us=%3")
                                 .arg(pingUserLabel(packet.peerUserId)).arg(rttMs).arg(rttUs));
+        sendRoomPingReport(packet.peerUserId, rttMs);
         emit pingProbeMeasured(packet.peerUserId, rttMs);
     }
 
@@ -999,7 +1065,16 @@ void LobbyClient::flushIceEvents()
                             QStringLiteral("peer=%1 state=%2 selected=%3")
                                 .arg(pingUserLabel(userId)).arg(state)
                                 .arg(QString::fromStdString(LobbyIce::peer_selected_addresses(userId))));
-        emit icePeerConnectionChanged(userId, LobbyIce::peer_connected(userId));
+        const bool connected = LobbyIce::peer_connected(userId);
+        emit icePeerConnectionChanged(userId, connected);
+        if (connected && userId == m_currentIceHostUserId)
+        {
+            // A peer-to-peer measurement may have completed before our host
+            // path did. Send any canonical reports now instead of waiting for
+            // the next three-second probe cycle.
+            for (auto it = m_measuredPing.constBegin(); it != m_measuredPing.constEnd(); ++it)
+                sendRoomPingReport(it.key(), it.value());
+        }
     }
 }
 
@@ -2414,6 +2489,48 @@ int LobbyClient::measuredPingMs(quint64 userId) const
 {
     const auto it = m_measuredPing.constFind(userId);
     return it == m_measuredPing.constEnd() ? -1 : it.value();
+}
+
+int LobbyClient::worstRoomPingMs(const QList<quint64>& roomUserIds, bool* complete) const
+{
+    QSet<quint64> uniqueIds;
+    for (quint64 userId : roomUserIds)
+    {
+        if (userId != 0)
+            uniqueIds.insert(userId);
+    }
+    QList<quint64> userIds = uniqueIds.values();
+    std::sort(userIds.begin(), userIds.end());
+
+    bool allMeasured = userIds.size() >= 2;
+    int worst = -1;
+    for (int i = 0; i < userIds.size(); ++i)
+    {
+        for (int j = i + 1; j < userIds.size(); ++j)
+        {
+            const quint64 first = userIds[i];
+            const quint64 second = userIds[j];
+            int ping = -1;
+            if (first == m_selfUserId || second == m_selfUserId)
+            {
+                const quint64 remote = first == m_selfUserId ? second : first;
+                ping = measuredPingMs(remote);
+            }
+            else
+            {
+                ping = m_roomPeerPings.value(first).value(second, -1);
+            }
+
+            if (ping < 0)
+                allMeasured = false;
+            else
+                worst = std::max(worst, ping);
+        }
+    }
+
+    if (complete)
+        *complete = allMeasured;
+    return worst;
 }
 
 bool LobbyClient::allIcePeersConnected(const QList<LobbyMatchPeer>& peers, QString* error) const

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -162,6 +162,11 @@ public:
     // we sent comes back.
     int measuredPingMs(quint64 userId) const;
 
+    // Worst measured RTT across every unordered pair in `roomUserIds`.
+    // Host-local paths come from our probes; non-host paths are reported to
+    // the host over ICE. `complete` is true only when every pair is known.
+    int worstRoomPingMs(const QList<quint64>& roomUserIds, bool* complete = nullptr) const;
+
     // True when every remote in this match has negotiated a direct ICE path.
     // error describes unsupported clients or the first incomplete peer.
     bool allIcePeersConnected(const QList<LobbyMatchPeer>& peers, QString* error = nullptr) const;
@@ -255,6 +260,8 @@ signals:
     // Emitted whenever libjuice advances a peer's ICE state. `connected` is
     // true only while a validated direct candidate pair is usable.
     void icePeerConnectionChanged(quint64 targetUserId, bool connected);
+    // The host received a fresh RTT for a path between two other players.
+    void roomPingMeasurementsChanged();
     // A burst went unanswered and we're sending another. `attempt` is 1-based
     // and counts the one now in flight. Surfaced in the room so a slow punch
     // reads as progress rather than a hang.
@@ -325,6 +332,7 @@ private:
     void resetIceMesh();
     void flushIceEvents();
     void sendIcePing(quint64 userId, quint64 nonce);
+    void sendRoomPingReport(quint64 targetUserId, int rttMs);
     // Start a probe series to `endpoint`. Shared by the reply and incoming
     // paths. No-op if a probe to that peer is already in flight.
     void sendProbeTo(quint64 userId, const QString& endpoint);
@@ -415,8 +423,12 @@ private:
     QString m_region;
     bool    m_isModerator = false; // set once ADMIN_AUTH_OK is received
     quint64 m_currentIceRoomId = 0;
+    quint64 m_currentIceHostUserId = 0;
     QSet<quint64> m_icePeerIds;
     QHash<quint64, int> m_lastIceStates;
+    // Host-only matrix for non-host paths. To avoid duplicate reports, only
+    // the lower user id measures/reports each unordered pair.
+    QHash<quint64, QHash<quint64, int>> m_roomPeerPings;
 
     // Ping diagnostics (see startPingDiagnosticLog).
     QFile*  m_pingDiagnosticFile    = nullptr;

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -346,8 +346,8 @@ private:
     // where an aged-out series says nothing about the peer.
     void cancelPendingProbes(const QString& reason);
 
-    // Opt-in on-disk trace of the whole probe pipeline, for diagnosing peer
-    // pings that never resolve. Off unless Rollback_PingDiagnostics is set;
+    // Opt-in on-disk trace of the probe and ICE pipelines, for diagnosing peer
+    // connections that never resolve. Off unless PingDiagnostics is set;
     // read once at connect time so toggling it mid-session does nothing until
     // the next lobby connect. One file per connection, in RMG-K's Logs folder.
     void startPingDiagnosticLog();

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -252,6 +252,9 @@ signals:
 
     void pingProbeReply(quint64 targetUserId, const QString& endpoint);
     void pingProbeMeasured(quint64 targetUserId, int rttMs);
+    // Emitted whenever libjuice advances a peer's ICE state. `connected` is
+    // true only while a validated direct candidate pair is usable.
+    void icePeerConnectionChanged(quint64 targetUserId, bool connected);
     // A burst went unanswered and we're sending another. `attempt` is 1-based
     // and counts the one now in flight. Surfaced in the room so a slow punch
     // reads as progress rather than a hang.

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -258,8 +258,9 @@ signals:
     void pingProbeReply(quint64 targetUserId, const QString& endpoint);
     void pingProbeMeasured(quint64 targetUserId, int rttMs);
     // Emitted whenever libjuice advances a peer's ICE state. `connected` is
-    // true only while a validated direct candidate pair is usable.
-    void icePeerConnectionChanged(quint64 targetUserId, bool connected);
+    // true only while a validated direct candidate pair is usable; `failed`
+    // distinguishes an exhausted ICE attempt from one still in progress.
+    void icePeerConnectionChanged(quint64 targetUserId, bool connected, bool failed);
     // The host received a fresh RTT for a path between two other players.
     void roomPingMeasurementsChanged();
     // A burst went unanswered and we're sending another. `attempt` is 1-based

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -147,10 +147,9 @@ public:
     // Server validates (host, waiting, valid slots) and rebroadcasts ROOM_STATE.
     void swapSeats(int slotA, int slotB);
 
-    // Host-only shared prediction/pacing update. Delay remains on the wire as a
-    // legacy compatibility value; current clients own and apply delay locally.
-    // Concrete values are always sent (Auto/Default are represented by flags).
-    void updateRoomSettings(int delay, int prediction, int pacing, bool delayAuto, bool predictionAuto);
+    // Publish this player's resolved local input delay for the room seat display.
+    // Each player owns this independently; Auto is resolved before sending.
+    void updateLocalFrameDelay(int delay, bool delayAuto);
 
     // Ping probe over the already-selected ICE candidate pair. This measures
     // the same direct path that the rollback session will use.

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -147,10 +147,9 @@ public:
     // Server validates (host, waiting, valid slots) and rebroadcasts ROOM_STATE.
     void swapSeats(int slotA, int slotB);
 
-    // Host-only: change the room's rollback delay / prediction / pacing. The
-    // *Auto flags tell the server whether delay/prediction are host-Auto-driven
-    // so non-hosts can mirror the host's label (pacing has no Auto). Server must
-    // ack with a fresh ROOM_STATE so all seated peers stay in sync.
+    // Host-only shared prediction/pacing update. Delay remains on the wire as a
+    // legacy compatibility value; current clients own and apply delay locally.
+    // Concrete values are always sent (Auto/Default are represented by flags).
     void updateRoomSettings(int delay, int prediction, int pacing, bool delayAuto, bool predictionAuto);
 
     // Ping probe over the already-selected ICE candidate pair. This measures

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -16,6 +16,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QTimer>
+#include <QSet>
 
 class QWebSocket;
 class QUdpSocket;
@@ -94,6 +95,7 @@ public:
         quint16 publicPort = 0;
         QString localIp;
         int slot = 0;
+        bool iceSupported = false;
     };
 
     struct ChatMessage
@@ -151,16 +153,18 @@ public:
     // ack with a fresh ROOM_STATE so all seated peers stay in sync.
     void updateRoomSettings(int delay, int prediction, int pacing, bool delayAuto, bool predictionAuto);
 
-    // Ping probe — server replies with target's UDP endpoint; client probes
-    // directly. The server also introduces us to the target so they probe back
-    // at the same moment; a lone one-way probe dies at their NAT. Rate limited
-    // server-side, so callers should still avoid firing these in a loop.
+    // Ping probe over the already-selected ICE candidate pair. This measures
+    // the same direct path that the rollback session will use.
     void requestPingProbe(quint64 targetUserId);
 
     // Most recent measured round-trip to this peer in milliseconds, or -1 if
     // no PROBE_REPLY has been received from them. Updated whenever a probe
     // we sent comes back.
     int measuredPingMs(quint64 userId) const;
+
+    // True when every remote in this match has negotiated a direct ICE path.
+    // error describes unsupported clients or the first incomplete peer.
+    bool allIcePeersConnected(const QList<LobbyMatchPeer>& peers, QString* error = nullptr) const;
 
     // Quick match queue. The ROM (name + md5) scopes the search so the server
     // only pairs players queued for the same game; the name lets the matched
@@ -194,8 +198,8 @@ public:
                        const QString& duration = QString(), const QString& reason = QString());
     bool isModerator() const { return m_isModerator; }
 
-    // UDP anchor port management — exposed so the GekkoNet session can take
-    // the same local port we registered with the server (matches NAT mapping).
+    // Legacy UDP-anchor compatibility API. ICE-capable rollback-lobby matches
+    // do not call these; they remain for compatibility with older servers.
     quint16 localUdpPort() const;
     void releaseUdpAnchor();
     void reopenUdpAnchor();
@@ -313,6 +317,11 @@ private:
     void handlePingProbeReply(const QJsonObject& data);
     void handleMatchBegin(const QJsonObject& data);
     void handlePingProbeIncoming(const QJsonObject& data);
+    void handleIceSignal(const QJsonObject& data);
+    void reconcileIcePeers(const QJsonObject& roomState);
+    void resetIceMesh();
+    void flushIceEvents();
+    void sendIcePing(quint64 userId, quint64 nonce, bool reply);
     // Start a probe series to `endpoint`. Shared by the reply and incoming
     // paths. No-op if a probe to that peer is already in flight.
     void sendProbeTo(quint64 userId, const QString& endpoint);
@@ -366,6 +375,7 @@ private:
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_udpKeepaliveTimer = nullptr;
     QTimer* m_probeRetryTimer = nullptr;
+    QTimer* m_iceTimer = nullptr;
     // Retries the pinned anchor port while GekkoNet's teardown still holds it
     // (see initiateUdpAnchor). 0 deadline = no retry window active.
     QTimer* m_anchorRetryTimer = nullptr;
@@ -401,6 +411,9 @@ private:
     QString m_observedIp;
     QString m_region;
     bool    m_isModerator = false; // set once ADMIN_AUTH_OK is received
+    quint64 m_currentIceRoomId = 0;
+    QSet<quint64> m_icePeerIds;
+    QHash<quint64, int> m_lastIceStates;
 
     // Ping diagnostics (see startPingDiagnosticLog).
     QFile*  m_pingDiagnosticFile    = nullptr;
@@ -423,7 +436,7 @@ private:
     QHash<quint64, LobbyUser> m_users;
     QHash<quint64, LobbyRoomSummary> m_rooms;
 
-    // In-flight UDP PROBE state, keyed by per-request nonce. Each entry maps
+    // In-flight direct ICE ping state, keyed by per-request nonce. Each entry maps
     // a sent probe back to the target user and the wall-clock send time so
     // we can compute RTT when PROBE_REPLY comes back.
     struct ProbeInFlight

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -321,7 +321,7 @@ private:
     void reconcileIcePeers(const QJsonObject& roomState);
     void resetIceMesh();
     void flushIceEvents();
-    void sendIcePing(quint64 userId, quint64 nonce, bool reply);
+    void sendIcePing(quint64 userId, quint64 nonce);
     // Start a probe series to `endpoint`. Shared by the reply and incoming
     // paths. No-op if a probe to that peer is already in flight.
     void sendProbeTo(quint64 userId, const QString& endpoint);

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyConnectDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyConnectDialog.cpp
@@ -70,10 +70,10 @@ void LobbyConnectDialog::buildUi()
     auto* form = new QFormLayout;
 
     m_usernameEdit = new QLineEdit(this);
-    m_usernameEdit->setMaxLength(16);
-    m_usernameEdit->setPlaceholderText("3-16 characters: letters, numbers, _ - .");
+    m_usernameEdit->setMaxLength(20);
+    m_usernameEdit->setPlaceholderText("2-20 characters: letters, numbers, _ - .");
     auto* validator = new QRegularExpressionValidator(
-        QRegularExpression(R"([A-Za-z0-9_\-\.]{1,16})"), this);
+        QRegularExpression(R"([A-Za-z0-9_\-\.]{1,20})"), this);
     m_usernameEdit->setValidator(validator);
     form->addRow("Enter a username:", m_usernameEdit);
 
@@ -101,8 +101,8 @@ void LobbyConnectDialog::validateInput()
     const QString user = m_usernameEdit->text().trimmed();
 
     QString reason;
-    if (user.length() < 3)
-        reason = "Username must be at least 3 characters.";
+    if (user.length() < 2)
+        reason = "Username must be at least 2 characters.";
 
     const QString message = reason.isEmpty() ? m_statusMessage : reason;
     m_validationLbl->setStyleSheet(

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -983,7 +983,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     m_roomMetaLabel->setContentsMargins(0, SPACING_TIGHT, 0, 0);
     lay->addWidget(m_roomMetaLabel);
 
-    // ── Rollback settings row (host-editable) ──
+    // ── Rollback settings row ──
     auto* settingsRow = new QHBoxLayout;
     settingsRow->setContentsMargins(0, SPACING_TIGHT, 0, 0);
     settingsRow->setSpacing(SPACING_DEFAULT);
@@ -993,7 +993,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         "Higher delay = fewer rollbacks but more input latency.\n"
         "Recommended: 2 for ~80ms RTT, 3-4 for ~150ms RTT.\n"
         "\n"
-        "Host-only. All players will use the same value.");
+        "Local setting — each player may choose a different value.");
     const QString predictionTip = QStringLiteral(
         "Maximum frames the rollback engine may predict ahead.\n"
         "Higher prediction = more network tolerance.\n"
@@ -1017,7 +1017,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         combo->setCurrentIndex(0); // default to the auto/default entry
     };
 
-    auto* delayLbl = new QLabel("Frame delay:", this);
+    auto* delayLbl = new QLabel("Your frame delay:", this);
     m_delayCombo = new QComboBox(this);
     m_delayCombo->setObjectName("LobbyCombo");
     // Re-measure when the Auto entry grows into "Auto (2 f)" so the resolved
@@ -1093,21 +1093,26 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     lay->addLayout(toggleRow);
 
-    // Both combos share the same change handler. Skip emits while we're
-    // applying values from a ROOM_STATE refresh — otherwise we'd ping-pong
-    // a settings update back to the server on every server-driven refresh.
-    auto pushSettings = [this]() {
+    // Delay is local: changing it never asks the server for permission and
+    // never changes another player's value. The host mirrors its resolved
+    // value through the legacy room field so older clients remain compatible.
+    auto applyDelay = [this]() {
         if (m_suppressSettingsSignal) return;
         if (m_currentRoomId == 0) return;
-        if (!m_client) return;
-        // A combo's "Auto" entry has data 0; track each mode, then resolve and
-        // push the concrete values (applyHostRoomSettings never sends 0).
-        m_delayAuto      = (m_delayCombo->currentData().toInt() == 0);
+        m_delayAuto = (m_delayCombo->currentData().toInt() == 0);
+        applyLocalFrameDelay(true);
+    };
+    // Prediction is still shared room state, so only the enabled host control
+    // can send it. Its Default entry resolves to a concrete value on the wire.
+    auto pushSharedSettings = [this]() {
+        if (m_suppressSettingsSignal) return;
+        if (m_currentRoomId == 0 || !m_client) return;
         m_predictionAuto = (m_predictionCombo->currentData().toInt() == 0);
         applyHostRoomSettings(true);
     };
-    connect(m_delayCombo,      QOverload<int>::of(&QComboBox::currentIndexChanged), this, pushSettings);
-    connect(m_predictionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, pushSettings);
+    connect(m_delayCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applyDelay);
+    connect(m_predictionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, pushSharedSettings);
 
     // ── Seats — bold section header + vertical player-list rows ──
     auto* seatsHeader = new QLabel("SEATS", this);
@@ -2809,12 +2814,19 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
     m_quickMatchActive = false;
     if (m_quickMatchBtn) m_quickMatchBtn->setText("⚡  Quick Match");
 
-    // Every freshly-entered room starts in Auto delay/prediction (the in-room
-    // combos default to "Auto", and Create Room no longer surfaces these). This
-    // is what makes a Quick Match host resolve delay from the room-wide ping
-    // matrix during the warmup; the host can still switch to a manual value.
+    // Every freshly-entered room starts in Auto delay/prediction. Delay is a
+    // per-player selection, so reset this client's combo here instead of ever
+    // copying the legacy room delay from ROOM_STATE.
     m_delayAuto      = true;
     m_predictionAuto = true;
+    m_currentRoomDelay = autoFrameDelayForPing(-1);
+    if (m_delayCombo)
+    {
+        m_suppressSettingsSignal = true;
+        m_delayCombo->setCurrentIndex(m_delayCombo->findData(0));
+        setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
+        m_suppressSettingsSignal = false;
+    }
 
     // Fresh room — don't chime for the seats already present in the first
     // ROOM_STATE; only for players who join after we've settled in.
@@ -2936,12 +2948,10 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     const QString romName = rom.value("name").toString();
     const QString romMd5 = rom.value("md5").toString();
     const QString romRegion = rom.value("region").toString();
-    const int delay = roomState.value("delay").toInt();
     const int prediction = roomState.value("prediction").toInt();
     const int pacing = roomState.value("pacing").toInt() == 1 ? 1 : 0;
-    // Whether the host left each value on "Auto" — lets non-hosts mirror the
-    // host's "Auto (N f)" / "Default" labels instead of a bare number.
-    const bool roomDelayAuto = roomState.value("delayAuto").toBool();
+    // Prediction remains host-owned, so non-hosts mirror whether the host left
+    // it on Default. Delay and delayAuto are intentionally local-only.
     const bool roomPredictionAuto = roomState.value("predictionAuto").toBool();
     const int maxPlayers = roomState.value("maxPlayers").toInt();
     const QString state = roomState.value("state").toString();
@@ -2951,7 +2961,6 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     m_currentRoomGame       = romName;
     m_currentRoomMd5        = romMd5;
     m_currentRoomRegion     = romRegion;
-    m_currentRoomDelay      = delay;
     m_currentRoomPrediction = prediction;
     m_currentRoomPacing     = pacing;
     m_currentRoomHostId     = hostId;
@@ -3013,18 +3022,18 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         metaParts << QString("<b>Region:</b> %1").arg(romRegion);
     m_roomMetaLabel->setText(metaParts.join("  ·  "));
 
-    // Sync the delay / prediction combos with the authoritative room state.
-    // Suppress the currentIndexChanged signal during the assignment so the
-    // combo doesn't immediately re-send an UPDATE for the same value we
-    // just received from the server.
+    // Sync shared prediction/pacing from authoritative room state while leaving
+    // this player's delay untouched. Suppress signals so a refresh doesn't echo
+    // the same shared values back to the server.
     if (m_delayCombo && m_predictionCombo && m_pacingCombo)
     {
         static const QString tipDisabledNotHost = QStringLiteral(
-            "Only the host can change rollback settings.");
+            "Only the host can change prediction.");
         static const QString tipDisabledMidMatch = QStringLiteral(
             "Can't change settings during a match.");
 
-        const bool editable = iAmHost && state == "waiting";
+        const bool delayEditable = state == "waiting";
+        const bool sharedEditable = iAmHost && state == "waiting";
         m_suppressSettingsSignal = true;
         // Look up the index for the server-supplied value via findData
         // since the combo's index no longer maps 1:1 to the value (0/Auto is
@@ -3034,17 +3043,11 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
             const int idx = combo->findData(value);
             return idx >= 0 ? idx : 0;
         };
-        // Show the "Auto"/"Default" entry whenever the value is auto-driven, so
-        // every seat displays the same thing. The host trusts their own local
-        // m_*Auto (the server echo of the resolved number must not knock their
-        // combo off Auto); non-hosts trust the room's auto flags. When not auto,
-        // everyone shows the concrete resolved value.
-        const bool showDelayAuto = editable ? m_delayAuto : roomDelayAuto;
-        const bool showPredAuto  = editable ? m_predictionAuto : roomPredictionAuto;
-        if (showDelayAuto)
-            m_delayCombo->setCurrentIndex(m_delayCombo->findData(0));
-        else
-            m_delayCombo->setCurrentIndex(pickIndex(m_delayCombo, delay));
+        // Delay selection is never assigned here: local manual values and Auto
+        // mode must survive every ROOM_STATE broadcast. Prediction is shared;
+        // the host trusts its local Default selection until the server echo,
+        // while non-hosts render the authoritative flag.
+        const bool showPredAuto = sharedEditable ? m_predictionAuto : roomPredictionAuto;
         if (showPredAuto)
             m_predictionCombo->setCurrentIndex(m_predictionCombo->findData(0));
         else
@@ -3052,20 +3055,19 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         // Pacing is a plain 2-choice value (no Auto): mirror the room's value on
         // every seat.
         m_pacingCombo->setCurrentIndex(pickIndex(m_pacingCombo, pacing));
-        // Keep the delay "Auto" entry's label showing the live resolved value.
-        // (Prediction's "Default" entry is a plain, fixed label.)
-        setAutoComboLabel(m_delayCombo, delay);
-        m_delayCombo->setEnabled(editable);
-        m_predictionCombo->setEnabled(editable);
-        m_pacingCombo->setEnabled(editable);
+        // Keep Auto labelled with this player's resolved local value.
+        setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
+        m_delayCombo->setEnabled(delayEditable);
+        m_predictionCombo->setEnabled(sharedEditable);
+        m_pacingCombo->setEnabled(sharedEditable);
 
-        const QString delayTip = editable
+        const QString delayTip = delayEditable
             ? m_delayCombo->property("originalTip").toString()
-            : (iAmHost ? tipDisabledMidMatch : tipDisabledNotHost);
-        const QString predTip = editable
+            : tipDisabledMidMatch;
+        const QString predTip = sharedEditable
             ? m_predictionCombo->property("originalTip").toString()
             : (iAmHost ? tipDisabledMidMatch : tipDisabledNotHost);
-        const QString pacingTip = editable
+        const QString pacingTip = sharedEditable
             ? m_pacingCombo->property("originalTip").toString()
             : (iAmHost ? tipDisabledMidMatch : tipDisabledNotHost);
         m_delayCombo->setToolTip(delayTip);
@@ -3163,6 +3165,10 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     }
 
     // Start button gating (host-only): waiting, 2+ seated, every pair measured.
+    // Re-resolve local Auto after seat changes too: a join/leave can change this
+    // player's worst relevant path even before another probe result arrives.
+    if (m_delayAuto)
+        applyLocalFrameDelay(false);
     refreshStartButton();
 }
 
@@ -3393,10 +3399,8 @@ void RollbackLobbyDialog::onIcePeerConnectionChanged(quint64 userId, bool connec
 
 void RollbackLobbyDialog::onRoomPingMeasurementsChanged()
 {
-    // Only the host receives non-host path reports. A fresh report can both
-    // change Auto delay and complete the matrix required to enable Start.
-    if (m_delayAuto)
-        applyHostRoomSettings(false);
+    // Only the host receives non-host path reports. They complete the matrix
+    // required to enable Start, but no longer affect anyone's local delay.
     refreshStartButton();
 }
 
@@ -3462,10 +3466,10 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
         break;
     }
 
-    // Auto delay follows ping — re-resolve when a fresh RTT lands. The helper
-    // only acts when we're the host of a waiting room with Auto selected.
+    // Auto delay follows this player's own direct peer RTTs. Every seated client
+    // runs this path independently, so their resolved delays may differ.
     if (m_delayAuto)
-        applyHostRoomSettings(false);
+        applyLocalFrameDelay(false);
 
     // A peer's first ping may be what unblocks the host's Start button.
     refreshStartButton();
@@ -3492,51 +3496,78 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
     }
 }
 
-int RollbackLobbyDialog::worstRoomPingMs() const
+int RollbackLobbyDialog::worstLocalPeerPingMs() const
 {
     if (!m_client) return -1;
-    QList<quint64> userIds;
+    const quint64 selfId = m_client->selfUserId();
+    int worst = -1;
     for (const auto& s : m_seats)
     {
-        if (s.userId != 0)
-            userIds.append(s.userId);
+        if (s.userId == 0 || s.userId == selfId)
+            continue;
+        const int ping = m_client->measuredPingMs(s.userId);
+        if (ping >= 0)
+            worst = std::max(worst, ping);
     }
-    return m_client->worstRoomPingMs(userIds);
+    return worst;
+}
+
+void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
+{
+    if (m_currentRoomId == 0 || m_currentRoomState != "waiting" || !m_delayCombo)
+        return;
+
+    const int delay = m_delayAuto
+        ? autoFrameDelayForPing(worstLocalPeerPingMs())
+        : m_delayCombo->currentData().toInt();
+    if (m_delayAuto)
+        setAutoComboLabel(m_delayCombo, delay);
+    if (!force && delay == m_currentRoomDelay)
+        return;
+
+    m_currentRoomDelay = delay;
+
+    // Persist the concrete local value (never the Auto sentinel) as the legacy
+    // create-room seed. Auto mode itself intentionally resets for each room.
+    QSettings s("RMG-K", "n02");
+    s.beginGroup("Lobby/CreateRoom");
+    s.setValue("Delay", delay);
+    s.endGroup();
+
+    // Keep the server's legacy shared delay aligned with the host for older
+    // clients. New clients never consume it as their local value.
+    if (m_predictionCombo && m_predictionCombo->isEnabled())
+        applyHostRoomSettings(true);
 }
 
 void RollbackLobbyDialog::applyHostRoomSettings(bool force)
 {
     if (m_currentRoomId == 0 || !m_client || !m_delayCombo || !m_predictionCombo || !m_pacingCombo)
         return;
-    // The delay combo is enabled only for the host of a waiting room, so its
-    // enabled state doubles as the "I'm allowed to push settings now" gate.
-    if (!m_delayCombo->isEnabled())
+    // Prediction stays host-only. Gate on authoritative room ownership/state,
+    // not transient widget state during a ROOM_STATE refresh.
+    if (m_currentRoomState != "waiting" ||
+        m_currentRoomHostId != m_client->selfUserId())
         return;
 
-    const int effDelay = m_delayAuto
-        ? autoFrameDelayForPing(worstRoomPingMs())
-        : m_delayCombo->currentData().toInt();
     const int effPred = m_predictionAuto
         ? kAutoPredictionWindow
         : m_predictionCombo->currentData().toInt();
     const int effPacing = m_pacingCombo->currentData().toInt() == 1 ? 1 : 0;
 
-    // Delay's "Auto" entry shows the resolved value, e.g. "Auto (4 f)".
-    // Prediction's "Default" entry stays a plain label (always 7, not ping-based).
-    if (m_delayAuto) setAutoComboLabel(m_delayCombo, effDelay);
-
-    if (!force && effDelay == m_currentRoomDelay && effPred == m_currentRoomPrediction &&
+    if (!force && effPred == m_currentRoomPrediction &&
         effPacing == m_currentRoomPacing)
         return;
 
-    m_client->updateRoomSettings(effDelay, effPred, effPacing, m_delayAuto, m_predictionAuto);
+    m_client->updateRoomSettings(m_currentRoomDelay, effPred, effPacing,
+                                 m_delayAuto, m_predictionAuto);
 
     // Persist the concrete resolved values (never the Auto sentinel 0) so
     // CreateRoomDialog seeds a valid delay/prediction for the next room. Pacing
     // also rides the engine setting so a freshly created room defaults to it.
     QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
-    s.setValue("Delay",      effDelay);
+    s.setValue("Delay",      m_currentRoomDelay);
     s.setValue("Prediction", effPred);
     s.endGroup();
     CoreSettingsSetValue(SettingsID::Rollback_PacingMode, effPacing);
@@ -4141,28 +4172,25 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     appendChatSystemLine(CHANNEL_LOBBY, line);
     appendChatSystemLine(CHANNEL_ROOM,  line);
 
-    // The host announces the rollback delay the room is about to play on, so
-    // everyone sees it in chat (and on the in-game overlay) — especially useful
-    // when Auto resolved it from ping. One authoritative message, gated to the
-    // host so a 4-player match doesn't print it four times.
-    if (m_client && m_currentRoomHostId == m_client->selfUserId())
+    // Delay is local now, so show each player their own resolved value without
+    // broadcasting a misleading room-wide setting.
     {
         QString delayMsg;
         if (m_delayAuto)
         {
-            const int worst = worstRoomPingMs();
+            const int worst = worstLocalPeerPingMs();
             delayMsg = worst >= 0
-                ? QStringLiteral("Frame delay: %1 (auto, from %2 ms ping) · prediction %3")
+                ? QStringLiteral("Your frame delay: %1 (auto, from %2 ms ping) · prediction %3")
                       .arg(m_currentRoomDelay).arg(worst).arg(m_currentRoomPrediction)
-                : QStringLiteral("Frame delay: %1 (auto) · prediction %2")
+                : QStringLiteral("Your frame delay: %1 (auto) · prediction %2")
                       .arg(m_currentRoomDelay).arg(m_currentRoomPrediction);
         }
         else
         {
-            delayMsg = QStringLiteral("Frame delay: %1 · prediction %2")
+            delayMsg = QStringLiteral("Your frame delay: %1 · prediction %2")
                            .arg(m_currentRoomDelay).arg(m_currentRoomPrediction);
         }
-        m_client->sendChat(CHANNEL_ROOM, delayMsg);
+        appendChatSystemLine(CHANNEL_ROOM, delayMsg);
     }
 
     m_currentMatchId = matchId;

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -528,6 +528,8 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
     connect(m_client, &LobbyClient::matchPeerLeft,        this, &RollbackLobbyDialog::onMatchPeerLeft);
     connect(m_client, &LobbyClient::icePeerConnectionChanged,
             this, &RollbackLobbyDialog::onIcePeerConnectionChanged);
+    connect(m_client, &LobbyClient::roomPingMeasurementsChanged,
+            this, &RollbackLobbyDialog::onRoomPingMeasurementsChanged);
     connect(m_client, &LobbyClient::pingProbeMeasured,    this, &RollbackLobbyDialog::onPingMeasured);
     connect(m_client, &LobbyClient::pingProbeRetrying,    this, &RollbackLobbyDialog::onPingProbeRetrying);
     connect(m_client, &LobbyClient::pingProbeFailed,      this, &RollbackLobbyDialog::onPingProbeFailed);
@@ -2802,8 +2804,8 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
 
     // Every freshly-entered room starts in Auto delay/prediction (the in-room
     // combos default to "Auto", and Create Room no longer surfaces these). This
-    // is what makes a Quick Match host resolve delay from the measured peer ping
-    // during the warmup; the host can still switch to a manual value in-room.
+    // is what makes a Quick Match host resolve delay from the room-wide ping
+    // matrix during the warmup; the host can still switch to a manual value.
     m_delayAuto      = true;
     m_predictionAuto = true;
 
@@ -2828,9 +2830,9 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
         appendChatLine(CHANNEL_ROOM, greetingChatLine);
 
     // Backstop in case ROOM_STATE seats arrive in a shape that didn't trigger a
-    // per-peer probe — kick one sweep shortly after entry so ping shows promptly
-    // and the host's Auto delay resolves before the match begins. Harmless in an
-    // empty room: onPingProbeTick skips self / unseated slots.
+    // per-peer probe — kick one sweep shortly after entry so every client starts
+    // filling the room-wide ping matrix promptly. Harmless in an empty room:
+    // onPingProbeTick skips self / unseated slots.
     QTimer::singleShot(600, this, &RollbackLobbyDialog::onPingProbeTick);
 }
 
@@ -3153,7 +3155,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         m_roomSeatsSeen = true;
     }
 
-    // Start button gating (host-only): waiting, 2+ seated, ping from everyone.
+    // Start button gating (host-only): waiting, 2+ seated, every pair measured.
     refreshStartButton();
 }
 
@@ -3171,21 +3173,19 @@ void RollbackLobbyDialog::refreshStartButton()
     // run contiguously from P1. The core sizes the GekkoNet session by the
     // highest occupied seat and feeds empty ports zeroed input.
     int seated = 0;
-    int peersAwaitingPing = 0;
+    QList<quint64> seatedUserIds;
     for (const auto& s : m_seats)
     {
         if (s.userId == 0)
             continue;
         ++seated;
-        // We never ping ourselves; every *other* seated player needs a measured
-        // ping before the host may start, so the match opens on real latency
-        // (and the Auto frame-delay has resolved from it).
-        if (s.userId != selfId && m_client && m_client->measuredPingMs(s.userId) < 0)
-            ++peersAwaitingPing;
+        seatedUserIds.append(s.userId);
     }
 
     const bool enoughPlayers = seated >= 2;
-    const bool pingsReady    = (peersAwaitingPing == 0);
+    bool pingsReady = false;
+    if (m_client)
+        m_client->worstRoomPingMs(seatedUserIds, &pingsReady);
     const bool canStart      = iAmHost && waiting && enoughPlayers && pingsReady;
 
     m_startBtn->setEnabled(canStart);
@@ -3193,7 +3193,7 @@ void RollbackLobbyDialog::refreshStartButton()
         !iAmHost         ? QStringLiteral("Only the host can start the game.")
         : !waiting       ? QStringLiteral("Already in a match.")
         : !enoughPlayers ? QStringLiteral("Need at least 2 players to start.")
-        : !pingsReady    ? QStringLiteral("Measuring ping to all players…")
+        : !pingsReady    ? QStringLiteral("Measuring every player-to-player path…")
                          : QString());
 }
 
@@ -3379,6 +3379,15 @@ void RollbackLobbyDialog::onIcePeerConnectionChanged(quint64 userId, bool connec
         m_client->requestPingProbe(userId);
 }
 
+void RollbackLobbyDialog::onRoomPingMeasurementsChanged()
+{
+    // Only the host receives non-host path reports. A fresh report can both
+    // change Auto delay and complete the matrix required to enable Start.
+    if (m_delayAuto)
+        applyHostRoomSettings(false);
+    refreshStartButton();
+}
+
 void RollbackLobbyDialog::onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts)
 {
     // Retry progress is first-contact feedback. Once a seat has a number the
@@ -3471,19 +3480,16 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
     }
 }
 
-int RollbackLobbyDialog::worstSeatPingMs() const
+int RollbackLobbyDialog::worstRoomPingMs() const
 {
     if (!m_client) return -1;
-    const quint64 selfId = m_client->selfUserId();
-    int worst = -1;
+    QList<quint64> userIds;
     for (const auto& s : m_seats)
     {
-        if (s.userId == 0 || s.userId == selfId)
-            continue;
-        const int p = m_client->measuredPingMs(s.userId);
-        if (p > worst) worst = p; // tune against the worst host↔peer link
+        if (s.userId != 0)
+            userIds.append(s.userId);
     }
-    return worst;
+    return m_client->worstRoomPingMs(userIds);
 }
 
 void RollbackLobbyDialog::applyHostRoomSettings(bool force)
@@ -3496,7 +3502,7 @@ void RollbackLobbyDialog::applyHostRoomSettings(bool force)
         return;
 
     const int effDelay = m_delayAuto
-        ? autoFrameDelayForPing(worstSeatPingMs())
+        ? autoFrameDelayForPing(worstRoomPingMs())
         : m_delayCombo->currentData().toInt();
     const int effPred = m_predictionAuto
         ? kAutoPredictionWindow
@@ -4132,7 +4138,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
         QString delayMsg;
         if (m_delayAuto)
         {
-            const int worst = worstSeatPingMs();
+            const int worst = worstRoomPingMs();
             delayMsg = worst >= 0
                 ? QStringLiteral("Frame delay: %1 (auto, from %2 ms ping) · prediction %3")
                       .arg(m_currentRoomDelay).arg(worst).arg(m_currentRoomPrediction)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -107,8 +107,9 @@ int autoFrameDelayForPing(int ping)
     return 5;
 }
 
-// Auto prediction is a fixed value so users don't have to think about it.
-constexpr int kAutoPredictionWindow = 7;
+// Lobby prediction is deliberately not user-configurable. All current clients
+// use the same generous rollback window.
+constexpr int kLobbyPredictionWindow = 9;
 
 // Show the resolved value on the "Auto" entry, e.g. "Auto (3 f)".
 void setAutoComboLabel(QComboBox* combo, int resolved)
@@ -279,13 +280,14 @@ namespace
         return c.idle;
     }
 
-    // Right-aligned seat meta as rich text: an accent-colored HOST badge and a
-    // ping-tier-colored "N ms". Shared by renderSeatFilled and the live ping
-    // refresh in onPingMeasured so the two never drift. pingMs < 0 hides ping.
+    // Right-aligned seat meta as rich text: an accent-colored HOST badge,
+    // ping-tier-colored "N ms", and the player's published local frame delay.
+    // Shared by renderSeatFilled and live refreshes so the render paths never
+    // drift. pingMs < 0 hides ping; frameDelay < 0 hides the delay.
     // `status`, when set, replaces the ping cell — used to show a punch being
     // retried or given up on, so a peer we can't reach reads as a stated
     // outcome instead of a number that never appears.
-    QString seatMetaHtml(int slot, bool isHost, int pingMs, bool dark,
+    QString seatMetaHtml(int slot, bool isHost, int pingMs, int frameDelay, bool dark,
                          const QString& status = QString())
     {
         QStringList parts;
@@ -297,6 +299,9 @@ namespace
         else if (pingMs >= 0)
             parts << QString("<span style='color:%1; font-weight:600;'>%2 ms</span>")
                          .arg(pingHex(pingMs)).arg(pingMs);
+        if (frameDelay >= 0)
+            parts << QStringLiteral("<span style='font-weight:600;'>Frame Delay: %1f</span>")
+                         .arg(frameDelay);
         return parts.join(QStringLiteral("&nbsp;·&nbsp;"));
     }
 
@@ -750,7 +755,7 @@ QWidget* RollbackLobbyDialog::buildBrowseView()
     m_quickMatchBtn->setCursor(Qt::PointingHandCursor);
     m_quickMatchBtn->setToolTip(
         "Auto-match with another player searching for the selected game.\n"
-        "Defaults to delay 2 / prediction 7.");
+        "Uses your automatic frame delay and a fixed 9-frame prediction window.");
 
     m_createRoomBtn = new QPushButton("Create Room…", this);
     m_createRoomBtn->setObjectName("CreateRoomBtn");
@@ -976,8 +981,8 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     m_roomSubtitle->setWordWrap(true);
     lay->addWidget(m_roomSubtitle);
 
-    // Meta line (Seats / Region) — plain rich text. Delay and prediction
-    // live in the editable settings row below instead of read-only chips.
+    // Meta line (Seats / Region) — plain rich text. Local delay lives in the
+    // editable settings row below instead of a read-only chip.
     m_roomMetaLabel = new QLabel("—", this);
     m_roomMetaLabel->setTextFormat(Qt::RichText);
     m_roomMetaLabel->setContentsMargins(0, SPACING_TIGHT, 0, 0);
@@ -994,12 +999,6 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         "Recommended: 2 for ~80ms RTT, 3-4 for ~150ms RTT.\n"
         "\n"
         "Local setting — each player may choose a different value.");
-    const QString predictionTip = QStringLiteral(
-        "Maximum frames the rollback engine may predict ahead.\n"
-        "Higher prediction = more network tolerance.\n"
-        "Recommended: 7 (matches Slippi default).\n"
-        "\n"
-        "Host-only. All players will use the same value.");
 
     // Frame values exposed in the dropdown. 0 is intentionally omitted —
     // GekkoNet's zero-delay path still has open bugs (see project memory:
@@ -1007,14 +1006,13 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     // users until that's resolved. Editing this list updates the UI; the
     // server's clamp range governs what values it'll actually accept.
     static const QList<int> FRAME_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    // The auto entry is data 0 (a value the numeric list never uses), inserted
-    // at the top of each combo. Delay's auto resolves from ping (labelled
-    // "Auto"); prediction's is a fixed 7 (labelled "Default").
+    // The Auto entry is data 0 (a value the numeric list never uses). It resolves
+    // independently from this client's direct pings to the other seats.
     auto fillFrameCombo = [](QComboBox* combo, const QString& autoLabel) {
         combo->addItem(autoLabel, 0);
         for (int v : FRAME_OPTIONS)
             combo->addItem(QString("%1 f").arg(v), v);
-        combo->setCurrentIndex(0); // default to the auto/default entry
+        combo->setCurrentIndex(0); // default to Auto
     };
 
     auto* delayLbl = new QLabel("Your frame delay:", this);
@@ -1030,25 +1028,6 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     m_delayCombo->setProperty("originalTip", delayTip);
     settingsRow->addWidget(delayLbl);
     settingsRow->addWidget(m_delayCombo);
-
-    settingsRow->addSpacing(SPACING_DEFAULT * 2);
-
-    auto* predLbl = new QLabel("Prediction:", this);
-    m_predictionCombo = new QComboBox(this);
-    m_predictionCombo->setObjectName("LobbyCombo");
-    fillFrameCombo(m_predictionCombo, QString("Default (%1 f)").arg(kAutoPredictionWindow));
-    m_predictionCombo->setToolTip(predictionTip);
-    m_predictionCombo->setProperty("originalTip", predictionTip);
-    settingsRow->addWidget(predLbl);
-    settingsRow->addWidget(m_predictionCombo);
-
-    // Pacing is no longer user-selectable — the engine hardwires the Smooth
-    // (asymmetric) model. The combo survives hidden and pinned to Smooth
-    // because the room-settings sync paths require all three combos non-null;
-    // it just always reports 1.
-    m_pacingCombo = new QComboBox(this);
-    m_pacingCombo->addItem("Smooth", 1);
-    m_pacingCombo->hide();
 
     settingsRow->addStretch(1);
     lay->addLayout(settingsRow);
@@ -1093,26 +1072,15 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     lay->addLayout(toggleRow);
 
-    // Delay is local: changing it never asks the server for permission and
-    // never changes another player's value. The host mirrors its resolved
-    // value through the legacy room field so older clients remain compatible.
+    // Delay is local: changing it never changes another player's value. The
+    // resolved number is published so it can be shown beside this player's seat.
     auto applyDelay = [this]() {
         if (m_suppressSettingsSignal) return;
         if (m_currentRoomId == 0) return;
         m_delayAuto = (m_delayCombo->currentData().toInt() == 0);
         applyLocalFrameDelay(true);
     };
-    // Prediction is still shared room state, so only the enabled host control
-    // can send it. Its Default entry resolves to a concrete value on the wire.
-    auto pushSharedSettings = [this]() {
-        if (m_suppressSettingsSignal) return;
-        if (m_currentRoomId == 0 || !m_client) return;
-        m_predictionAuto = (m_predictionCombo->currentData().toInt() == 0);
-        applyHostRoomSettings(true);
-    };
     connect(m_delayCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applyDelay);
-    connect(m_predictionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, pushSharedSettings);
 
     // ── Seats — bold section header + vertical player-list rows ──
     auto* seatsHeader = new QLabel("SEATS", this);
@@ -1285,6 +1253,7 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
 {
     s.isHost = false;
     s.userId = 0;
+    s.frameDelay = -1;
 
     // Muted, dashed card — clearly "open seat" without competing with the
     // filled, color-tinted player cards.
@@ -1323,9 +1292,10 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
 }
 
 void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, bool isHost,
-                                           bool isSelf, int pingMs, bool canKick)
+                                           bool isSelf, int pingMs, int frameDelay, bool canKick)
 {
     s.isHost = isHost;
+    s.frameDelay = frameDelay;
     if (s.kickButton) s.kickButton->setVisible(canKick);
 
     const bool dark = isDarkTheme();
@@ -1373,7 +1343,8 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
     {
         // Self is a local zero-latency endpoint. Remote ping appears after the
         // first reply; until then onRoomStateChanged supplies an ICE status.
-        s.metaLabel->setText(seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, dark));
+        s.metaLabel->setText(
+            seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, frameDelay, dark));
     }
 }
 
@@ -2197,7 +2168,9 @@ void RollbackLobbyDialog::onHelloFailed(const QString& reason)
     if (reason == "username_taken")    human = "That username is already in use.";
     else if (reason == "invalid_hello") human = "Server rejected the connection handshake.";
     else if (reason == "invalid_payload") human = "That username isn't allowed.";
-    else if (reason == "version_mismatch") human = "Client version is incompatible with this server.";
+    else if (reason == "version_mismatch") human =
+        "Your RMG-K client is out of date. This lobby requires RMG-K 9.13 "
+        "or vdev-2367 or newer.";
     else if (reason == "server_full") human = "The lobby is currently full.";
 
     m_connectPromptMessage = human;
@@ -2814,11 +2787,11 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
     m_quickMatchActive = false;
     if (m_quickMatchBtn) m_quickMatchBtn->setText("⚡  Quick Match");
 
-    // Every freshly-entered room starts in Auto delay/prediction. Delay is a
-    // per-player selection, so reset this client's combo here instead of ever
-    // copying the legacy room delay from ROOM_STATE.
-    m_delayAuto      = true;
-    m_predictionAuto = true;
+    // Every freshly-entered room starts in Auto delay. It is a per-player
+    // selection, so reset this client's combo here instead of ever copying the
+    // legacy room delay from ROOM_STATE.
+    m_delayAuto = true;
+    m_localDelayPublished = false;
     m_currentRoomDelay = autoFrameDelayForPing(-1);
     if (m_delayCombo)
     {
@@ -2948,11 +2921,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     const QString romName = rom.value("name").toString();
     const QString romMd5 = rom.value("md5").toString();
     const QString romRegion = rom.value("region").toString();
-    const int prediction = roomState.value("prediction").toInt();
     const int pacing = roomState.value("pacing").toInt() == 1 ? 1 : 0;
-    // Prediction remains host-owned, so non-hosts mirror whether the host left
-    // it on Default. Delay and delayAuto are intentionally local-only.
-    const bool roomPredictionAuto = roomState.value("predictionAuto").toBool();
     const int maxPlayers = roomState.value("maxPlayers").toInt();
     const QString state = roomState.value("state").toString();
     const quint64 hostId = static_cast<quint64>(roomState.value("hostId").toDouble());
@@ -2961,7 +2930,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     m_currentRoomGame       = romName;
     m_currentRoomMd5        = romMd5;
     m_currentRoomRegion     = romRegion;
-    m_currentRoomPrediction = prediction;
+    m_currentRoomPrediction = kLobbyPredictionWindow;
     m_currentRoomPacing     = pacing;
     m_currentRoomHostId     = hostId;
 
@@ -3022,58 +2991,21 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         metaParts << QString("<b>Region:</b> %1").arg(romRegion);
     m_roomMetaLabel->setText(metaParts.join("  ·  "));
 
-    // Sync shared prediction/pacing from authoritative room state while leaving
-    // this player's delay untouched. Suppress signals so a refresh doesn't echo
-    // the same shared values back to the server.
-    if (m_delayCombo && m_predictionCombo && m_pacingCombo)
+    // Room refreshes never assign the local delay selection. Every player owns
+    // their combo; it only locks after the match begins.
+    if (m_delayCombo)
     {
-        static const QString tipDisabledNotHost = QStringLiteral(
-            "Only the host can change prediction.");
         static const QString tipDisabledMidMatch = QStringLiteral(
             "Can't change settings during a match.");
 
         const bool delayEditable = state == "waiting";
-        const bool sharedEditable = iAmHost && state == "waiting";
-        m_suppressSettingsSignal = true;
-        // Look up the index for the server-supplied value via findData
-        // since the combo's index no longer maps 1:1 to the value (0/Auto is
-        // not a real value). Falls back to the floor entry if the server
-        // somehow handed us a value we don't expose.
-        auto pickIndex = [](QComboBox* combo, int value) {
-            const int idx = combo->findData(value);
-            return idx >= 0 ? idx : 0;
-        };
-        // Delay selection is never assigned here: local manual values and Auto
-        // mode must survive every ROOM_STATE broadcast. Prediction is shared;
-        // the host trusts its local Default selection until the server echo,
-        // while non-hosts render the authoritative flag.
-        const bool showPredAuto = sharedEditable ? m_predictionAuto : roomPredictionAuto;
-        if (showPredAuto)
-            m_predictionCombo->setCurrentIndex(m_predictionCombo->findData(0));
-        else
-            m_predictionCombo->setCurrentIndex(pickIndex(m_predictionCombo, prediction));
-        // Pacing is a plain 2-choice value (no Auto): mirror the room's value on
-        // every seat.
-        m_pacingCombo->setCurrentIndex(pickIndex(m_pacingCombo, pacing));
-        // Keep Auto labelled with this player's resolved local value.
         setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
         m_delayCombo->setEnabled(delayEditable);
-        m_predictionCombo->setEnabled(sharedEditable);
-        m_pacingCombo->setEnabled(sharedEditable);
 
         const QString delayTip = delayEditable
             ? m_delayCombo->property("originalTip").toString()
             : tipDisabledMidMatch;
-        const QString predTip = sharedEditable
-            ? m_predictionCombo->property("originalTip").toString()
-            : (iAmHost ? tipDisabledMidMatch : tipDisabledNotHost);
-        const QString pacingTip = sharedEditable
-            ? m_pacingCombo->property("originalTip").toString()
-            : (iAmHost ? tipDisabledMidMatch : tipDisabledNotHost);
         m_delayCombo->setToolTip(delayTip);
-        m_predictionCombo->setToolTip(predTip);
-        m_pacingCombo->setToolTip(pacingTip);
-        m_suppressSettingsSignal = false;
     }
 
     // Broadcasting is host-only — one authoritative stream per match. Hide the
@@ -3099,13 +3031,17 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         const bool slotIsHost = (uid == hostId);
         const bool slotIsSelf = (uid == m_client->selfUserId());
         const int pingMs = slotIsSelf ? 0 : m_client->measuredPingMs(uid);
+        const int frameDelay = slotIsSelf
+            ? m_currentRoomDelay
+            : p.value("frameDelay").toInt(-1);
         // The host can remove any seated player except themselves (the host seat).
         const bool canKick = iAmHost && !slotIsHost;
         m_seats[slot - 1].userId = uid;
-        renderSeatFilled(m_seats[slot - 1], user, slotIsHost, slotIsSelf, pingMs, canKick);
+        renderSeatFilled(m_seats[slot - 1], user, slotIsHost, slotIsSelf,
+                         pingMs, frameDelay, canKick);
         if (!slotIsSelf && pingMs < 0 && m_seats[slot - 1].metaLabel)
             m_seats[slot - 1].metaLabel->setText(
-                seatMetaHtml(slot, slotIsHost, pingMs, isDarkTheme(),
+                seatMetaHtml(slot, slotIsHost, pingMs, frameDelay, isDarkTheme(),
                              seatIceStatusHtml()));
         filled[slot - 1] = true;
     }
@@ -3151,8 +3087,8 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
             if (uid == selfId || m_knownSeatedUsers.contains(uid))
                 continue;
             // Probe a newly-seated peer immediately so their ping appears within
-            // an RTT instead of waiting on the next probe tick — and so the host's
-            // Auto delay resolves from real ping before the match begins.
+            // an RTT instead of waiting on the next probe tick — and so this
+            // player's Auto delay resolves from real ping before the match begins.
             if (m_client) m_client->requestPingProbe(uid);
             sawNewPeer = true;
         }
@@ -3373,7 +3309,8 @@ void RollbackLobbyDialog::refreshSeatMeta(quint64 userId, const QString& statusH
             continue;
         const bool isSelf = m_client && userId == m_client->selfUserId();
         const int pingMs = isSelf ? 0 : (m_client ? m_client->measuredPingMs(userId) : -1);
-        s.metaLabel->setText(seatMetaHtml(s.slot, s.isHost, pingMs, isDarkTheme(), statusHtml));
+        s.metaLabel->setText(
+            seatMetaHtml(s.slot, s.isHost, pingMs, s.frameDelay, isDarkTheme(), statusHtml));
         break;
     }
 }
@@ -3462,7 +3399,8 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
     {
         if (s.userId != userId || !s.metaLabel)
             continue;
-        s.metaLabel->setText(seatMetaHtml(s.slot, s.isHost, rttMs, isDarkTheme()));
+        s.metaLabel->setText(
+            seatMetaHtml(s.slot, s.isHost, rttMs, s.frameDelay, isDarkTheme()));
         break;
     }
 
@@ -3522,10 +3460,22 @@ void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
         : m_delayCombo->currentData().toInt();
     if (m_delayAuto)
         setAutoComboLabel(m_delayCombo, delay);
-    if (!force && delay == m_currentRoomDelay)
+    if (!force && delay == m_currentRoomDelay && m_localDelayPublished)
         return;
 
     m_currentRoomDelay = delay;
+    if (m_client)
+    {
+        const quint64 selfId = m_client->selfUserId();
+        for (auto& seat : m_seats)
+        {
+            if (seat.userId != selfId)
+                continue;
+            seat.frameDelay = delay;
+            refreshSeatMeta(selfId, QString());
+            break;
+        }
+    }
 
     // Persist the concrete local value (never the Auto sentinel) as the legacy
     // create-room seed. Auto mode itself intentionally resets for each room.
@@ -3534,43 +3484,9 @@ void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
     s.setValue("Delay", delay);
     s.endGroup();
 
-    // Keep the server's legacy shared delay aligned with the host for older
-    // clients. New clients never consume it as their local value.
-    if (m_predictionCombo && m_predictionCombo->isEnabled())
-        applyHostRoomSettings(true);
-}
-
-void RollbackLobbyDialog::applyHostRoomSettings(bool force)
-{
-    if (m_currentRoomId == 0 || !m_client || !m_delayCombo || !m_predictionCombo || !m_pacingCombo)
-        return;
-    // Prediction stays host-only. Gate on authoritative room ownership/state,
-    // not transient widget state during a ROOM_STATE refresh.
-    if (m_currentRoomState != "waiting" ||
-        m_currentRoomHostId != m_client->selfUserId())
-        return;
-
-    const int effPred = m_predictionAuto
-        ? kAutoPredictionWindow
-        : m_predictionCombo->currentData().toInt();
-    const int effPacing = m_pacingCombo->currentData().toInt() == 1 ? 1 : 0;
-
-    if (!force && effPred == m_currentRoomPrediction &&
-        effPacing == m_currentRoomPacing)
-        return;
-
-    m_client->updateRoomSettings(m_currentRoomDelay, effPred, effPacing,
-                                 m_delayAuto, m_predictionAuto);
-
-    // Persist the concrete resolved values (never the Auto sentinel 0) so
-    // CreateRoomDialog seeds a valid delay/prediction for the next room. Pacing
-    // also rides the engine setting so a freshly created room defaults to it.
-    QSettings s("RMG-K", "n02");
-    s.beginGroup("Lobby/CreateRoom");
-    s.setValue("Delay",      m_currentRoomDelay);
-    s.setValue("Prediction", effPred);
-    s.endGroup();
-    CoreSettingsSetValue(SettingsID::Rollback_PacingMode, effPacing);
+    m_localDelayPublished = true;
+    if (m_client)
+        m_client->updateLocalFrameDelay(delay, m_delayAuto);
 }
 
 void RollbackLobbyDialog::onRoomLeft(const QString& reason)
@@ -3586,7 +3502,7 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
     m_currentRoomRegion.clear();
     m_currentRoomState.clear();
     m_currentRoomDelay = 2;
-    m_currentRoomPrediction = 7;
+    m_currentRoomPrediction = kLobbyPredictionWindow;
     m_currentRoomPacing = 0;
     m_currentRoomHostId = 0;
     m_currentMatchId = 0;
@@ -3596,6 +3512,7 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
     m_emulationActive = false;
     m_knownSeatedUsers.clear();
     m_roomSeatsSeen = false;
+    m_localDelayPublished = false;
 
     if (m_chatViewRoom) m_chatViewRoom->clear();
     if (m_roomChatInput) m_roomChatInput->setEnabled(false);

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -3252,12 +3252,6 @@ void RollbackLobbyDialog::notifyEmulationFinished()
     m_currentMatchId = 0;
     if (m_dropBtn) m_dropBtn->setEnabled(false);
 
-    // Re-open the UDP anchor so the next MATCH_BEGIN can hand us a fresh
-    // local port. Without this, localUdpPort() returns 0 (socket is aborted
-    // after onMatchBegin's releaseUdpAnchor), GekkoNet binds to a random
-    // kernel-picked port for match #2, and peers send to the stale port from
-    // match #1 — black screen on every match after the first.
-    if (m_client) m_client->reopenUdpAnchor();
 }
 
 void RollbackLobbyDialog::onMatchPeerLeft(quint64 matchId, quint64 userId, int slot, const QString& reason)
@@ -3517,12 +3511,12 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
     m_currentRoomPacing = 0;
     m_currentRoomHostId = 0;
     m_currentMatchId = 0;
+    m_iceWaitingMatchId = 0;
+    m_iceMatchDeadlineMs = 0;
     m_awaitingEmulationStart = false;
     m_emulationActive = false;
     m_knownSeatedUsers.clear();
     m_roomSeatsSeen = false;
-
-    if (m_client) m_client->reopenUdpAnchor();
 
     if (m_chatViewRoom) m_chatViewRoom->clear();
     if (m_roomChatInput) m_roomChatInput->setEnabled(false);
@@ -4035,6 +4029,8 @@ void RollbackLobbyDialog::onSpectateFailed(quint64 matchId, const QString& reaso
 
 void RollbackLobbyDialog::abortMatchStart(const QString& reason)
 {
+    m_iceWaitingMatchId = 0;
+    m_iceMatchDeadlineMs = 0;
     if (!reason.isEmpty())
     {
         appendChatSystemLine(CHANNEL_ROOM, reason);
@@ -4055,14 +4051,44 @@ void RollbackLobbyDialog::abortMatchStart(const QString& reason)
 
     if (m_dropBtn) m_dropBtn->setEnabled(false);
 
-    // No-op while the anchor is still open (these failures all happen before
-    // releaseUdpAnchor); guards the rare path where it was already torn down so
-    // ping probing keeps working without a relaunch.
-    if (m_client) m_client->reopenUdpAnchor();
 }
 
 void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient::LobbyMatchPeer>& peers)
 {
+    QString iceError;
+    if (!m_client->allIcePeersConnected(peers, &iceError))
+    {
+        const bool unsupported = std::any_of(peers.cbegin(), peers.cend(), [this](const auto& peer) {
+            return peer.userId != m_client->selfUserId() && !peer.iceSupported;
+        });
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (m_iceWaitingMatchId != matchId)
+        {
+            m_iceWaitingMatchId = matchId;
+            m_iceMatchDeadlineMs = nowMs + 15'000;
+            appendChatSystemLine(CHANNEL_ROOM, "Negotiating direct ICE connections...");
+        }
+        if (unsupported || nowMs >= m_iceMatchDeadlineMs)
+        {
+            m_currentMatchId = matchId;
+            m_awaitingEmulationStart = true;
+            m_iceWaitingMatchId = 0;
+            m_iceMatchDeadlineMs = 0;
+            abortMatchStart(unsupported
+                ? QStringLiteral("Match start failed: %1").arg(iceError)
+                : QStringLiteral("Match start failed: direct ICE negotiation timed out. No TURN relay is configured."));
+            return;
+        }
+        applyRoomStateBadge("Negotiating ICE…", stateHex("connecting", isDarkTheme()));
+        QTimer::singleShot(100, this, [this, matchId, peers]() {
+            if (m_iceWaitingMatchId == matchId)
+                onMatchBegin(matchId, peers);
+        });
+        return;
+    }
+    m_iceWaitingMatchId = 0;
+    m_iceMatchDeadlineMs = 0;
+
     const QString line = QString("Match #%1 starting with %2 player(s)").arg(matchId).arg(peers.size());
     appendChatSystemLine(CHANNEL_LOBBY, line);
     appendChatSystemLine(CHANNEL_ROOM,  line);
@@ -4102,14 +4128,13 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     applyRoomStateBadge("Connecting…", stateHex("connecting", isDarkTheme()));
 
     CoreAddCallbackMessage(CoreDebugMessageType::Info,
-        QString("Rollback lobby MATCH_BEGIN: match=%1 peers=%2 self=%3 roomGame='%4' delay=%5 prediction=%6 anchorPort=%7")
+        QString("Rollback lobby MATCH_BEGIN: match=%1 peers=%2 self=%3 roomGame='%4' delay=%5 prediction=%6 transport=ice")
             .arg(matchId)
             .arg(peers.size())
             .arg(m_client->selfUserId())
             .arg(m_currentRoomGame)
             .arg(m_currentRoomDelay)
             .arg(m_currentRoomPrediction)
-            .arg(m_client->localUdpPort())
             .toUtf8().constData());
 
     const quint64 selfId = m_client->selfUserId();
@@ -4176,37 +4201,17 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
         }
     }
 
-    const quint16 localPort = m_client->localUdpPort();
+    const quint16 localPort = 0;
 
     for (const auto& p : peers)
     {
         if (p.userId == selfId)
             continue;
 
-        QString endpointIp = p.publicIp;
-        QString endpointKind = "public";
-
-        if (!local.publicIp.isEmpty() &&
-            !p.publicIp.isEmpty() &&
-            local.publicIp == p.publicIp &&
-            !p.localIp.isEmpty())
-        {
-            endpointIp = p.localIp;
-            endpointKind = "local";
-        }
-
-        const QString selectedLine = QString("Rollback lobby selected endpoint: peerUser=%1 slot=%2 kind=%3 endpoint=%4:%5 localPublic=%6 peerPublic=%7 peerLocal=%8")
-            .arg(p.userId)
-            .arg(p.slot)
-            .arg(endpointKind)
-            .arg(endpointIp)
-            .arg(p.publicPort)
-            .arg(local.publicIp)
-            .arg(p.publicIp)
-            .arg(p.localIp);
+        const QString selectedLine = QString("Rollback lobby selected ICE peer: peerUser=%1 slot=%2")
+            .arg(p.userId).arg(p.slot);
         CoreAddCallbackMessage(CoreDebugMessageType::Info, selectedLine.toUtf8().constData());
-
-        remotePeers << QString("%1,%2,%3").arg(p.slot).arg(endpointIp).arg(p.publicPort);
+        remotePeers << QString("%1,ice,%2").arg(p.slot).arg(p.userId);
     }
 
     if (remotePeers.isEmpty())
@@ -4214,12 +4219,6 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
         abortMatchStart("Match start failed: missing remote peer.");
         return;
     }
-
-    // Punch peer NATs from the anchor socket before handing the port to
-    // GekkoNet. Both peers receive MATCH_BEGIN within ~RTT of each other, so
-    // both fire while the other's anchor is still open — opens the NAT
-    // mapping so GekkoNet's first frame doesn't have to eat the handshake.
-    m_client->punchPeerEndpoints(peers);
 
     const QString localRomFile = localRomPathForMd5(m_currentRoomMd5);
     if (localRomFile.isEmpty())
@@ -4238,30 +4237,15 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     }
     appendChatSystemLine(CHANNEL_ROOM, "Pre-match sync complete.");
 
-    // n02-style shared transport: lend the live anchor socket to GekkoNet
-    // instead of releasing the port for it to rebind. The port and every
-    // peer's NAT mapping to us survive the match; reclaim happens through the
-    // existing reopenUdpAnchor calls on the match-end paths. Falls back to
-    // the old release/rebind handoff if the descriptor can't be obtained.
-    const qintptr anchorFd = m_client->lendAnchorToMatch();
-    if (anchorFd != -1)
-    {
-        rmgk_gekko::set_external_socket(static_cast<uintptr_t>(anchorFd));
-    }
-    else
-    {
-        rmgk_gekko::clear_external_socket();
-        m_client->releaseUdpAnchor();
-    }
+    rmgk_gekko::clear_external_socket();
 
     {
         char buf[640];
         std::snprintf(buf, sizeof(buf),
-            "Lobby→matchReady (deferred 100ms): game='%s' peers=%d (%s) localPort=%u slot=%d delay=%d pred=%d",
+            "Lobby→matchReady: game='%s' peers=%d (%s) transport=ice slot=%d delay=%d pred=%d",
             m_currentRoomGame.toUtf8().constData(),
             int(remotePeers.size()),
             remotePeers.join("; ").toUtf8().constData(),
-            unsigned(localPort),
             local.slot,
             m_currentRoomDelay,
             m_currentRoomPrediction);
@@ -4273,18 +4257,8 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     // here so the match definitively runs the host-selected model.
     CoreSettingsSetValue(SettingsID::Rollback_PacingMode, m_currentRoomPacing);
 
-    // Defer the emit so the OS finishes releasing the anchor port before
-    // GekkoNet attempts to bind it. 100ms is plenty on Windows for an UDP
-    // socket teardown to complete; without this delay the bind races.
-    const QString gameName  = m_currentRoomGame;
-    const QString romFile   = localRomFile; // resolved above by MD5 — robust for off-database ROMs
-    const int localPortInt  = int(localPort);
-    const int slot          = local.slot;
-    const int delay         = m_currentRoomDelay;
-    const int prediction    = m_currentRoomPrediction;
-    QTimer::singleShot(100, this, [this, gameName, romFile, remotePeers, localPortInt, slot, delay, prediction]() {
-        emit matchReady(gameName, romFile, remotePeers, localPortInt, slot, delay, prediction);
-    });
+    emit matchReady(m_currentRoomGame, localRomFile, remotePeers, int(localPort),
+                    local.slot, m_currentRoomDelay, m_currentRoomPrediction);
 }
 
 #endif // NETPLAY

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -310,6 +310,16 @@ namespace
                    .arg(c.wait).arg(attempt).arg(maxAttempts);
     }
 
+    // Shown before the first ping can be sent. ICE negotiation may take a few
+    // seconds on restrictive NATs, so leaving this cell blank makes a healthy
+    // connection look stalled.
+    QString seatIceStatusHtml()
+    {
+        const auto c = statusColors();
+        return QString("<span style='color:%1; font-weight:600;'>establishing connection…</span>")
+                   .arg(c.wait);
+    }
+
     // A translucent fill derived from a solid hex — used for the soft pill /
     // badge backgrounds so an accent reads gently over palette(window/base).
     QString tintRgba(const QString& hex, double alpha)
@@ -516,6 +526,8 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
     connect(m_client, &LobbyClient::modListReceived,      this, &RollbackLobbyDialog::onModListReceived);
     connect(m_client, &LobbyClient::matchBegin,           this, &RollbackLobbyDialog::onMatchBegin);
     connect(m_client, &LobbyClient::matchPeerLeft,        this, &RollbackLobbyDialog::onMatchPeerLeft);
+    connect(m_client, &LobbyClient::icePeerConnectionChanged,
+            this, &RollbackLobbyDialog::onIcePeerConnectionChanged);
     connect(m_client, &LobbyClient::pingProbeMeasured,    this, &RollbackLobbyDialog::onPingMeasured);
     connect(m_client, &LobbyClient::pingProbeRetrying,    this, &RollbackLobbyDialog::onPingProbeRetrying);
     connect(m_client, &LobbyClient::pingProbeFailed,      this, &RollbackLobbyDialog::onPingProbeFailed);
@@ -1345,10 +1357,9 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
     }
     if (s.metaLabel)
     {
-        // HOST badge + ping. Self never shows a ping (pingMs == -1 also means
-        // "no measurement yet" for peers we haven't probed). Ping shows up
-        // after the first PROBE_REPLY arrives, refreshed on each tick.
-        s.metaLabel->setText(seatMetaHtml(s.slot, isHost, isSelf ? -1 : pingMs, dark));
+        // Self is a local zero-latency endpoint. Remote ping appears after the
+        // first reply; until then onRoomStateChanged supplies an ICE status.
+        s.metaLabel->setText(seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, dark));
     }
 }
 
@@ -3076,11 +3087,15 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         const quint64 uid = static_cast<quint64>(p.value("userId").toDouble());
         const bool slotIsHost = (uid == hostId);
         const bool slotIsSelf = (uid == m_client->selfUserId());
-        const int pingMs = slotIsSelf ? -1 : m_client->measuredPingMs(uid);
+        const int pingMs = slotIsSelf ? 0 : m_client->measuredPingMs(uid);
         // The host can remove any seated player except themselves (the host seat).
         const bool canKick = iAmHost && !slotIsHost;
         m_seats[slot - 1].userId = uid;
         renderSeatFilled(m_seats[slot - 1], user, slotIsHost, slotIsSelf, pingMs, canKick);
+        if (!slotIsSelf && pingMs < 0 && m_seats[slot - 1].metaLabel)
+            m_seats[slot - 1].metaLabel->setText(
+                seatMetaHtml(slot, slotIsHost, pingMs, isDarkTheme(),
+                             seatIceStatusHtml()));
         filled[slot - 1] = true;
     }
     for (int i = 0; i < 4; ++i)
@@ -3343,10 +3358,25 @@ void RollbackLobbyDialog::refreshSeatMeta(quint64 userId, const QString& statusH
     {
         if (s.userId != userId || !s.metaLabel)
             continue;
-        const int pingMs = m_client ? m_client->measuredPingMs(userId) : -1;
+        const bool isSelf = m_client && userId == m_client->selfUserId();
+        const int pingMs = isSelf ? 0 : (m_client ? m_client->measuredPingMs(userId) : -1);
         s.metaLabel->setText(seatMetaHtml(s.slot, s.isHost, pingMs, isDarkTheme(), statusHtml));
         break;
     }
+}
+
+void RollbackLobbyDialog::onIcePeerConnectionChanged(quint64 userId, bool connected)
+{
+    if (!m_client || userId == m_client->selfUserId())
+        return;
+
+    // Keep the connection progress visible until the first RTT replaces it.
+    // Once ICE connects, probe immediately rather than waiting up to three
+    // seconds for the periodic refresh timer.
+    if (m_client->measuredPingMs(userId) < 0)
+        refreshSeatMeta(userId, seatIceStatusHtml());
+    if (connected)
+        m_client->requestPingProbe(userId);
 }
 
 void RollbackLobbyDialog::onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -2067,7 +2067,7 @@ QString RollbackLobbyDialog::prefillUsername() const
     }
 
     name.remove(QRegularExpression(R"([^A-Za-z0-9_\-\.])"));
-    return name.left(16);
+    return name.left(20);
 }
 
 void RollbackLobbyDialog::promptForUsername(const QString& statusMessage)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -320,6 +320,13 @@ namespace
                    .arg(c.wait);
     }
 
+    QString seatIceFailedStatusHtml()
+    {
+        const auto c = statusColors();
+        return QString("<span style='color:%1; font-weight:600;'>connection failed</span>")
+                   .arg(c.fail);
+    }
+
     // A translucent fill derived from a solid hex — used for the soft pill /
     // badge backgrounds so an accent reads gently over palette(window/base).
     QString tintRgba(const QString& hex, double alpha)
@@ -3365,15 +3372,20 @@ void RollbackLobbyDialog::refreshSeatMeta(quint64 userId, const QString& statusH
     }
 }
 
-void RollbackLobbyDialog::onIcePeerConnectionChanged(quint64 userId, bool connected)
+void RollbackLobbyDialog::onIcePeerConnectionChanged(quint64 userId, bool connected, bool failed)
 {
     if (!m_client || userId == m_client->selfUserId())
         return;
 
-    // Keep the connection progress visible until the first RTT replaces it.
+    // Keep connection progress visible until the first RTT replaces it, but
+    // do not leave a peer looking busy after ICE has exhausted every pair.
+    // Failure supersedes a cached RTT because that old measurement no longer
+    // represents a usable direct connection.
+    if (failed)
+        refreshSeatMeta(userId, seatIceFailedStatusHtml());
     // Once ICE connects, probe immediately rather than waiting up to three
     // seconds for the periodic refresh timer.
-    if (m_client->measuredPingMs(userId) < 0)
+    else if (m_client->measuredPingMs(userId) < 0)
         refreshSeatMeta(userId, seatIceStatusHtml());
     if (connected)
         m_client->requestPingProbe(userId);

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -169,6 +169,7 @@ private slots:
 
     // Punch progress for a seated peer, so a slow or failing NAT punch is
     // visible in the room rather than looking like a stalled Start button.
+    void onIcePeerConnectionChanged(quint64 userId, bool connected);
     void onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts);
     void onPingProbeFailed(quint64 userId);
     // First consecutive miss on a peer we've measured before — treat as

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -236,11 +236,10 @@ private:
     void    updateServerMeta();
     void    updateInRoomBanner();   // refresh "you're in: X" banner in browse view
 
-    // Delay is local to this player. Auto resolves from this client's direct
-    // RTTs to the other seats; prediction remains a shared host setting.
+    // Delay is local to this player. Auto resolves only from this client's
+    // direct RTTs to the other seats.
     int     worstLocalPeerPingMs() const;
     void    applyLocalFrameDelay(bool force);
-    void    applyHostRoomSettings(bool force);
 
     // Broadcaster lifecycle. startBroadcast arms the n02 recording sink + drain
     // timer and sends BROADCAST_BEGIN; stopBroadcast flushes and sends
@@ -263,16 +262,17 @@ private:
         QLabel*  dotLabel  = nullptr;     // ● filled, ○ empty
         QLabel*  slotLabel = nullptr;     // "P1"
         QLabel*  nameLabel = nullptr;     // username or "Waiting…"
-        QLabel*  metaLabel = nullptr;     // "host · 12ms" — right-aligned
+        QLabel*  metaLabel = nullptr;     // "host · 12ms · Frame Delay: 2f"
         QPushButton* kickButton = nullptr; // ✕ — host-only, removes the seated player
         bool     isHost    = false;
         quint64  userId    = 0;           // seated user, 0 when empty
         int      slot      = 0;           // 1-4, drives the per-player accent color
+        int      frameDelay = -1;          // published local input delay
     };
     void buildSeatRow(SeatRow& row, int slotIdx, QWidget* parent);
     void renderSeatEmpty(SeatRow& row);
     void renderSeatFilled(SeatRow& row, const QString& username, bool isHost,
-                          bool isSelf, int pingMs, bool canKick);
+                          bool isSelf, int pingMs, int frameDelay, bool canKick);
 
     // Seat reorder (host, waiting): a seat's drag handle starts a QDrag carrying
     // its slot; the seats container handles the drop and asks the server to swap.
@@ -355,12 +355,9 @@ private:
     QLabel*    m_roomStateLabel = nullptr;   // "Waiting" / "In Game"
     QLabel*    m_roomMetaLabel  = nullptr;   // Seats 2/4 · Region NTSC
 
-    // Delay is locally editable by every player; prediction is host-editable
-    // and shared. Both lock once the match starts. Data 0 is the Auto/Default
-    // sentinel; numeric entries contain their concrete frame value.
+    // Delay is locally editable by every player and locks once the match starts.
+    // Data 0 is the Auto sentinel; numeric entries contain concrete frame values.
     QComboBox* m_delayCombo      = nullptr;
-    QComboBox* m_predictionCombo = nullptr;
-    QComboBox* m_pacingCombo     = nullptr;  // 0 = aggressive, 1 = smooth
     bool       m_suppressSettingsSignal = false;  // guard against ROOM_STATE → setCurrentIndex echo
 
     // Per-player local toggle: when checked, this client writes a .krec of the
@@ -437,7 +434,7 @@ private:
     QString m_currentRoomRegion;
     QString m_currentRoomState;
     int     m_currentRoomDelay      = 2;   // this client's local input delay
-    int     m_currentRoomPrediction = 7;
+    int     m_currentRoomPrediction = 9;
     int     m_currentRoomPacing     = 0;   // 0 = aggressive, 1 = smooth
     quint64 m_currentRoomHostId     = 0;   // seated host's user id (0 when none)
     quint64 m_currentMatchId        = 0;
@@ -450,10 +447,9 @@ private:
     QSet<quint64> m_knownSeatedUsers;
     bool          m_roomSeatsSeen = false;
 
-    // Delay-auto is local and ping-based for every player. Prediction-auto is
-    // host-owned and fixed at 7. Both default on in a fresh room.
+    // Delay-auto is local and ping-based for every player.
     bool    m_delayAuto      = true;
-    bool    m_predictionAuto = true;
+    bool    m_localDelayPublished = false;
 
     bool m_awaitingEmulationStart = false;
     bool m_emulationActive        = false;

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -170,6 +170,7 @@ private slots:
     // Punch progress for a seated peer, so a slow or failing NAT punch is
     // visible in the room rather than looking like a stalled Start button.
     void onIcePeerConnectionChanged(quint64 userId, bool connected);
+    void onRoomPingMeasurementsChanged();
     void onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts);
     void onPingProbeFailed(quint64 userId);
     // First consecutive miss on a peer we've measured before — treat as
@@ -235,10 +236,9 @@ private:
     void    updateServerMeta();
     void    updateInRoomBanner();   // refresh "you're in: X" banner in browse view
 
-    // Host-only auto delay/prediction. worstSeatPingMs() = max measured RTT
-    // over seated peers (-1 if none). applyHostRoomSettings() resolves the
-    // Auto selections and pushes the concrete values via the lobby client.
-    int     worstSeatPingMs() const;
+    // Host-only auto delay/prediction. worstRoomPingMs() includes every direct
+    // player pair in the ICE mesh, not only host-to-peer paths.
+    int     worstRoomPingMs() const;
     void    applyHostRoomSettings(bool force);
 
     // Broadcaster lifecycle. startBroadcast arms the n02 recording sink + drain

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -169,7 +169,7 @@ private slots:
 
     // Punch progress for a seated peer, so a slow or failing NAT punch is
     // visible in the room rather than looking like a stalled Start button.
-    void onIcePeerConnectionChanged(quint64 userId, bool connected);
+    void onIcePeerConnectionChanged(quint64 userId, bool connected, bool failed);
     void onRoomPingMeasurementsChanged();
     void onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts);
     void onPingProbeFailed(quint64 userId);

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -439,6 +439,8 @@ private:
     int     m_currentRoomPacing     = 0;   // 0 = aggressive, 1 = smooth
     quint64 m_currentRoomHostId     = 0;   // seated host's user id (0 when none)
     quint64 m_currentMatchId        = 0;
+    quint64 m_iceWaitingMatchId     = 0;
+    qint64  m_iceMatchDeadlineMs    = 0;
 
     // Seated user ids as of the last ROOM_STATE, used to detect when a *new*
     // player joins (so we can flash/chime). m_roomSeatsSeen suppresses the chime

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -236,9 +236,10 @@ private:
     void    updateServerMeta();
     void    updateInRoomBanner();   // refresh "you're in: X" banner in browse view
 
-    // Host-only auto delay/prediction. worstRoomPingMs() includes every direct
-    // player pair in the ICE mesh, not only host-to-peer paths.
-    int     worstRoomPingMs() const;
+    // Delay is local to this player. Auto resolves from this client's direct
+    // RTTs to the other seats; prediction remains a shared host setting.
+    int     worstLocalPeerPingMs() const;
+    void    applyLocalFrameDelay(bool force);
     void    applyHostRoomSettings(bool force);
 
     // Broadcaster lifecycle. startBroadcast arms the n02 recording sink + drain
@@ -354,9 +355,9 @@ private:
     QLabel*    m_roomStateLabel = nullptr;   // "Waiting" / "In Game"
     QLabel*    m_roomMetaLabel  = nullptr;   // Seats 2/4 · Region NTSC
 
-    // Host-editable rollback settings (delay / prediction). Disabled for
-    // non-hosts and mid-match. Combo index maps 1:1 to the integer value
-    // (0..9), so currentIndex() is the wire value.
+    // Delay is locally editable by every player; prediction is host-editable
+    // and shared. Both lock once the match starts. Data 0 is the Auto/Default
+    // sentinel; numeric entries contain their concrete frame value.
     QComboBox* m_delayCombo      = nullptr;
     QComboBox* m_predictionCombo = nullptr;
     QComboBox* m_pacingCombo     = nullptr;  // 0 = aggressive, 1 = smooth
@@ -435,7 +436,7 @@ private:
     QString m_currentRoomMd5;
     QString m_currentRoomRegion;
     QString m_currentRoomState;
-    int     m_currentRoomDelay      = 2;
+    int     m_currentRoomDelay      = 2;   // this client's local input delay
     int     m_currentRoomPrediction = 7;
     int     m_currentRoomPacing     = 0;   // 0 = aggressive, 1 = smooth
     quint64 m_currentRoomHostId     = 0;   // seated host's user id (0 when none)
@@ -449,9 +450,8 @@ private:
     QSet<quint64> m_knownSeatedUsers;
     bool          m_roomSeatsSeen = false;
 
-    // Host-only "Auto" selections for the in-room dropdowns. Delay-auto is
-    // ping-based; prediction-auto is a fixed 7. Default on so a fresh host
-    // gets sensible tuning without thinking about it.
+    // Delay-auto is local and ping-based for every player. Prediction-auto is
+    // host-owned and fixed at 7. Both default on in a fresh room.
     bool    m_delayAuto      = true;
     bool    m_predictionAuto = true;
 

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -248,9 +248,10 @@ SettingsDialog::SettingsDialog(QWidget *parent, QString file) : QDialog(parent)
     this->rollbackVerboseGlideInputLoggingCheckBox = new QCheckBox("Enable verbose Glide input logging", rollbackLoggingGroupBox);
     this->rollbackPingDiagnosticsCheckBox = new QCheckBox("Enable lobby ping diagnostics logging", rollbackLoggingGroupBox);
     this->rollbackPingDiagnosticsCheckBox->setToolTip(
-        "Write a detailed lobby_ping_*.log file (in the Logs folder) tracing lobby ping\n"
-        "probes and NAT hole-punching. Only useful when debugging connection problems\n"
-        "with another player. Applies the next time you connect to the lobby.");
+        "Write a detailed lobby_ping_*.log file (in the Logs folder) tracing ICE/STUN\n"
+        "candidate gathering, signaling, connectivity checks, and peer pings. Candidate\n"
+        "addresses are included, but ICE credentials are redacted. Only useful when\n"
+        "debugging connection problems. Applies the next time you connect to the lobby.");
     this->rollbackHideLocationCheckBox = new QCheckBox("Hide my location from other players", rollbackTab);
     this->rollbackHideLocationCheckBox->setToolTip(
         "Your row in the netplay lobby shows no country flag, and no country in its\n"


### PR DESCRIPTION
NOTE: This PR supersedes #188.

## Summary

This replaces the rollback lobby’s custom UDP hole-punching path with libjuice ICE/STUN for direct peer-to-peer connectivity.

It also changes rollback rooms to use independent per-player frame delays. Each player can choose a manual delay or use their own automatic recommendation without changing another player’s delay.

Setting your own delay lower than recommended will give you less frame delay at the cost of more rollbacks. It will NOT negatively affect other players in your game.

Prediction is no longer configurable in rollback lobby rooms and is fixed at 9 frames.

No TURN server or relay is currently used, although the configuration leaves room for TURN support in the future.

## Changes

### ICE transport

- Vendor libjuice with its upstream license.
- Add an ICE transport layer for rollback lobby peers.
- Exchange ICE descriptions and candidates through the lobby server.
- Route lobby ping probes, pre-match synchronization, and GekkoNet traffic through the selected ICE candidate pair.
- Preserve the existing connect-code P2P path without modification.
- Measure ping RTT with higher-resolution timing while continuing to display millisecond values.
- Display `0 ms` for the local player.

### Connection status and diagnostics

- Display connection progress and failure states:
- Lobby diagnostics re-implemented to audit the ICE code path

### Individual frame delay

- Allow every player in a rollback room to select their own frame delay.
- Allow players in the same room to use different delays.
- Give every player their own `Auto` recommendation.
- Calculate Auto from that player’s direct pings to the other occupied seats.
- Publish each player’s resolved manual or Auto delay to the lobby server.
- Display `Frame Delay: Nf` next to each player’s ping in the Seats section.
- Keep the setting labeled `Your frame delay`.
- Lock each player’s delay control after the match begins.

### Rollback timing behavior

- Offset each player’s simulation target according to the difference between player delays.
- Allow a lower-delay player to run numerically ahead of a higher-delay player by the delay difference.
- Make the player choosing the lower delay carry the resulting rollback risk themselves.
- Prevent one player’s low-delay choice from increasing the rollback burden for their opponents.
- Update GekkoNet advantage calculations and frame pacing to use the delay-balanced simulation target.

### Prediction

- Remove the Prediction dropdown from rollback lobby rooms.
- Fix the prediction window at 9 frames on both the client and lobby server.

### Lobby compatibility and validation

- Reject outdated RMG-K clients during the initial lobby handshake.
- Return a visible out-of-date error when the client does not meet the minimum.
- Increase the allowed lobby username range from 3–16 characters to 2–20 characters.
- Preserve the existing username character set: letters, numbers, `_`, `-`, and `.`.

## Scope

These changes affect only the rollback lobby P2P components. The connect-code P2P path is intentionally untouched.

The transport is currently direct-only:

- STUN is enabled.
- The production server now defaults to the dedicated RMG-K STUN endpoint instead of Google’s public STUN server.
- No TURN server is configured.
- No relay candidate is used.
- Peers whose IPv4 NATs are incompatible may require IPv6 or future TURN support.

The lobby server must support:

- Relaying ICE signaling messages between clients.
- Advertising the STUN configuration.
- Storing and broadcasting independent per-seat frame delays.
- Enforcing the fixed 9-frame prediction window.
- Enforcing the minimum supported RMG-K version.
- Accepting usernames between 2 and 20 characters.

The corresponding lobby-server changes are being provided separately.
