### PR TITLE
ICE fixes / QoL updates

### DIFF
--- a/Source/3rdParty/libjuice/src/agent.c
+++ b/Source/3rdParty/libjuice/src/agent.c
@@ -963,10 +963,16 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				if (ret >= 0) {
 					--entry->retransmissions;
 					if (entry->retransmissions < 0) {
-						entry->next_transmission = now + LAST_STUN_RETRANSMISSION_TIMEOUT;
+						entry->next_transmission = now +
+						    (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK
+						         ? LAST_STUN_CHECK_RESPONSE_TIMEOUT
+						         : LAST_STUN_RETRANSMISSION_TIMEOUT);
 					} else {
 						entry->next_transmission = now + entry->retransmission_timeout;
-						entry->retransmission_timeout *= 2;
+						// A short ICE generation needs repeated chances on the same NAT
+						// mapping. Server and TURN transactions retain exponential backoff.
+						if (entry->type != AGENT_STUN_ENTRY_TYPE_CHECK)
+							entry->retransmission_timeout *= 2;
 					}
 					continue;
 				}
@@ -1218,7 +1224,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			}
 		}
 
-	} else if (pending_count == 0 && agent->pac_timestamp) {
+	} else if (agent->pac_timestamp) {
 		// RFC 8863: While the timer is still running, the ICE agent MUST NOT update a checklist
 		// state from Running to Failed, even if there are no pairs left in the checklist to check.
 		if (now >= agent->pac_timestamp) {

--- a/Source/3rdParty/libjuice/src/agent.h
+++ b/Source/3rdParty/libjuice/src/agent.h
@@ -24,9 +24,12 @@
 
 // RFC 8445: Agents MUST NOT use an RTO value smaller than 500 ms.
 #define MIN_STUN_RETRANSMISSION_TIMEOUT 500 // msecs
-#define LAST_STUN_RETRANSMISSION_TIMEOUT (MIN_STUN_RETRANSMISSION_TIMEOUT * 16)
-#define MAX_STUN_CHECK_RETRANSMISSION_COUNT 6  // exponential backoff, total 39500ms
-#define MAX_STUN_SERVER_RETRANSMISSION_COUNT 5 // total 23500ms
+#define LAST_STUN_RETRANSMISSION_TIMEOUT (MIN_STUN_RETRANSMISSION_TIMEOUT * 2)
+#define LAST_STUN_CHECK_RESPONSE_TIMEOUT MIN_STUN_RETRANSMISSION_TIMEOUT
+// Connectivity checks use a fixed 500 ms cadence: six sends at 0, 500, 1000,
+// 1500, 2000, and 2500 ms, followed by a final 500 ms response window.
+#define MAX_STUN_CHECK_RETRANSMISSION_COUNT 5
+#define MAX_STUN_SERVER_RETRANSMISSION_COUNT 3
 #define STUN_TCP_TIMEOUT LAST_STUN_RETRANSMISSION_TIMEOUT
 
 // RFC 8445: ICE agents SHOULD use a default Ta value, 50 ms, but MAY use another value based on the
@@ -40,7 +43,7 @@
 // ICE Patiently Awaiting Connectivity timer
 // RFC 8863: The RECOMMENDED duration for the PAC timer is equal to the agent's connectivity check
 // transaction timeout, including all retransmissions.
-#define ICE_PAC_TIMEOUT 39500 // msecs
+#define ICE_PAC_TIMEOUT 3000 // msecs
 
 // Consent freshness
 // RFC 7675: Consent expires after 30 seconds.

--- a/Source/RMG-Core/LobbyIce.cpp
+++ b/Source/RMG-Core/LobbyIce.cpp
@@ -54,6 +54,11 @@ std::string g_stunHost;
 std::uint16_t g_stunPort = 0;
 std::vector<LobbyIceTurnServer> g_turnServers;
 std::map<std::uint64_t, std::shared_ptr<Peer>> g_peers;
+// Consecutive agents for a peer alternate between disjoint IANA dynamic-port
+// ranges. This guarantees that an ICE restart cannot reuse its prior local UDP
+// port while still leaving thousands of ports available if individual binds
+// collide with another process or peer agent.
+std::map<std::uint64_t, bool> g_nextPeerUsesUpperPortRange;
 std::map<std::uint64_t, std::vector<PendingRemoteSignal>> g_pendingRemoteSignals;
 std::deque<LobbyIceSignal> g_localSignals;
 std::deque<QueuedPacket> g_packets;
@@ -61,6 +66,9 @@ std::atomic<bool> g_diagnosticsEnabled{false};
 std::vector<LobbyIceDiagnostic> g_diagnostics;
 std::size_t g_diagnosticsDropped = 0;
 constexpr std::size_t DIAGNOSTIC_QUEUE_CAP = 4096;
+constexpr std::uint16_t DYNAMIC_PORT_RANGE_BEGIN = 49152;
+constexpr std::uint16_t DYNAMIC_PORT_RANGE_MIDDLE = 57344;
+constexpr std::uint16_t DYNAMIC_PORT_RANGE_END = 65535;
 
 std::uint64_t steady_now_us()
 {
@@ -337,6 +345,7 @@ void LobbyIce::reset()
             peers.push_back(peer);
         }
         g_peers.clear();
+        g_nextPeerUsesUpperPortRange.clear();
         g_pendingRemoteSignals.clear();
         g_localSignals.clear();
         g_packets.clear();
@@ -360,6 +369,7 @@ bool LobbyIce::add_peer(std::uint64_t peerUserId)
 {
     std::string stunHost;
     std::uint16_t stunPort = 0;
+    bool useUpperPortRange = false;
     std::vector<LobbyIceTurnServer> turnServers;
     std::vector<PendingRemoteSignal> pending;
     auto peer = std::make_shared<Peer>();
@@ -376,6 +386,8 @@ bool LobbyIce::add_peer(std::uint64_t peerUserId)
         {
             return true;
         }
+        useUpperPortRange = g_nextPeerUsesUpperPortRange[peerUserId];
+        g_nextPeerUsesUpperPortRange[peerUserId] = !useUpperPortRange;
         stunHost = g_stunHost;
         stunPort = g_stunPort;
         turnServers = g_turnServers;
@@ -400,6 +412,10 @@ bool LobbyIce::add_peer(std::uint64_t peerUserId)
     config.concurrency_mode = JUICE_CONCURRENCY_MODE_POLL;
     config.stun_server_host = stunHost.c_str();
     config.stun_server_port = stunPort;
+    config.local_port_range_begin = useUpperPortRange ?
+        DYNAMIC_PORT_RANGE_MIDDLE : DYNAMIC_PORT_RANGE_BEGIN;
+    config.local_port_range_end = useUpperPortRange ?
+        DYNAMIC_PORT_RANGE_END : static_cast<std::uint16_t>(DYNAMIC_PORT_RANGE_MIDDLE - 1);
     config.turn_servers = juiceTurnServers.empty() ? nullptr : juiceTurnServers.data();
     config.turn_servers_count = static_cast<int>(juiceTurnServers.size());
     config.cb_state_changed = on_state_changed;
@@ -451,6 +467,11 @@ void LobbyIce::remove_peer(std::uint64_t peerUserId)
     std::shared_ptr<Peer> peer;
     {
         std::lock_guard<std::mutex> lock(g_mutex);
+        // Removing a peer is also the generation boundary for any signaling
+        // that arrived before its agent existed. Otherwise an old description
+        // queued during a room-state race can poison the replacement agent
+        // before its fresh credentials arrive.
+        g_pendingRemoteSignals.erase(peerUserId);
         const auto it = g_peers.find(peerUserId);
         if (it == g_peers.end())
         {

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.cpp
@@ -70,7 +70,7 @@ void CreateRoomDialog::buildUi(const QString& defaultUsername, const QString& de
     root->addLayout(form);
 
     // Rollback settings are not surfaced here. Each player configures local
-    // delay in the room, and prediction is fixed at 9 frames.
+    // delay and prediction in the room.
 
     // Optional password (collapsed by default)
     auto* pwRow = new QHBoxLayout;
@@ -152,7 +152,7 @@ void CreateRoomDialog::validateInput()
 
 void CreateRoomDialog::onCreateClicked()
 {
-    // The legacy delay and fixed prediction stay at their loadDefaults() values.
+    // The legacy room seeds stay at their loadDefaults() values.
     m_name = m_nameEdit->text().trimmed();
     // m_romName / m_romMd5 were set from the lobby picker in the constructor.
     m_romRegion  = ""; // baked into the ROM; resolved later via md5 lookup
@@ -188,10 +188,10 @@ void CreateRoomDialog::loadDefaults()
     QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     if (s.contains("MaxPlayers")) m_maxPlayersSpin->setValue(s.value("MaxPlayers").toInt());
-    // Seed the legacy room delay from the last local value. Prediction is a
-    // fixed lobby rule and is never loaded from older user settings.
+    // Seed legacy room fields for older clients. Current clients publish their
+    // own rollback settings after entering the room.
     if (s.contains("Delay")) m_delay = s.value("Delay").toInt();
-    m_prediction = 9;
+    m_prediction = 7;
     s.endGroup();
 }
 
@@ -201,7 +201,7 @@ void CreateRoomDialog::saveDefaults()
     s.beginGroup("Lobby/CreateRoom");
     // The game selection is persisted by the lobby's shared picker, not here.
     s.setValue("MaxPlayers", m_maxPlayers);
-    // Delay persistence lives in the room view; CreateRoom only consumes it.
+    // Rollback-setting persistence lives in the room view.
     s.endGroup();
 }
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
@@ -72,7 +72,7 @@ private:
     void saveDefaults();
     void setFormEnabled(bool enabled);
 
-    // UI — local delay lives in the room view; prediction is fixed at 9.
+    // UI — local delay and prediction live in the room view.
     QLineEdit*   m_nameEdit       = nullptr;
     QLabel*      m_gameLabel      = nullptr;   // read-only game from the lobby picker
     QSpinBox*    m_maxPlayersSpin = nullptr;

--- a/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/CreateRoomDialog.hpp
@@ -89,7 +89,7 @@ private:
     QString m_romRegion;
     int     m_maxPlayers = 2;
     int     m_delay      = 2;
-    int     m_prediction = 9;
+    int     m_prediction = 7;
     QString m_password;
 };
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -2901,15 +2901,20 @@ void LobbyClient::startRoom()
     sendEnvelope("ROOM_START");
 }
 
-void LobbyClient::updateLocalRollbackSettings(int delay, bool delayAuto,
-                                              int prediction, bool predictionAuto)
+void LobbyClient::updateLocalFrameDelay(int delay, bool delayAuto)
 {
     QJsonObject d;
     d["delay"] = delay;
     d["delayAuto"] = delayAuto;
+    sendEnvelope("ROOM_UPDATE_DELAY", d);
+}
+
+void LobbyClient::updateRoomPrediction(int prediction, bool predictionAuto)
+{
+    QJsonObject d;
     d["prediction"] = prediction;
     d["predictionAuto"] = predictionAuto;
-    sendEnvelope("ROOM_UPDATE_PLAYER_SETTINGS", d);
+    sendEnvelope("ROOM_UPDATE_PREDICTION", d);
 }
 
 void LobbyClient::kickFromRoom(quint64 userId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -111,6 +111,11 @@ namespace
     constexpr quint8 ICE_PING_OP_REPORT  = 3;
     constexpr int ICE_PING_PACKET_SIZE = 1 + int(sizeof(quint64));
     constexpr int ICE_PING_REPORT_SIZE = 1 + int(sizeof(quint64)) + int(sizeof(quint16));
+    // Twenty three-second ICE generations give each peer pair up to 60 seconds.
+    // Every failed generation gets fresh credentials and a different local UDP
+    // port; only the twentieth failure reaches the UI.
+    constexpr int MAX_ICE_AUTO_RESTARTS = 19;
+    constexpr int MAX_ICE_CONNECTION_ATTEMPTS = MAX_ICE_AUTO_RESTARTS + 1;
 
     QString iceStateName(int state)
     {
@@ -960,9 +965,16 @@ void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
         desired.insert(userId);
         if (!m_icePeerIds.contains(userId))
         {
+            if (!m_iceGenerations.contains(userId))
+                m_iceGenerations.insert(userId, 0);
+            if (!m_iceRestartAttempts.contains(userId))
+                m_iceRestartAttempts.insert(userId, 0);
             if (LobbyIce::add_peer(userId))
             {
                 m_icePeerIds.insert(userId);
+                emit icePeerConnectionAttemptChanged(
+                    userId, m_iceRestartAttempts.value(userId, 0) + 1,
+                    MAX_ICE_CONNECTION_ATTEMPTS);
                 writePingDiagnostic(QStringLiteral("ICE_PEER_ADDED"),
                                     QStringLiteral("peer=%1 room=%2")
                                         .arg(pingUserLabel(userId)).arg(roomId));
@@ -985,6 +997,8 @@ void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
         LobbyIce::remove_peer(userId);
         m_icePeerIds.remove(userId);
         m_lastIceStates.remove(userId);
+        m_iceGenerations.remove(userId);
+        m_iceRestartAttempts.remove(userId);
         m_roomPeerPings.remove(userId);
         for (auto it = m_roomPeerPings.begin(); it != m_roomPeerPings.end(); ++it)
             it.value().remove(userId);
@@ -997,6 +1011,8 @@ void LobbyClient::resetIceMesh()
         LobbyIce::remove_peer(userId);
     m_icePeerIds.clear();
     m_lastIceStates.clear();
+    m_iceGenerations.clear();
+    m_iceRestartAttempts.clear();
     m_currentIceRoomId = 0;
     m_currentIceHostUserId = 0;
     m_roomPeerPings.clear();
@@ -1008,6 +1024,7 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
     const quint64 roomId = static_cast<quint64>(data.value("roomId").toDouble());
     const quint64 fromUserId = static_cast<quint64>(data.value("fromUserId").toDouble());
     const QString kind = data.value("kind").toString();
+    const quint32 generation = static_cast<quint32>(data.value("generation").toInt());
     if (roomId == 0 || roomId != m_currentIceRoomId || fromUserId == 0 ||
         fromUserId == m_selfUserId)
     {
@@ -1016,16 +1033,120 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
                                 .arg(fromUserId).arg(roomId).arg(m_currentIceRoomId).arg(kind));
         return;
     }
+
+    const quint32 currentGeneration = m_iceGenerations.value(fromUserId, 0);
+    if (generation < currentGeneration)
+    {
+        writePingDiagnostic(QStringLiteral("ICE_SIGNAL_IN_DROPPED"),
+                            QStringLiteral("peer=%1 room=%2 kind=%3 generation=%4 current_generation=%5 reason=stale_generation")
+                                .arg(pingUserLabel(fromUserId)).arg(roomId).arg(kind)
+                                .arg(generation).arg(currentGeneration));
+        return;
+    }
+
+    if (kind == QStringLiteral("restart"))
+    {
+        if (generation == 0 || generation == currentGeneration)
+        {
+            writePingDiagnostic(QStringLiteral("ICE_RESTART_IN_IGNORED"),
+                                QStringLiteral("peer=%1 room=%2 generation=%3 current_generation=%4 reason=invalid_or_duplicate")
+                                    .arg(pingUserLabel(fromUserId)).arg(roomId)
+                                    .arg(generation).arg(currentGeneration));
+            return;
+        }
+
+        if (!m_icePeerIds.contains(fromUserId))
+        {
+            LobbyIce::remove_peer(fromUserId);
+            m_iceGenerations[fromUserId] = generation;
+            m_iceRestartAttempts[fromUserId] =
+                m_iceRestartAttempts.value(fromUserId, 0) + 1;
+            writePingDiagnostic(QStringLiteral("ICE_RESTART_IN_QUEUED"),
+                                QStringLiteral("peer=%1 room=%2 generation=%3")
+                                    .arg(pingUserLabel(fromUserId)).arg(roomId).arg(generation));
+            return;
+        }
+
+        restartIcePeer(fromUserId, generation, QStringLiteral("remote_request"), false);
+        return;
+    }
+
+    // A generation-scoped description is also an implicit restart request.
+    // This covers a client that reconnects between the explicit restart and
+    // the new description without ever allowing old candidates into its agent.
+    if (generation > currentGeneration)
+    {
+        if (m_icePeerIds.contains(fromUserId))
+            restartIcePeer(fromUserId, generation, QStringLiteral("new_generation_signal"), false);
+        else
+        {
+            LobbyIce::remove_peer(fromUserId);
+            m_iceGenerations[fromUserId] = generation;
+        }
+    }
+
     const QString value = data.value("value").toString();
     const bool hadPeer = LobbyIce::has_peer(fromUserId);
     const bool accepted = LobbyIce::handle_remote_signal(fromUserId, kind.toStdString(),
                                                          value.toStdString());
     writePingDiagnostic(QStringLiteral("ICE_SIGNAL_IN"),
-                        QStringLiteral("peer=%1 room=%2 kind=%3 disposition=%4 accepted=%5 %6")
+                        QStringLiteral("peer=%1 room=%2 kind=%3 generation=%4 disposition=%5 accepted=%6 %7")
                             .arg(pingUserLabel(fromUserId)).arg(roomId).arg(kind)
+                            .arg(generation)
                             .arg(hadPeer ? QStringLiteral("applied") : QStringLiteral("queued"))
                             .arg(accepted ? QStringLiteral("true") : QStringLiteral("false"))
                             .arg(iceSignalSummary(kind, value)));
+}
+
+bool LobbyClient::restartIcePeer(quint64 userId, quint32 generation,
+                                 const QString& reason, bool notifyPeer)
+{
+    if (m_currentIceRoomId == 0 || !m_icePeerIds.contains(userId) ||
+        generation == 0 || generation <= m_iceGenerations.value(userId, 0) ||
+        m_iceRestartAttempts.value(userId, 0) >= MAX_ICE_AUTO_RESTARTS)
+    {
+        return false;
+    }
+
+    if (notifyPeer)
+    {
+        QJsonObject data;
+        data["targetUserId"] = QJsonValue(qint64(userId));
+        data["roomId"] = QJsonValue(qint64(m_currentIceRoomId));
+        data["kind"] = QStringLiteral("restart");
+        data["generation"] = int(generation);
+        writePingDiagnostic(QStringLiteral("ICE_RESTART_OUT"),
+                            QStringLiteral("peer=%1 room=%2 generation=%3 reason=%4")
+                                .arg(pingUserLabel(userId)).arg(m_currentIceRoomId)
+                                .arg(generation).arg(reason));
+        sendEnvelope("ICE_SIGNAL", data);
+    }
+
+    m_iceGenerations[userId] = generation;
+    m_iceRestartAttempts[userId] = m_iceRestartAttempts.value(userId, 0) + 1;
+    m_lastIceStates.remove(userId);
+    emit icePeerConnectionAttemptChanged(
+        userId, m_iceRestartAttempts.value(userId) + 1,
+        MAX_ICE_CONNECTION_ATTEMPTS);
+
+    for (auto it = m_pendingProbes.begin(); it != m_pendingProbes.end();)
+    {
+        if (it->targetUserId == userId)
+            it = m_pendingProbes.erase(it);
+        else
+            ++it;
+    }
+
+    LobbyIce::remove_peer(userId);
+    const bool added = LobbyIce::add_peer(userId);
+    writePingDiagnostic(QStringLiteral("ICE_RESTART_APPLIED"),
+                        QStringLiteral("peer=%1 room=%2 generation=%3 reason=%4 added=%5")
+                            .arg(pingUserLabel(userId)).arg(m_currentIceRoomId)
+                            .arg(generation).arg(reason)
+                            .arg(added ? QStringLiteral("true") : QStringLiteral("false")));
+    if (!added)
+        emit icePeerConnectionChanged(userId, false, true);
+    return added;
 }
 
 void LobbyClient::sendIcePing(quint64 userId, quint64 nonce)
@@ -1078,14 +1199,16 @@ void LobbyClient::flushIceEvents()
             data["targetUserId"] = QJsonValue(qint64(signal.peerUserId));
             data["roomId"] = QJsonValue(qint64(m_currentIceRoomId));
             data["kind"] = QString::fromStdString(signal.kind);
+            data["generation"] = int(m_iceGenerations.value(signal.peerUserId, 0));
             if (!signal.value.empty())
                 data["value"] = QString::fromStdString(signal.value);
             const QString kind = QString::fromStdString(signal.kind);
             const QString value = QString::fromStdString(signal.value);
             writePingDiagnostic(QStringLiteral("ICE_SIGNAL_OUT"),
-                                QStringLiteral("peer=%1 room=%2 kind=%3 %4")
+                                QStringLiteral("peer=%1 room=%2 kind=%3 generation=%4 %5")
                                     .arg(pingUserLabel(signal.peerUserId))
                                     .arg(m_currentIceRoomId).arg(kind)
+                                    .arg(m_iceGenerations.value(signal.peerUserId, 0))
                                     .arg(iceSignalSummary(kind, value)));
             sendEnvelope("ICE_SIGNAL", data);
         }
@@ -1154,6 +1277,7 @@ void LobbyClient::flushIceEvents()
         emit pingProbeMeasured(packet.peerUserId, rttMs);
     }
 
+    std::vector<quint64> peersToRestart;
     for (quint64 userId : std::as_const(m_icePeerIds))
     {
         const int state = static_cast<int>(LobbyIce::peer_state(userId));
@@ -1166,6 +1290,16 @@ void LobbyClient::flushIceEvents()
                                 .arg(QString::fromStdString(LobbyIce::peer_selected_addresses(userId))));
         const bool connected = LobbyIce::peer_connected(userId);
         const bool failed = state == static_cast<int>(LobbyIcePeerState::Failed);
+        if (failed && m_iceRestartAttempts.value(userId, 0) < MAX_ICE_AUTO_RESTARTS)
+        {
+            // Keep the seat in its connecting state while the coordinated
+            // replacement happens; only the fresh session's failure is final.
+            emit icePeerConnectionChanged(userId, false, false);
+            peersToRestart.push_back(userId);
+            continue;
+        }
+        if (state == static_cast<int>(LobbyIcePeerState::Completed))
+            m_iceRestartAttempts[userId] = 0;
         emit icePeerConnectionChanged(userId, connected, failed);
         if (connected && userId == m_currentIceHostUserId)
         {
@@ -1175,6 +1309,12 @@ void LobbyClient::flushIceEvents()
             for (auto it = m_measuredPing.constBegin(); it != m_measuredPing.constEnd(); ++it)
                 sendRoomPingReport(it.key(), it.value());
         }
+    }
+
+    for (quint64 userId : peersToRestart)
+    {
+        const quint32 nextGeneration = m_iceGenerations.value(userId, 0) + 1;
+        restartIcePeer(userId, nextGeneration, QStringLiteral("connectivity_failed"), true);
     }
 }
 
@@ -2761,12 +2901,15 @@ void LobbyClient::startRoom()
     sendEnvelope("ROOM_START");
 }
 
-void LobbyClient::updateLocalFrameDelay(int delay, bool delayAuto)
+void LobbyClient::updateLocalRollbackSettings(int delay, bool delayAuto,
+                                              int prediction, bool predictionAuto)
 {
     QJsonObject d;
     d["delay"] = delay;
     d["delayAuto"] = delayAuto;
-    sendEnvelope("ROOM_UPDATE_DELAY", d);
+    d["prediction"] = prediction;
+    d["predictionAuto"] = predictionAuto;
+    sendEnvelope("ROOM_UPDATE_PLAYER_SETTINGS", d);
 }
 
 void LobbyClient::kickFromRoom(quint64 userId)

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -147,10 +147,11 @@ public:
     // Server validates (host, waiting, valid slots) and rebroadcasts ROOM_STATE.
     void swapSeats(int slotA, int slotB);
 
-    // Publish this player's resolved local rollback settings for the room seat
-    // display. Each player owns both values independently.
-    void updateLocalRollbackSettings(int delay, bool delayAuto,
-                                     int prediction, bool predictionAuto);
+    // Publish this player's resolved local input delay for the room seat display.
+    void updateLocalFrameDelay(int delay, bool delayAuto);
+
+    // Publish the host-controlled prediction window for the whole room.
+    void updateRoomPrediction(int prediction, bool predictionAuto);
 
     // Ping probe over the already-selected ICE candidate pair. This measures
     // the same direct path that the rollback session will use.

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -147,9 +147,10 @@ public:
     // Server validates (host, waiting, valid slots) and rebroadcasts ROOM_STATE.
     void swapSeats(int slotA, int slotB);
 
-    // Publish this player's resolved local input delay for the room seat display.
-    // Each player owns this independently; Auto is resolved before sending.
-    void updateLocalFrameDelay(int delay, bool delayAuto);
+    // Publish this player's resolved local rollback settings for the room seat
+    // display. Each player owns both values independently.
+    void updateLocalRollbackSettings(int delay, bool delayAuto,
+                                     int prediction, bool predictionAuto);
 
     // Ping probe over the already-selected ICE candidate pair. This measures
     // the same direct path that the rollback session will use.
@@ -259,6 +260,7 @@ signals:
     // true only while a validated direct candidate pair is usable; `failed`
     // distinguishes an exhausted ICE attempt from one still in progress.
     void icePeerConnectionChanged(quint64 targetUserId, bool connected, bool failed);
+    void icePeerConnectionAttemptChanged(quint64 targetUserId, int attempt, int maxAttempts);
     // The host received a fresh RTT for a path between two other players.
     void roomPingMeasurementsChanged();
     // A burst went unanswered and we're sending another. `attempt` is 1-based
@@ -329,6 +331,8 @@ private:
     void handleIceSignal(const QJsonObject& data);
     void reconcileIcePeers(const QJsonObject& roomState);
     void resetIceMesh();
+    bool restartIcePeer(quint64 userId, quint32 generation,
+                        const QString& reason, bool notifyPeer);
     void flushIceEvents();
     void sendIcePing(quint64 userId, quint64 nonce);
     void sendRoomPingReport(quint64 targetUserId, int rttMs);
@@ -425,6 +429,11 @@ private:
     quint64 m_currentIceHostUserId = 0;
     QSet<quint64> m_icePeerIds;
     QHash<quint64, int> m_lastIceStates;
+    // Every restart replaces both libjuice agents for this pair. Generations
+    // scope trickled signals so candidates delayed from an old WebSocket
+    // session cannot be applied to the fresh credentials and UDP socket.
+    QHash<quint64, quint32> m_iceGenerations;
+    QHash<quint64, int> m_iceRestartAttempts;
     // Host-only matrix for non-host paths. To avoid duplicate reports, only
     // the lower user id measures/reports each unordered pair.
     QHash<quint64, QHash<quint64, int>> m_roomPeerPings;

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -107,9 +107,9 @@ int autoFrameDelayForPing(int ping)
     return 5;
 }
 
-// Lobby prediction is deliberately not user-configurable. All current clients
-// use the same generous rollback window.
-constexpr int kLobbyPredictionWindow = 9;
+// Prediction's per-player Default entry matches the earlier configurable
+// lobby behavior and Slippi's traditional default.
+constexpr int kDefaultPredictionWindow = 7;
 
 // Show the resolved value on the "Auto" entry, e.g. "Auto (3 f)".
 void setAutoComboLabel(QComboBox* combo, int resolved)
@@ -280,20 +280,23 @@ namespace
         return c.idle;
     }
 
-    // Right-aligned seat meta as rich text: an accent-colored HOST badge,
-    // ping-tier-colored "N ms", and the player's published local frame delay.
+    // Right-aligned seat meta as rich text: an accent-colored HOST badge, the
+    // player's local delay/prediction pair, then the ping-tier-colored "N ms".
     // Shared by renderSeatFilled and live refreshes so the render paths never
-    // drift. pingMs < 0 hides ping; frameDelay < 0 hides the delay.
+    // drift. Negative settings hide the pair; pingMs < 0 hides ping.
     // `status`, when set, replaces the ping cell — used to show a punch being
     // retried or given up on, so a peer we can't reach reads as a stated
     // outcome instead of a number that never appears.
-    QString seatMetaHtml(int slot, bool isHost, int pingMs, int frameDelay, bool dark,
-                         const QString& status = QString())
+    QString seatMetaHtml(int slot, bool isHost, int pingMs, int frameDelay,
+                         int predictionWindow, bool dark, const QString& status = QString())
     {
         QStringList parts;
         if (isHost)
             parts << QString("<span style='color:%1; font-weight:700;'>HOST</span>")
                          .arg(playerAccentHex(slot, dark));
+        if (frameDelay >= 0 && predictionWindow >= 0)
+            parts << QStringLiteral("<span style='font-weight:600;'>Delay/Prediction: %1f/%2f</span>")
+                         .arg(frameDelay).arg(predictionWindow);
         if (!status.isEmpty())
             parts << status;
         else if (pingMs >= 0)
@@ -318,11 +321,11 @@ namespace
     // Shown before the first ping can be sent. ICE negotiation may take a few
     // seconds on restrictive NATs, so leaving this cell blank makes a healthy
     // connection look stalled.
-    QString seatIceStatusHtml()
+    QString seatIceStatusHtml(int attempt = 1, int maxAttempts = 20)
     {
         const auto c = statusColors();
-        return QString("<span style='color:%1; font-weight:600;'>establishing connection…</span>")
-                   .arg(c.wait);
+        return QString("<span style='color:%1; font-weight:600;'>Connection attempt %2/%3…</span>")
+                   .arg(c.wait).arg(attempt).arg(maxAttempts);
     }
 
     QString seatIceFailedStatusHtml()
@@ -540,6 +543,8 @@ RollbackLobbyDialog::RollbackLobbyDialog(QWidget* parent)
     connect(m_client, &LobbyClient::matchPeerLeft,        this, &RollbackLobbyDialog::onMatchPeerLeft);
     connect(m_client, &LobbyClient::icePeerConnectionChanged,
             this, &RollbackLobbyDialog::onIcePeerConnectionChanged);
+    connect(m_client, &LobbyClient::icePeerConnectionAttemptChanged,
+            this, &RollbackLobbyDialog::onIcePeerConnectionAttemptChanged);
     connect(m_client, &LobbyClient::roomPingMeasurementsChanged,
             this, &RollbackLobbyDialog::onRoomPingMeasurementsChanged);
     connect(m_client, &LobbyClient::pingProbeMeasured,    this, &RollbackLobbyDialog::onPingMeasured);
@@ -755,7 +760,8 @@ QWidget* RollbackLobbyDialog::buildBrowseView()
     m_quickMatchBtn->setCursor(Qt::PointingHandCursor);
     m_quickMatchBtn->setToolTip(
         "Auto-match with another player searching for the selected game.\n"
-        "Uses your automatic frame delay and a fixed 9-frame prediction window.");
+        "Uses your automatic frame delay and default 7-frame prediction window.\n"
+        "Both can be changed per player during the warmup.");
 
     m_createRoomBtn = new QPushButton("Create Room…", this);
     m_createRoomBtn->setObjectName("CreateRoomBtn");
@@ -999,6 +1005,12 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         "Recommended: 2 for ~80ms RTT, 3-4 for ~150ms RTT.\n"
         "\n"
         "Local setting — each player may choose a different value.");
+    const QString predictionTip = QStringLiteral(
+        "Maximum frames the rollback engine may predict ahead.\n"
+        "Higher prediction tolerates longer network stalls but can produce larger rollbacks.\n"
+        "Default: 7 frames.\n"
+        "\n"
+        "Local setting — each player may choose a different value.");
 
     // Frame values exposed in the dropdown. 0 is intentionally omitted —
     // GekkoNet's zero-delay path still has open bugs (see project memory:
@@ -1028,6 +1040,19 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     m_delayCombo->setProperty("originalTip", delayTip);
     settingsRow->addWidget(delayLbl);
     settingsRow->addWidget(m_delayCombo);
+
+    settingsRow->addSpacing(SPACING_DEFAULT * 2);
+
+    auto* predictionLbl = new QLabel("Your prediction:", this);
+    m_predictionCombo = new QComboBox(this);
+    m_predictionCombo->setObjectName("LobbyCombo");
+    m_predictionCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    fillFrameCombo(m_predictionCombo,
+                   QStringLiteral("Default (%1 f)").arg(kDefaultPredictionWindow));
+    m_predictionCombo->setToolTip(predictionTip);
+    m_predictionCombo->setProperty("originalTip", predictionTip);
+    settingsRow->addWidget(predictionLbl);
+    settingsRow->addWidget(m_predictionCombo);
 
     settingsRow->addStretch(1);
     lay->addLayout(settingsRow);
@@ -1072,15 +1097,18 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     lay->addLayout(toggleRow);
 
-    // Delay is local: changing it never changes another player's value. The
-    // resolved number is published so it can be shown beside this player's seat.
-    auto applyDelay = [this]() {
+    // Both controls are local: changing them never changes another player's
+    // values. Resolved numbers are published for the seat display.
+    auto applySettings = [this]() {
         if (m_suppressSettingsSignal) return;
         if (m_currentRoomId == 0) return;
         m_delayAuto = (m_delayCombo->currentData().toInt() == 0);
-        applyLocalFrameDelay(true);
+        m_predictionAuto = (m_predictionCombo->currentData().toInt() == 0);
+        applyLocalRollbackSettings(true);
     };
-    connect(m_delayCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applyDelay);
+    connect(m_delayCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applySettings);
+    connect(m_predictionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, applySettings);
 
     // ── Seats — bold section header + vertical player-list rows ──
     auto* seatsHeader = new QLabel("SEATS", this);
@@ -1254,6 +1282,9 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
     s.isHost = false;
     s.userId = 0;
     s.frameDelay = -1;
+    s.predictionWindow = -1;
+    s.iceAttempt = 1;
+    s.iceMaxAttempts = 20;
 
     // Muted, dashed card — clearly "open seat" without competing with the
     // filled, color-tinted player cards.
@@ -1292,10 +1323,12 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
 }
 
 void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, bool isHost,
-                                           bool isSelf, int pingMs, int frameDelay, bool canKick)
+                                           bool isSelf, int pingMs, int frameDelay,
+                                           int predictionWindow, bool canKick)
 {
     s.isHost = isHost;
     s.frameDelay = frameDelay;
+    s.predictionWindow = predictionWindow;
     if (s.kickButton) s.kickButton->setVisible(canKick);
 
     const bool dark = isDarkTheme();
@@ -1344,7 +1377,8 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
         // Self is a local zero-latency endpoint. Remote ping appears after the
         // first reply; until then onRoomStateChanged supplies an ICE status.
         s.metaLabel->setText(
-            seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, frameDelay, dark));
+            seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, frameDelay,
+                         predictionWindow, dark));
     }
 }
 
@@ -2169,7 +2203,7 @@ void RollbackLobbyDialog::onHelloFailed(const QString& reason)
     else if (reason == "invalid_hello") human = "Server rejected the connection handshake.";
     else if (reason == "invalid_payload") human = "That username isn't allowed.";
     else if (reason == "version_mismatch") human =
-        "Your RMG-K client is out of date. This lobby requires RMG-K 9.13 "
+        "Your RMG-K client is out of date. This lobby requires RMG-K 0.9.13 "
         "or vdev-2367 or newer.";
     else if (reason == "server_full") human = "The lobby is currently full.";
 
@@ -2770,7 +2804,10 @@ void RollbackLobbyDialog::onRoomJoinFailed(const QString& reason)
     else if (reason == "already_started") human = "That game has already started.";
     else if (reason == "already_in_room") human = "You're already in a room.";
     else if (reason == "room_not_found")  human = "That room no longer exists.";
-    else if (reason == "kicked_recently") human = "You were recently removed from this room. Try again in a moment.";
+    else if (reason == "kicked_from_room") human =
+        "You were removed from this room and cannot rejoin.";
+    else if (reason == "kicked_recently") human =
+        "You were recently removed from this room. Try again in a moment.";
     QMessageBox::warning(this, "Couldn't join room", human);
 }
 
@@ -2787,17 +2824,19 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
     m_quickMatchActive = false;
     if (m_quickMatchBtn) m_quickMatchBtn->setText("⚡  Quick Match");
 
-    // Every freshly-entered room starts in Auto delay. It is a per-player
-    // selection, so reset this client's combo here instead of ever copying the
-    // legacy room delay from ROOM_STATE.
+    // Every freshly-entered room starts in Auto delay and Default prediction.
+    // Both are per-player selections and are never copied from legacy room state.
     m_delayAuto = true;
-    m_localDelayPublished = false;
+    m_predictionAuto = true;
+    m_localRollbackSettingsPublished = false;
     m_currentRoomDelay = autoFrameDelayForPing(-1);
-    if (m_delayCombo)
+    m_currentRoomPrediction = kDefaultPredictionWindow;
+    if (m_delayCombo && m_predictionCombo)
     {
         m_suppressSettingsSignal = true;
         m_delayCombo->setCurrentIndex(m_delayCombo->findData(0));
         setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
+        m_predictionCombo->setCurrentIndex(m_predictionCombo->findData(0));
         m_suppressSettingsSignal = false;
     }
 
@@ -2921,6 +2960,8 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     const QString romName = rom.value("name").toString();
     const QString romMd5 = rom.value("md5").toString();
     const QString romRegion = rom.value("region").toString();
+    const int legacyRoomPrediction = roomState.value("prediction")
+        .toInt(kDefaultPredictionWindow);
     const int pacing = roomState.value("pacing").toInt() == 1 ? 1 : 0;
     const int maxPlayers = roomState.value("maxPlayers").toInt();
     const QString state = roomState.value("state").toString();
@@ -2930,7 +2971,6 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     m_currentRoomGame       = romName;
     m_currentRoomMd5        = romMd5;
     m_currentRoomRegion     = romRegion;
-    m_currentRoomPrediction = kLobbyPredictionWindow;
     m_currentRoomPacing     = pacing;
     m_currentRoomHostId     = hostId;
 
@@ -2991,21 +3031,26 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         metaParts << QString("<b>Region:</b> %1").arg(romRegion);
     m_roomMetaLabel->setText(metaParts.join("  ·  "));
 
-    // Room refreshes never assign the local delay selection. Every player owns
-    // their combo; it only locks after the match begins.
-    if (m_delayCombo)
+    // Room refreshes never assign local rollback selections. Every player owns
+    // both combos; they only lock after the match begins.
+    if (m_delayCombo && m_predictionCombo)
     {
         static const QString tipDisabledMidMatch = QStringLiteral(
             "Can't change settings during a match.");
 
-        const bool delayEditable = state == "waiting";
+        const bool settingsEditable = state == "waiting";
         setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
-        m_delayCombo->setEnabled(delayEditable);
+        m_delayCombo->setEnabled(settingsEditable);
+        m_predictionCombo->setEnabled(settingsEditable);
 
-        const QString delayTip = delayEditable
+        const QString delayTip = settingsEditable
             ? m_delayCombo->property("originalTip").toString()
             : tipDisabledMidMatch;
+        const QString predictionTip = settingsEditable
+            ? m_predictionCombo->property("originalTip").toString()
+            : tipDisabledMidMatch;
         m_delayCombo->setToolTip(delayTip);
+        m_predictionCombo->setToolTip(predictionTip);
     }
 
     // Broadcasting is host-only — one authoritative stream per match. Hide the
@@ -3034,15 +3079,25 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         const int frameDelay = slotIsSelf
             ? m_currentRoomDelay
             : p.value("frameDelay").toInt(-1);
+        const int predictionWindow = slotIsSelf
+            ? m_currentRoomPrediction
+            : p.value("predictionWindow").toInt(legacyRoomPrediction);
         // The host can remove any seated player except themselves (the host seat).
         const bool canKick = iAmHost && !slotIsHost;
+        if (m_seats[slot - 1].userId != uid)
+        {
+            m_seats[slot - 1].iceAttempt = 1;
+            m_seats[slot - 1].iceMaxAttempts = 20;
+        }
         m_seats[slot - 1].userId = uid;
         renderSeatFilled(m_seats[slot - 1], user, slotIsHost, slotIsSelf,
-                         pingMs, frameDelay, canKick);
+                         pingMs, frameDelay, predictionWindow, canKick);
         if (!slotIsSelf && pingMs < 0 && m_seats[slot - 1].metaLabel)
             m_seats[slot - 1].metaLabel->setText(
-                seatMetaHtml(slot, slotIsHost, pingMs, frameDelay, isDarkTheme(),
-                             seatIceStatusHtml()));
+                seatMetaHtml(slot, slotIsHost, pingMs, frameDelay, predictionWindow,
+                             isDarkTheme(),
+                             seatIceStatusHtml(m_seats[slot - 1].iceAttempt,
+                                               m_seats[slot - 1].iceMaxAttempts)));
         filled[slot - 1] = true;
     }
     for (int i = 0; i < 4; ++i)
@@ -3104,7 +3159,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     // Re-resolve local Auto after seat changes too: a join/leave can change this
     // player's worst relevant path even before another probe result arrives.
     if (m_delayAuto)
-        applyLocalFrameDelay(false);
+        applyLocalRollbackSettings(false);
     refreshStartButton();
 }
 
@@ -3310,7 +3365,8 @@ void RollbackLobbyDialog::refreshSeatMeta(quint64 userId, const QString& statusH
         const bool isSelf = m_client && userId == m_client->selfUserId();
         const int pingMs = isSelf ? 0 : (m_client ? m_client->measuredPingMs(userId) : -1);
         s.metaLabel->setText(
-            seatMetaHtml(s.slot, s.isHost, pingMs, s.frameDelay, isDarkTheme(), statusHtml));
+            seatMetaHtml(s.slot, s.isHost, pingMs, s.frameDelay, s.predictionWindow,
+                         isDarkTheme(), statusHtml));
         break;
     }
 }
@@ -3329,9 +3385,37 @@ void RollbackLobbyDialog::onIcePeerConnectionChanged(quint64 userId, bool connec
     // Once ICE connects, probe immediately rather than waiting up to three
     // seconds for the periodic refresh timer.
     else if (m_client->measuredPingMs(userId) < 0)
-        refreshSeatMeta(userId, seatIceStatusHtml());
+    {
+        for (const auto& seat : m_seats)
+        {
+            if (seat.userId != userId)
+                continue;
+            refreshSeatMeta(userId,
+                seatIceStatusHtml(seat.iceAttempt, seat.iceMaxAttempts));
+            break;
+        }
+    }
     if (connected)
         m_client->requestPingProbe(userId);
+}
+
+void RollbackLobbyDialog::onIcePeerConnectionAttemptChanged(
+    quint64 userId, int attempt, int maxAttempts)
+{
+    if (!m_client || userId == m_client->selfUserId())
+        return;
+    for (auto& seat : m_seats)
+    {
+        if (seat.userId != userId)
+            continue;
+        seat.iceMaxAttempts = std::max(1, maxAttempts);
+        seat.iceAttempt = std::clamp(attempt, 1, seat.iceMaxAttempts);
+        // A fresh ICE generation invalidates the usefulness of any cached ping
+        // until this new path connects and is measured.
+        refreshSeatMeta(userId,
+            seatIceStatusHtml(seat.iceAttempt, seat.iceMaxAttempts));
+        break;
+    }
 }
 
 void RollbackLobbyDialog::onRoomPingMeasurementsChanged()
@@ -3400,14 +3484,15 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
         if (s.userId != userId || !s.metaLabel)
             continue;
         s.metaLabel->setText(
-            seatMetaHtml(s.slot, s.isHost, rttMs, s.frameDelay, isDarkTheme()));
+            seatMetaHtml(s.slot, s.isHost, rttMs, s.frameDelay, s.predictionWindow,
+                         isDarkTheme()));
         break;
     }
 
     // Auto delay follows this player's own direct peer RTTs. Every seated client
     // runs this path independently, so their resolved delays may differ.
     if (m_delayAuto)
-        applyLocalFrameDelay(false);
+        applyLocalRollbackSettings(false);
 
     // A peer's first ping may be what unblocks the host's Start button.
     refreshStartButton();
@@ -3450,20 +3535,26 @@ int RollbackLobbyDialog::worstLocalPeerPingMs() const
     return worst;
 }
 
-void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
+void RollbackLobbyDialog::applyLocalRollbackSettings(bool force)
 {
-    if (m_currentRoomId == 0 || m_currentRoomState != "waiting" || !m_delayCombo)
+    if (m_currentRoomId == 0 || m_currentRoomState != "waiting" ||
+        !m_delayCombo || !m_predictionCombo)
         return;
 
     const int delay = m_delayAuto
         ? autoFrameDelayForPing(worstLocalPeerPingMs())
         : m_delayCombo->currentData().toInt();
+    const int prediction = m_predictionAuto
+        ? kDefaultPredictionWindow
+        : m_predictionCombo->currentData().toInt();
     if (m_delayAuto)
         setAutoComboLabel(m_delayCombo, delay);
-    if (!force && delay == m_currentRoomDelay && m_localDelayPublished)
+    if (!force && delay == m_currentRoomDelay &&
+        prediction == m_currentRoomPrediction && m_localRollbackSettingsPublished)
         return;
 
     m_currentRoomDelay = delay;
+    m_currentRoomPrediction = prediction;
     if (m_client)
     {
         const quint64 selfId = m_client->selfUserId();
@@ -3472,6 +3563,7 @@ void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
             if (seat.userId != selfId)
                 continue;
             seat.frameDelay = delay;
+            seat.predictionWindow = prediction;
             refreshSeatMeta(selfId, QString());
             break;
         }
@@ -3482,11 +3574,13 @@ void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
     QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     s.setValue("Delay", delay);
+    s.setValue("Prediction", prediction);
     s.endGroup();
 
-    m_localDelayPublished = true;
+    m_localRollbackSettingsPublished = true;
     if (m_client)
-        m_client->updateLocalFrameDelay(delay, m_delayAuto);
+        m_client->updateLocalRollbackSettings(delay, m_delayAuto,
+                                              prediction, m_predictionAuto);
 }
 
 void RollbackLobbyDialog::onRoomLeft(const QString& reason)
@@ -3502,7 +3596,7 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
     m_currentRoomRegion.clear();
     m_currentRoomState.clear();
     m_currentRoomDelay = 2;
-    m_currentRoomPrediction = kLobbyPredictionWindow;
+    m_currentRoomPrediction = kDefaultPredictionWindow;
     m_currentRoomPacing = 0;
     m_currentRoomHostId = 0;
     m_currentMatchId = 0;
@@ -3512,7 +3606,7 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
     m_emulationActive = false;
     m_knownSeatedUsers.clear();
     m_roomSeatsSeen = false;
-    m_localDelayPublished = false;
+    m_localRollbackSettingsPublished = false;
 
     if (m_chatViewRoom) m_chatViewRoom->clear();
     if (m_roomChatInput) m_roomChatInput->setEnabled(false);
@@ -4089,8 +4183,8 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     appendChatSystemLine(CHANNEL_LOBBY, line);
     appendChatSystemLine(CHANNEL_ROOM,  line);
 
-    // Delay is local now, so show each player their own resolved value without
-    // broadcasting a misleading room-wide setting.
+    // Both rollback settings are local, so show each player their own resolved
+    // values without implying that they are room-wide.
     {
         QString delayMsg;
         if (m_delayAuto)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -107,7 +107,7 @@ int autoFrameDelayForPing(int ping)
     return 5;
 }
 
-// Prediction's per-player Default entry matches the earlier configurable
+// The host-controlled room prediction defaults to the earlier configurable
 // lobby behavior and Slippi's traditional default.
 constexpr int kDefaultPredictionWindow = 7;
 
@@ -281,22 +281,22 @@ namespace
     }
 
     // Right-aligned seat meta as rich text: an accent-colored HOST badge, the
-    // player's local delay/prediction pair, then the ping-tier-colored "N ms".
+    // player's local frame delay, then the ping-tier-colored "N ms".
     // Shared by renderSeatFilled and live refreshes so the render paths never
-    // drift. Negative settings hide the pair; pingMs < 0 hides ping.
+    // drift. A negative delay hides it; pingMs < 0 hides ping.
     // `status`, when set, replaces the ping cell — used to show a punch being
     // retried or given up on, so a peer we can't reach reads as a stated
     // outcome instead of a number that never appears.
     QString seatMetaHtml(int slot, bool isHost, int pingMs, int frameDelay,
-                         int predictionWindow, bool dark, const QString& status = QString())
+                         bool dark, const QString& status = QString())
     {
         QStringList parts;
         if (isHost)
             parts << QString("<span style='color:%1; font-weight:700;'>HOST</span>")
                          .arg(playerAccentHex(slot, dark));
-        if (frameDelay >= 0 && predictionWindow >= 0)
-            parts << QStringLiteral("<span style='font-weight:600;'>Delay/Prediction: %1f/%2f</span>")
-                         .arg(frameDelay).arg(predictionWindow);
+        if (frameDelay >= 0)
+            parts << QStringLiteral("<span style='font-weight:600;'>Frame delay: %1f</span>")
+                         .arg(frameDelay);
         if (!status.isEmpty())
             parts << status;
         else if (pingMs >= 0)
@@ -1007,19 +1007,16 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         "Higher prediction tolerates longer network stalls but can produce larger rollbacks.\n"
         "Default: 7 frames.\n"
         "\n"
-        "Local setting — each player may choose a different value.");
+        "Room setting — only the host may change this value.");
 
-    // Frame values exposed in the dropdown. 0 is intentionally omitted —
-    // GekkoNet's zero-delay path still has open bugs (see project memory:
-    // 0-delay host crash with non-zero analog drift), so we hide it from
-    // users until that's resolved. Editing this list updates the UI; the
-    // server's clamp range governs what values it'll actually accept.
-    static const QList<int> FRAME_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    // The Auto entry is data 0 (a value the numeric list never uses). It resolves
-    // independently from this client's direct pings to the other seats.
-    auto fillFrameCombo = [](QComboBox* combo, const QString& autoLabel) {
-        combo->addItem(autoLabel, 0);
-        for (int v : FRAME_OPTIONS)
+    static const QList<int> DELAY_OPTIONS = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    static const QList<int> PREDICTION_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    // Delay uses -1 for Auto so numeric zero remains selectable. Prediction can
+    // continue using zero as its Default sentinel because its range begins at 1.
+    auto fillFrameCombo = [](QComboBox* combo, const QString& autoLabel,
+                             int sentinel, const QList<int>& options) {
+        combo->addItem(autoLabel, sentinel);
+        for (int v : options)
             combo->addItem(QString("%1 f").arg(v), v);
         combo->setCurrentIndex(0); // default to Auto
     };
@@ -1030,7 +1027,7 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
     // Re-measure when the Auto entry grows into "Auto (2 f)" so the resolved
     // value isn't clipped.
     m_delayCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    fillFrameCombo(m_delayCombo, "Auto");
+    fillFrameCombo(m_delayCombo, "Auto", -1, DELAY_OPTIONS);
     m_delayCombo->setToolTip(delayTip);
     // Stash the explainer so onRoomStateChanged can restore it after a
     // disabled stint (host became host again, or match ended).
@@ -1040,12 +1037,13 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     settingsRow->addSpacing(SPACING_DEFAULT * 2);
 
-    auto* predictionLbl = new QLabel("Your prediction:", this);
+    auto* predictionLbl = new QLabel("Prediction:", this);
     m_predictionCombo = new QComboBox(this);
     m_predictionCombo->setObjectName("LobbyCombo");
     m_predictionCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     fillFrameCombo(m_predictionCombo,
-                   QStringLiteral("Default (%1 f)").arg(kDefaultPredictionWindow));
+                   QStringLiteral("Default (%1 f)").arg(kDefaultPredictionWindow),
+                   0, PREDICTION_OPTIONS);
     m_predictionCombo->setToolTip(predictionTip);
     m_predictionCombo->setProperty("originalTip", predictionTip);
     settingsRow->addWidget(predictionLbl);
@@ -1094,18 +1092,26 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
 
     lay->addLayout(toggleRow);
 
-    // Both controls are local: changing them never changes another player's
-    // values. Resolved numbers are published for the seat display.
-    auto applySettings = [this]() {
+    // Delay is local to each player and is published for the seat display.
+    auto applyDelay = [this]() {
         if (m_suppressSettingsSignal) return;
         if (m_currentRoomId == 0) return;
-        m_delayAuto = (m_delayCombo->currentData().toInt() == 0);
-        m_predictionAuto = (m_predictionCombo->currentData().toInt() == 0);
-        applyLocalRollbackSettings(true);
+        m_delayAuto = (m_delayCombo->currentData().toInt() == -1);
+        applyLocalFrameDelay(true);
     };
-    connect(m_delayCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applySettings);
+    connect(m_delayCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, applyDelay);
+
+    // Prediction is authoritative room state. The server repeats the host check
+    // so enabling this widget in a modified client cannot grant permission.
+    auto applyPrediction = [this]() {
+        if (m_suppressSettingsSignal) return;
+        if (m_currentRoomId == 0) return;
+        m_predictionAuto = (m_predictionCombo->currentData().toInt() == 0);
+        applyRoomPrediction(true);
+    };
     connect(m_predictionCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, applySettings);
+            this, applyPrediction);
 
     // ── Seats — bold section header + vertical player-list rows ──
     auto* seatsHeader = new QLabel("SEATS", this);
@@ -1279,7 +1285,6 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
     s.isHost = false;
     s.userId = 0;
     s.frameDelay = -1;
-    s.predictionWindow = -1;
     s.iceAttempt = 1;
     s.iceMaxAttempts = 20;
 
@@ -1320,12 +1325,10 @@ void RollbackLobbyDialog::renderSeatEmpty(SeatRow& s)
 }
 
 void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, bool isHost,
-                                           bool isSelf, int pingMs, int frameDelay,
-                                           int predictionWindow, bool canKick)
+                                           bool isSelf, int pingMs, int frameDelay, bool canKick)
 {
     s.isHost = isHost;
     s.frameDelay = frameDelay;
-    s.predictionWindow = predictionWindow;
     if (s.kickButton) s.kickButton->setVisible(canKick);
 
     const bool dark = isDarkTheme();
@@ -1374,8 +1377,7 @@ void RollbackLobbyDialog::renderSeatFilled(SeatRow& s, const QString& username, 
         // Self is a local zero-latency endpoint. Remote ping appears after the
         // first reply; until then onRoomStateChanged supplies an ICE status.
         s.metaLabel->setText(
-            seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, frameDelay,
-                         predictionWindow, dark));
+            seatMetaHtml(s.slot, isHost, isSelf ? 0 : pingMs, frameDelay, dark));
     }
 }
 
@@ -2821,17 +2823,17 @@ void RollbackLobbyDialog::enterRoom(quint64 roomId, const QString& greetingChatL
     m_quickMatchActive = false;
     if (m_quickMatchBtn) m_quickMatchBtn->setText("⚡  Quick Match");
 
-    // Every freshly-entered room starts in Auto delay and Default prediction.
-    // Both are per-player selections and are never copied from legacy room state.
+    // Every freshly-entered room starts in Auto delay while waiting for the
+    // authoritative room prediction to arrive in ROOM_STATE.
     m_delayAuto = true;
     m_predictionAuto = true;
-    m_localRollbackSettingsPublished = false;
+    m_localDelayPublished = false;
     m_currentRoomDelay = autoFrameDelayForPing(-1);
     m_currentRoomPrediction = kDefaultPredictionWindow;
     if (m_delayCombo && m_predictionCombo)
     {
         m_suppressSettingsSignal = true;
-        m_delayCombo->setCurrentIndex(m_delayCombo->findData(0));
+        m_delayCombo->setCurrentIndex(m_delayCombo->findData(-1));
         setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
         m_predictionCombo->setCurrentIndex(m_predictionCombo->findData(0));
         m_suppressSettingsSignal = false;
@@ -2957,8 +2959,9 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     const QString romName = rom.value("name").toString();
     const QString romMd5 = rom.value("md5").toString();
     const QString romRegion = rom.value("region").toString();
-    const int legacyRoomPrediction = roomState.value("prediction")
-        .toInt(kDefaultPredictionWindow);
+    const int roomPrediction = std::clamp(
+        roomState.value("prediction").toInt(kDefaultPredictionWindow), 1, 9);
+    const bool roomPredictionAuto = roomState.value("predictionAuto").toBool(true);
     const int pacing = roomState.value("pacing").toInt() == 1 ? 1 : 0;
     const int maxPlayers = roomState.value("maxPlayers").toInt();
     const QString state = roomState.value("state").toString();
@@ -2968,6 +2971,8 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     m_currentRoomGame       = romName;
     m_currentRoomMd5        = romMd5;
     m_currentRoomRegion     = romRegion;
+    m_currentRoomPrediction = roomPrediction;
+    m_predictionAuto        = roomPredictionAuto;
     m_currentRoomPacing     = pacing;
     m_currentRoomHostId     = hostId;
 
@@ -3028,24 +3033,35 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         metaParts << QString("<b>Region:</b> %1").arg(romRegion);
     m_roomMetaLabel->setText(metaParts.join("  ·  "));
 
-    // Room refreshes never assign local rollback selections. Every player owns
-    // both combos; they only lock after the match begins.
+    // Delay remains local to every player. Prediction mirrors authoritative
+    // room state and is editable only by the host while waiting.
     if (m_delayCombo && m_predictionCombo)
     {
         static const QString tipDisabledMidMatch = QStringLiteral(
             "Can't change settings during a match.");
+        static const QString tipHostControlled = QStringLiteral(
+            "Only the room host can change the prediction window.");
 
-        const bool settingsEditable = state == "waiting";
+        const bool delayEditable = state == "waiting";
+        const bool predictionEditable = delayEditable && iAmHost;
         setAutoComboLabel(m_delayCombo, m_currentRoomDelay);
-        m_delayCombo->setEnabled(settingsEditable);
-        m_predictionCombo->setEnabled(settingsEditable);
+        m_delayCombo->setEnabled(delayEditable);
 
-        const QString delayTip = settingsEditable
+        m_suppressSettingsSignal = true;
+        const int predictionData = roomPredictionAuto ? 0 : roomPrediction;
+        const int predictionIndex = m_predictionCombo->findData(predictionData);
+        if (predictionIndex >= 0)
+            m_predictionCombo->setCurrentIndex(predictionIndex);
+        m_suppressSettingsSignal = false;
+        m_predictionCombo->setEnabled(predictionEditable);
+
+        const QString delayTip = delayEditable
             ? m_delayCombo->property("originalTip").toString()
             : tipDisabledMidMatch;
-        const QString predictionTip = settingsEditable
-            ? m_predictionCombo->property("originalTip").toString()
-            : tipDisabledMidMatch;
+        const QString predictionTip = state != "waiting"
+            ? tipDisabledMidMatch
+            : (iAmHost ? m_predictionCombo->property("originalTip").toString()
+                       : tipHostControlled);
         m_delayCombo->setToolTip(delayTip);
         m_predictionCombo->setToolTip(predictionTip);
     }
@@ -3076,9 +3092,6 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         const int frameDelay = slotIsSelf
             ? m_currentRoomDelay
             : p.value("frameDelay").toInt(-1);
-        const int predictionWindow = slotIsSelf
-            ? m_currentRoomPrediction
-            : p.value("predictionWindow").toInt(legacyRoomPrediction);
         // The host can remove any seated player except themselves (the host seat).
         const bool canKick = iAmHost && !slotIsHost;
         if (m_seats[slot - 1].userId != uid)
@@ -3088,11 +3101,10 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
         }
         m_seats[slot - 1].userId = uid;
         renderSeatFilled(m_seats[slot - 1], user, slotIsHost, slotIsSelf,
-                         pingMs, frameDelay, predictionWindow, canKick);
+                         pingMs, frameDelay, canKick);
         if (!slotIsSelf && pingMs < 0 && m_seats[slot - 1].metaLabel)
             m_seats[slot - 1].metaLabel->setText(
-                seatMetaHtml(slot, slotIsHost, pingMs, frameDelay, predictionWindow,
-                             isDarkTheme(),
+                seatMetaHtml(slot, slotIsHost, pingMs, frameDelay, isDarkTheme(),
                              seatIceStatusHtml(m_seats[slot - 1].iceAttempt,
                                                m_seats[slot - 1].iceMaxAttempts)));
         filled[slot - 1] = true;
@@ -3156,7 +3168,7 @@ void RollbackLobbyDialog::onRoomStateChanged(const QJsonObject& roomState)
     // Re-resolve local Auto after seat changes too: a join/leave can change this
     // player's worst relevant path even before another probe result arrives.
     if (m_delayAuto)
-        applyLocalRollbackSettings(false);
+        applyLocalFrameDelay(false);
     refreshStartButton();
 }
 
@@ -3362,7 +3374,7 @@ void RollbackLobbyDialog::refreshSeatMeta(quint64 userId, const QString& statusH
         const bool isSelf = m_client && userId == m_client->selfUserId();
         const int pingMs = isSelf ? 0 : (m_client ? m_client->measuredPingMs(userId) : -1);
         s.metaLabel->setText(
-            seatMetaHtml(s.slot, s.isHost, pingMs, s.frameDelay, s.predictionWindow,
+            seatMetaHtml(s.slot, s.isHost, pingMs, s.frameDelay,
                          isDarkTheme(), statusHtml));
         break;
     }
@@ -3481,15 +3493,14 @@ void RollbackLobbyDialog::onPingMeasured(quint64 userId, int rttMs)
         if (s.userId != userId || !s.metaLabel)
             continue;
         s.metaLabel->setText(
-            seatMetaHtml(s.slot, s.isHost, rttMs, s.frameDelay, s.predictionWindow,
-                         isDarkTheme()));
+            seatMetaHtml(s.slot, s.isHost, rttMs, s.frameDelay, isDarkTheme()));
         break;
     }
 
     // Auto delay follows this player's own direct peer RTTs. Every seated client
     // runs this path independently, so their resolved delays may differ.
     if (m_delayAuto)
-        applyLocalRollbackSettings(false);
+        applyLocalFrameDelay(false);
 
     // A peer's first ping may be what unblocks the host's Start button.
     refreshStartButton();
@@ -3532,26 +3543,20 @@ int RollbackLobbyDialog::worstLocalPeerPingMs() const
     return worst;
 }
 
-void RollbackLobbyDialog::applyLocalRollbackSettings(bool force)
+void RollbackLobbyDialog::applyLocalFrameDelay(bool force)
 {
-    if (m_currentRoomId == 0 || m_currentRoomState != "waiting" ||
-        !m_delayCombo || !m_predictionCombo)
+    if (m_currentRoomId == 0 || m_currentRoomState != "waiting" || !m_delayCombo)
         return;
 
     const int delay = m_delayAuto
         ? autoFrameDelayForPing(worstLocalPeerPingMs())
         : m_delayCombo->currentData().toInt();
-    const int prediction = m_predictionAuto
-        ? kDefaultPredictionWindow
-        : m_predictionCombo->currentData().toInt();
     if (m_delayAuto)
         setAutoComboLabel(m_delayCombo, delay);
-    if (!force && delay == m_currentRoomDelay &&
-        prediction == m_currentRoomPrediction && m_localRollbackSettingsPublished)
+    if (!force && delay == m_currentRoomDelay && m_localDelayPublished)
         return;
 
     m_currentRoomDelay = delay;
-    m_currentRoomPrediction = prediction;
     if (m_client)
     {
         const quint64 selfId = m_client->selfUserId();
@@ -3560,7 +3565,6 @@ void RollbackLobbyDialog::applyLocalRollbackSettings(bool force)
             if (seat.userId != selfId)
                 continue;
             seat.frameDelay = delay;
-            seat.predictionWindow = prediction;
             refreshSeatMeta(selfId, QString());
             break;
         }
@@ -3571,13 +3575,34 @@ void RollbackLobbyDialog::applyLocalRollbackSettings(bool force)
     QSettings s("RMG-K", "n02");
     s.beginGroup("Lobby/CreateRoom");
     s.setValue("Delay", delay);
+    s.endGroup();
+
+    m_localDelayPublished = true;
+    if (m_client)
+        m_client->updateLocalFrameDelay(delay, m_delayAuto);
+}
+
+void RollbackLobbyDialog::applyRoomPrediction(bool force)
+{
+    if (m_currentRoomId == 0 || m_currentRoomState != "waiting" ||
+        !m_predictionCombo || !m_client ||
+        m_currentRoomHostId != m_client->selfUserId())
+        return;
+
+    const int prediction = m_predictionAuto
+        ? kDefaultPredictionWindow
+        : m_predictionCombo->currentData().toInt();
+    if (!force && prediction == m_currentRoomPrediction)
+        return;
+
+    m_currentRoomPrediction = prediction;
+
+    QSettings s("RMG-K", "n02");
+    s.beginGroup("Lobby/CreateRoom");
     s.setValue("Prediction", prediction);
     s.endGroup();
 
-    m_localRollbackSettingsPublished = true;
-    if (m_client)
-        m_client->updateLocalRollbackSettings(delay, m_delayAuto,
-                                              prediction, m_predictionAuto);
+    m_client->updateRoomPrediction(prediction, m_predictionAuto);
 }
 
 void RollbackLobbyDialog::onRoomLeft(const QString& reason)
@@ -3603,7 +3628,7 @@ void RollbackLobbyDialog::onRoomLeft(const QString& reason)
     m_emulationActive = false;
     m_knownSeatedUsers.clear();
     m_roomSeatsSeen = false;
-    m_localRollbackSettingsPublished = false;
+    m_localDelayPublished = false;
 
     if (m_chatViewRoom) m_chatViewRoom->clear();
     if (m_roomChatInput) m_roomChatInput->setEnabled(false);
@@ -4180,8 +4205,7 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     appendChatSystemLine(CHANNEL_LOBBY, line);
     appendChatSystemLine(CHANNEL_ROOM,  line);
 
-    // Both rollback settings are local, so show each player their own resolved
-    // values without implying that they are room-wide.
+    // Delay is local to this player; prediction is the host-controlled room value.
     {
         QString delayMsg;
         if (m_delayAuto)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -302,9 +302,6 @@ namespace
         else if (pingMs >= 0)
             parts << QString("<span style='color:%1; font-weight:600;'>%2 ms</span>")
                          .arg(pingHex(pingMs)).arg(pingMs);
-        if (frameDelay >= 0)
-            parts << QStringLiteral("<span style='font-weight:600;'>Frame Delay: %1f</span>")
-                         .arg(frameDelay);
         return parts.join(QStringLiteral("&nbsp;·&nbsp;"));
     }
 

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -111,11 +111,12 @@ int autoFrameDelayForPing(int ping)
 // lobby behavior and Slippi's traditional default.
 constexpr int kDefaultPredictionWindow = 7;
 
-// Show the resolved value on the "Auto" entry, e.g. "Auto (3 f)".
+// Show the resolved value on the delay combo's Auto entry (data -1),
+// e.g. "Auto (3 f)".
 void setAutoComboLabel(QComboBox* combo, int resolved)
 {
     if (!combo) return;
-    const int idx = combo->findData(0);
+    const int idx = combo->findData(-1);
     if (idx >= 0) combo->setItemText(idx, QStringLiteral("Auto (%1 f)").arg(resolved));
 }
 
@@ -1009,10 +1010,15 @@ QWidget* RollbackLobbyDialog::buildInRoomView()
         "\n"
         "Room setting — only the host may change this value.");
 
-    static const QList<int> DELAY_OPTIONS = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    // Delay 0 is intentionally omitted — GekkoNet's zero-delay path still has
+    // open bugs (see project memory: 0-delay host crash with non-zero analog
+    // drift), so we hide it from users until that's resolved. Editing this
+    // list updates the UI; the server's clamp range governs what values it'll
+    // actually accept.
+    static const QList<int> DELAY_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     static const QList<int> PREDICTION_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    // Delay uses -1 for Auto so numeric zero remains selectable. Prediction can
-    // continue using zero as its Default sentinel because its range begins at 1.
+    // Delay keeps -1 as its Auto sentinel; prediction uses zero as its Default
+    // sentinel since both ranges begin at 1.
     auto fillFrameCombo = [](QComboBox* combo, const QString& autoLabel,
                              int sentinel, const QList<int>& options) {
         combo->addItem(autoLabel, sentinel);

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -170,6 +170,7 @@ private slots:
     // Punch progress for a seated peer, so a slow or failing NAT punch is
     // visible in the room rather than looking like a stalled Start button.
     void onIcePeerConnectionChanged(quint64 userId, bool connected, bool failed);
+    void onIcePeerConnectionAttemptChanged(quint64 userId, int attempt, int maxAttempts);
     void onRoomPingMeasurementsChanged();
     void onPingProbeRetrying(quint64 userId, int attempt, int maxAttempts);
     void onPingProbeFailed(quint64 userId);
@@ -236,10 +237,10 @@ private:
     void    updateServerMeta();
     void    updateInRoomBanner();   // refresh "you're in: X" banner in browse view
 
-    // Delay is local to this player. Auto resolves only from this client's
-    // direct RTTs to the other seats.
+    // Delay and prediction are local to this player. Delay Auto resolves from
+    // this client's direct RTTs; prediction Default resolves to seven frames.
     int     worstLocalPeerPingMs() const;
-    void    applyLocalFrameDelay(bool force);
+    void    applyLocalRollbackSettings(bool force);
 
     // Broadcaster lifecycle. startBroadcast arms the n02 recording sink + drain
     // timer and sends BROADCAST_BEGIN; stopBroadcast flushes and sends
@@ -262,17 +263,21 @@ private:
         QLabel*  dotLabel  = nullptr;     // ● filled, ○ empty
         QLabel*  slotLabel = nullptr;     // "P1"
         QLabel*  nameLabel = nullptr;     // username or "Waiting…"
-        QLabel*  metaLabel = nullptr;     // "host · 12ms · Frame Delay: 2f"
+        QLabel*  metaLabel = nullptr;     // "host · Delay/Prediction: 2f/7f · 12ms"
         QPushButton* kickButton = nullptr; // ✕ — host-only, removes the seated player
         bool     isHost    = false;
         quint64  userId    = 0;           // seated user, 0 when empty
         int      slot      = 0;           // 1-4, drives the per-player accent color
         int      frameDelay = -1;          // published local input delay
+        int      predictionWindow = -1;    // published local prediction window
+        int      iceAttempt = 1;            // current ICE generation, one-based
+        int      iceMaxAttempts = 20;
     };
     void buildSeatRow(SeatRow& row, int slotIdx, QWidget* parent);
     void renderSeatEmpty(SeatRow& row);
     void renderSeatFilled(SeatRow& row, const QString& username, bool isHost,
-                          bool isSelf, int pingMs, int frameDelay, bool canKick);
+                          bool isSelf, int pingMs, int frameDelay,
+                          int predictionWindow, bool canKick);
 
     // Seat reorder (host, waiting): a seat's drag handle starts a QDrag carrying
     // its slot; the seats container handles the drop and asks the server to swap.
@@ -355,9 +360,10 @@ private:
     QLabel*    m_roomStateLabel = nullptr;   // "Waiting" / "In Game"
     QLabel*    m_roomMetaLabel  = nullptr;   // Seats 2/4 · Region NTSC
 
-    // Delay is locally editable by every player and locks once the match starts.
-    // Data 0 is the Auto sentinel; numeric entries contain concrete frame values.
+    // Both rollback values are locally editable and lock once the match starts.
+    // Data 0 is the Auto/Default sentinel; numeric entries are concrete values.
     QComboBox* m_delayCombo      = nullptr;
+    QComboBox* m_predictionCombo = nullptr;
     bool       m_suppressSettingsSignal = false;  // guard against ROOM_STATE → setCurrentIndex echo
 
     // Per-player local toggle: when checked, this client writes a .krec of the
@@ -434,7 +440,7 @@ private:
     QString m_currentRoomRegion;
     QString m_currentRoomState;
     int     m_currentRoomDelay      = 2;   // this client's local input delay
-    int     m_currentRoomPrediction = 9;
+    int     m_currentRoomPrediction = 7;
     int     m_currentRoomPacing     = 0;   // 0 = aggressive, 1 = smooth
     quint64 m_currentRoomHostId     = 0;   // seated host's user id (0 when none)
     quint64 m_currentMatchId        = 0;
@@ -447,9 +453,10 @@ private:
     QSet<quint64> m_knownSeatedUsers;
     bool          m_roomSeatsSeen = false;
 
-    // Delay-auto is local and ping-based for every player.
-    bool    m_delayAuto      = true;
-    bool    m_localDelayPublished = false;
+    // Both selections are local. Prediction's Default entry resolves to 7.
+    bool    m_delayAuto = true;
+    bool    m_predictionAuto = true;
+    bool    m_localRollbackSettingsPublished = false;
 
     bool m_awaitingEmulationStart = false;
     bool m_emulationActive        = false;

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -237,10 +237,11 @@ private:
     void    updateServerMeta();
     void    updateInRoomBanner();   // refresh "you're in: X" banner in browse view
 
-    // Delay and prediction are local to this player. Delay Auto resolves from
-    // this client's direct RTTs; prediction Default resolves to seven frames.
+    // Delay is local to this player. Auto resolves from this client's direct
+    // RTTs. Prediction is room-wide and may be changed only by the host.
     int     worstLocalPeerPingMs() const;
-    void    applyLocalRollbackSettings(bool force);
+    void    applyLocalFrameDelay(bool force);
+    void    applyRoomPrediction(bool force);
 
     // Broadcaster lifecycle. startBroadcast arms the n02 recording sink + drain
     // timer and sends BROADCAST_BEGIN; stopBroadcast flushes and sends
@@ -263,21 +264,19 @@ private:
         QLabel*  dotLabel  = nullptr;     // ● filled, ○ empty
         QLabel*  slotLabel = nullptr;     // "P1"
         QLabel*  nameLabel = nullptr;     // username or "Waiting…"
-        QLabel*  metaLabel = nullptr;     // "host · Delay/Prediction: 2f/7f · 12ms"
+        QLabel*  metaLabel = nullptr;     // "host · Frame delay: 2f · 12ms"
         QPushButton* kickButton = nullptr; // ✕ — host-only, removes the seated player
         bool     isHost    = false;
         quint64  userId    = 0;           // seated user, 0 when empty
         int      slot      = 0;           // 1-4, drives the per-player accent color
         int      frameDelay = -1;          // published local input delay
-        int      predictionWindow = -1;    // published local prediction window
         int      iceAttempt = 1;            // current ICE generation, one-based
         int      iceMaxAttempts = 20;
     };
     void buildSeatRow(SeatRow& row, int slotIdx, QWidget* parent);
     void renderSeatEmpty(SeatRow& row);
     void renderSeatFilled(SeatRow& row, const QString& username, bool isHost,
-                          bool isSelf, int pingMs, int frameDelay,
-                          int predictionWindow, bool canKick);
+                          bool isSelf, int pingMs, int frameDelay, bool canKick);
 
     // Seat reorder (host, waiting): a seat's drag handle starts a QDrag carrying
     // its slot; the seats container handles the drop and asks the server to swap.
@@ -360,8 +359,9 @@ private:
     QLabel*    m_roomStateLabel = nullptr;   // "Waiting" / "In Game"
     QLabel*    m_roomMetaLabel  = nullptr;   // Seats 2/4 · Region NTSC
 
-    // Both rollback values are locally editable and lock once the match starts.
-    // Data 0 is the Auto/Default sentinel; numeric entries are concrete values.
+    // Delay is locally editable for every player; prediction is room-wide and
+    // host-editable. Both lock once the match starts. Delay uses data -1 for
+    // Auto; prediction uses data 0 for Default.
     QComboBox* m_delayCombo      = nullptr;
     QComboBox* m_predictionCombo = nullptr;
     bool       m_suppressSettingsSignal = false;  // guard against ROOM_STATE → setCurrentIndex echo
@@ -453,10 +453,11 @@ private:
     QSet<quint64> m_knownSeatedUsers;
     bool          m_roomSeatsSeen = false;
 
-    // Both selections are local. Prediction's Default entry resolves to 7.
+    // Delay Auto is local. Prediction Auto is the host-owned room selection;
+    // its Default entry resolves to 7.
     bool    m_delayAuto = true;
     bool    m_predictionAuto = true;
-    bool    m_localRollbackSettingsPublished = false;
+    bool    m_localDelayPublished = false;
 
     bool m_awaitingEmulationStart = false;
     bool m_emulationActive        = false;


### PR DESCRIPTION
Improve p2p connection reliability (with more purposeful retries)
Host-controlled prediction frames dropdown menu is back!
Kicked people stay kicked, within the lifetime of that room

EDIT: No longer allows 0f delay... yet.