### PR TITLE
Server restart bug fix

### DIFF
--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.cpp
@@ -485,6 +485,15 @@ LobbyClient::~LobbyClient()
 void LobbyClient::connectToServer(const QString& wsUrl, const QString& username,
                                    const QStringList& romHashes, const QString& udpAddr)
 {
+    // HELLO_OK calls LobbyIce::configure(), which resets the process-wide ICE
+    // mesh. A running GekkoNet lobby match owns that mesh, so reconnecting now
+    // would sever otherwise healthy peer-to-peer gameplay. The lobby dialog
+    // offers the connection prompt again after emulation finishes.
+    if (m_matchTransportActive)
+    {
+        qWarning() << "lobby: reconnect deferred while match ICE transport is active";
+        return;
+    }
     if (m_state != ConnectionState::Disconnected && m_state != ConnectionState::Failed)
     {
         return;
@@ -538,8 +547,7 @@ void LobbyClient::disconnectFromServer()
     m_anchorRetryDeadlineMs = 0;
     m_heartbeatTimer->stop();
     m_udpKeepaliveTimer->stop();
-    resetIceMesh();
-    LobbyIce::reset();
+    resetIceTransport();
     if (m_ws && m_ws->state() != QAbstractSocket::UnconnectedState)
     {
         m_ws->close();
@@ -652,8 +660,11 @@ void LobbyClient::onWsConnected()
 void LobbyClient::onWsDisconnected()
 {
     stopPingDiagnosticLog(QStringLiteral("connection_lost"));
-    resetIceMesh();
-    LobbyIce::reset();
+    // The WebSocket is only ICE's signaling/control plane. Once a match has
+    // started, its established agents carry GekkoNet traffic peer-to-peer and
+    // must outlive a lobby restart or network interruption. Defer teardown
+    // until the emulation owner releases the transport.
+    resetIceTransport();
     // Passive drops (server restart, network cut, server-side kick) never go
     // through disconnectFromServer, so the anchor socket used to stay bound —
     // and the next connect's pinned-port bind then failed against our own
@@ -939,6 +950,12 @@ void LobbyClient::handleRoomJoinFail(const QJsonObject& data)
 
 void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
 {
+    // Room state is control-plane data. Once GekkoNet owns the established
+    // mesh, no server-side room transition may add, replace, or remove its
+    // transport agents; actual actor teardown is driven by emulation finish.
+    if (m_matchTransportActive)
+        return;
+
     const quint64 roomId = static_cast<quint64>(roomState.value("id").toDouble());
     if (roomId == 0)
         return;
@@ -1007,6 +1024,12 @@ void LobbyClient::reconcileIcePeers(const QJsonObject& roomState)
 
 void LobbyClient::resetIceMesh()
 {
+    if (m_matchTransportActive)
+    {
+        m_deferredIceMeshReset = true;
+        return;
+    }
+
     for (quint64 userId : std::as_const(m_icePeerIds))
         LobbyIce::remove_peer(userId);
     m_icePeerIds.clear();
@@ -1017,6 +1040,46 @@ void LobbyClient::resetIceMesh()
     m_currentIceHostUserId = 0;
     m_roomPeerPings.clear();
     m_pendingProbes.clear();
+}
+
+void LobbyClient::resetIceTransport()
+{
+    if (m_matchTransportActive)
+    {
+        // A full reset was requested (normally because the lobby WebSocket
+        // went away). Keep both the peer map and queued Gekko packets intact
+        // until the running match has actually stopped.
+        m_deferredIceTransportReset = true;
+        return;
+    }
+
+    resetIceMesh();
+    LobbyIce::reset();
+    m_deferredIceMeshReset = false;
+    m_deferredIceTransportReset = false;
+}
+
+void LobbyClient::setMatchTransportActive(bool active)
+{
+    if (m_matchTransportActive == active)
+        return;
+
+    m_matchTransportActive = active;
+    if (active)
+        return;
+
+    // A lobby disconnect requires a full reset, while an ordinary ROOM_LEFT
+    // only requires removal of the old room mesh. Full reset subsumes mesh
+    // reset and intentionally clears the obsolete lobby identity/config.
+    if (m_deferredIceTransportReset)
+    {
+        resetIceTransport();
+    }
+    else if (m_deferredIceMeshReset)
+    {
+        m_deferredIceMeshReset = false;
+        resetIceMesh();
+    }
 }
 
 void LobbyClient::handleIceSignal(const QJsonObject& data)
@@ -1041,6 +1104,18 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
                             QStringLiteral("peer=%1 room=%2 kind=%3 generation=%4 current_generation=%5 reason=stale_generation")
                                 .arg(pingUserLabel(fromUserId)).arg(roomId).arg(kind)
                                 .arg(generation).arg(currentGeneration));
+        return;
+    }
+
+    // Replacing an agent underneath GekkoNet interrupts the active data plane.
+    // Same-generation trickle candidates remain safe to apply, but ICE restart
+    // signaling is deferred until the match has released the mesh.
+    if (m_matchTransportActive &&
+        (kind == QStringLiteral("restart") || generation > currentGeneration))
+    {
+        writePingDiagnostic(QStringLiteral("ICE_SIGNAL_IN_DROPPED"),
+                            QStringLiteral("peer=%1 room=%2 kind=%3 generation=%4 reason=match_transport_active")
+                                .arg(pingUserLabel(fromUserId)).arg(roomId).arg(kind).arg(generation));
         return;
     }
 
@@ -1101,7 +1176,7 @@ void LobbyClient::handleIceSignal(const QJsonObject& data)
 bool LobbyClient::restartIcePeer(quint64 userId, quint32 generation,
                                  const QString& reason, bool notifyPeer)
 {
-    if (m_currentIceRoomId == 0 || !m_icePeerIds.contains(userId) ||
+    if (m_matchTransportActive || m_currentIceRoomId == 0 || !m_icePeerIds.contains(userId) ||
         generation == 0 || generation <= m_iceGenerations.value(userId, 0) ||
         m_iceRestartAttempts.value(userId, 0) >= MAX_ICE_AUTO_RESTARTS)
     {

--- a/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/LobbyClient.hpp
@@ -171,6 +171,14 @@ public:
     // error describes unsupported clients or the first incomplete peer.
     bool allIcePeersConnected(const QList<LobbyMatchPeer>& peers, QString* error = nullptr) const;
 
+    // The running GekkoNet match consumes the room's established libjuice
+    // agents directly. While active, lobby/room cleanup must not destroy those
+    // agents, and reconnect must be deferred because HELLO_OK reconfigures the
+    // process-wide ICE context. Cleanup requested during the match is applied
+    // when ownership is released after emulation stops.
+    void setMatchTransportActive(bool active);
+    bool matchTransportActive() const { return m_matchTransportActive; }
+
     // Quick match queue. The ROM (name + md5) scopes the search so the server
     // only pairs players queued for the same game; the name lets the matched
     // room resolve to a local ROM by name on both clients.
@@ -332,6 +340,7 @@ private:
     void handleIceSignal(const QJsonObject& data);
     void reconcileIcePeers(const QJsonObject& roomState);
     void resetIceMesh();
+    void resetIceTransport();
     bool restartIcePeer(quint64 userId, quint32 generation,
                         const QString& reason, bool notifyPeer);
     void flushIceEvents();
@@ -435,6 +444,9 @@ private:
     // session cannot be applied to the fresh credentials and UDP socket.
     QHash<quint64, quint32> m_iceGenerations;
     QHash<quint64, int> m_iceRestartAttempts;
+    bool m_matchTransportActive = false;
+    bool m_deferredIceMeshReset = false;
+    bool m_deferredIceTransportReset = false;
     // Host-only matrix for non-host paths. To avoid duplicate reports, only
     // the lower user id measures/reports each unordered pair.
     QHash<quint64, QHash<quint64, int>> m_roomPeerPings;

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -1910,8 +1910,9 @@ void RollbackLobbyDialog::refreshSameGameFilter()
 void RollbackLobbyDialog::showEvent(QShowEvent* event)
 {
     QDialog::showEvent(event);
-    if (m_client->state() == LobbyClient::ConnectionState::Disconnected ||
-        m_client->state() == LobbyClient::ConnectionState::Failed)
+    if (!matchTransportInProgress() &&
+        (m_client->state() == LobbyClient::ConnectionState::Disconnected ||
+         m_client->state() == LobbyClient::ConnectionState::Failed))
     {
         QTimer::singleShot(0, this, [this]() {
             if (!isVisible() || m_connectPromptOpen ||
@@ -2202,7 +2203,7 @@ QString RollbackLobbyDialog::prefillUsername() const
 
 void RollbackLobbyDialog::promptForUsername(const QString& statusMessage)
 {
-    if (m_connectPromptOpen || !isVisible() ||
+    if (m_connectPromptOpen || !isVisible() || matchTransportInProgress() ||
         m_client->state() == LobbyClient::ConnectionState::Connected)
         return;
 
@@ -2228,6 +2229,36 @@ void RollbackLobbyDialog::promptForUsername(const QString& statusMessage)
     m_client->connectToServer(m_serverUrl, m_username, {}, QString());
 }
 
+bool RollbackLobbyDialog::matchTransportInProgress() const
+{
+    return m_emulationActive || m_awaitingEmulationStart ||
+           (m_client && m_client->matchTransportActive());
+}
+
+void RollbackLobbyDialog::showMatchConnectionLostNotice()
+{
+    const QString notice = QStringLiteral(
+        "Error: lost connection to server. You can continue the game but without chat.");
+    if (m_connectPromptMessage.isEmpty())
+        m_connectPromptMessage = notice;
+
+    if (!m_matchConnectionLostNoticeShown)
+    {
+        appendChatSystemLine(CHANNEL_ROOM, notice);
+        emit matchServerConnectionLost(notice);
+        m_matchConnectionLostNoticeShown = true;
+    }
+
+    if (m_roomChatInput)
+        m_roomChatInput->setEnabled(false);
+    applyRoomStateBadge(QStringLiteral("Lobby offline — game continues"),
+                        QString(statusColors().fail));
+
+    // Broadcast and spectator traffic use the WebSocket, unlike gameplay.
+    // Detach the recording tee and stop attempting uploads while offline.
+    stopBroadcast();
+}
+
 // ──────────────────────────────────────────────────────────────────────
 //  Connection events
 // ──────────────────────────────────────────────────────────────────────
@@ -2237,6 +2268,8 @@ void RollbackLobbyDialog::onClientStateChanged(LobbyClient::ConnectionState s)
     updateStatusIndicator(s);
 
     const bool connected = (s == LobbyClient::ConnectionState::Connected);
+    if (connected)
+        m_matchConnectionLostNoticeShown = false;
     // Ping probing runs for the whole connection lifetime — it feeds the
     // players-list hover tooltips in the lobby, not just seated peers.
     if (m_pingProbeTimer)
@@ -2260,18 +2293,28 @@ void RollbackLobbyDialog::onClientStateChanged(LobbyClient::ConnectionState s)
         m_matchesTree->clear();
         m_userItems.clear();
         m_roomItems.clear();
-        m_currentRoomId = 0;
-        m_currentRoomState.clear();
-        m_currentMatchId = 0;
-        m_awaitingEmulationStart = false;
-        m_emulationActive = false;
         m_quickMatchActive = false;
         if (m_quickMatchBtn) m_quickMatchBtn->setText("⚡  Quick Match");
 
         if (m_chatViewLobby) m_chatViewLobby->clear();
-        if (m_chatViewRoom) m_chatViewRoom->clear();
-        if (m_roomChatInput) m_roomChatInput->setEnabled(false);
-        switchToRoomsView();
+        if (matchTransportInProgress())
+        {
+            // The room UI is useful as a non-modal status surface and its ICE
+            // agents are still the running game's data plane. Preserve match
+            // bookkeeping until emulation really finishes.
+            showMatchConnectionLostNotice();
+        }
+        else
+        {
+            m_currentRoomId = 0;
+            m_currentRoomState.clear();
+            m_currentMatchId = 0;
+            m_awaitingEmulationStart = false;
+            m_emulationActive = false;
+            if (m_chatViewRoom) m_chatViewRoom->clear();
+            if (m_roomChatInput) m_roomChatInput->setEnabled(false);
+            switchToRoomsView();
+        }
     }
     updateServerMeta();
     updateInRoomBanner();
@@ -2279,10 +2322,11 @@ void RollbackLobbyDialog::onClientStateChanged(LobbyClient::ConnectionState s)
     // A normal disconnect returns to the username prompt. Failed connections
     // are reopened by the error slots below so the server's message is retained.
     if (s == LobbyClient::ConnectionState::Disconnected && isVisible() &&
+        !matchTransportInProgress() &&
         !m_connectPromptOpen)
     {
         QTimer::singleShot(0, this, [this]() {
-            if (!isVisible() || m_connectPromptOpen ||
+            if (!isVisible() || m_connectPromptOpen || matchTransportInProgress() ||
                 m_client->state() == LobbyClient::ConnectionState::Connected)
                 return;
             const QString message = m_connectPromptMessage;
@@ -2304,8 +2348,13 @@ void RollbackLobbyDialog::onHelloFailed(const QString& reason)
     else if (reason == "server_full") human = "The lobby is currently full.";
 
     m_connectPromptMessage = human;
+    if (matchTransportInProgress())
+    {
+        showMatchConnectionLostNotice();
+        return;
+    }
     QTimer::singleShot(0, this, [this]() {
-        if (!isVisible() || m_connectPromptOpen)
+        if (!isVisible() || m_connectPromptOpen || matchTransportInProgress())
             return;
         const QString message = m_connectPromptMessage;
         m_connectPromptMessage.clear();
@@ -2316,8 +2365,13 @@ void RollbackLobbyDialog::onHelloFailed(const QString& reason)
 void RollbackLobbyDialog::onConnectError(const QString& msg)
 {
     m_connectPromptMessage = "Couldn't reach the lobby: " + msg;
+    if (matchTransportInProgress())
+    {
+        showMatchConnectionLostNotice();
+        return;
+    }
     QTimer::singleShot(0, this, [this]() {
-        if (!isVisible() || m_connectPromptOpen)
+        if (!isVisible() || m_connectPromptOpen || matchTransportInProgress())
             return;
         const QString message = m_connectPromptMessage;
         m_connectPromptMessage.clear();
@@ -3361,10 +3415,13 @@ void RollbackLobbyDialog::notifyEmulationFinished()
     // through the early-return below (it flushes the tail + sends BROADCAST_END).
     stopBroadcast();
 
-    if (!m_emulationActive && !m_awaitingEmulationStart) return;
+    const bool ownedMatchTransport = m_client && m_client->matchTransportActive();
+    if (!m_emulationActive && !m_awaitingEmulationStart && !ownedMatchTransport) return;
     const quint64 matchId = m_currentMatchId;
     m_emulationActive = false;
     m_awaitingEmulationStart = false;
+    if (m_client)
+        m_client->setMatchTransportActive(false);
 
     {
         char buf[128];
@@ -3376,6 +3433,23 @@ void RollbackLobbyDialog::notifyEmulationFinished()
         m_client->reportMatchFinished(matchId);
     m_currentMatchId = 0;
     if (m_dropBtn) m_dropBtn->setEnabled(false);
+
+    // A disconnect prompt suppressed during play becomes safe once the game no
+    // longer owns ICE. Offer reconnection now without ever stealing focus from
+    // active emulation.
+    if (m_client && isVisible() && !m_connectPromptOpen &&
+        (m_client->state() == LobbyClient::ConnectionState::Disconnected ||
+         m_client->state() == LobbyClient::ConnectionState::Failed))
+    {
+        QTimer::singleShot(0, this, [this]() {
+            if (!isVisible() || m_connectPromptOpen || matchTransportInProgress() ||
+                m_client->state() == LobbyClient::ConnectionState::Connected)
+                return;
+            const QString message = m_connectPromptMessage;
+            m_connectPromptMessage.clear();
+            promptForUsername(message);
+        });
+    }
 
 }
 
@@ -4250,6 +4324,8 @@ void RollbackLobbyDialog::abortMatchStart(const QString& reason)
     const quint64 matchId = m_currentMatchId;
     m_awaitingEmulationStart = false;
     m_currentMatchId = 0;
+    if (m_client)
+        m_client->setMatchTransportActive(false);
 
     // Cancel any launch the MainWindow may already be spinning up, and tell the
     // server the match is over so the room flips back to "waiting" for everyone
@@ -4462,6 +4538,10 @@ void RollbackLobbyDialog::onMatchBegin(quint64 matchId, const QList<LobbyClient:
     // here so the match definitively runs the host-selected model.
     CoreSettingsSetValue(SettingsID::Rollback_PacingMode, m_currentRoomPacing);
 
+    // From this point until notifyEmulationFinished, the GekkoNet adapter owns
+    // these established agents. Lobby disconnect/room cleanup is deferred so
+    // signaling loss cannot tear down the peer-to-peer data plane.
+    m_client->setMatchTransportActive(true);
     emit matchReady(m_currentRoomGame, localRomFile, remotePeers, int(localPort),
                     local.slot, m_currentRoomDelay, m_currentRoomPrediction);
 }

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.cpp
@@ -2225,6 +2225,10 @@ void RollbackLobbyDialog::promptForUsername(const QString& statusMessage)
     if (m_userLabel)
         m_userLabel->setText(QString("User: %1").arg(m_username));
 
+    // A new WebSocket session has no claim on a room from the previous server
+    // session. This is normally already cleared by the disconnect handler, but
+    // doing it here as well makes every reconnect start from a clean lobby.
+    clearServerRoomSnapshot();
     updateServerMeta();
     m_client->connectToServer(m_serverUrl, m_username, {}, QString());
 }
@@ -2299,21 +2303,18 @@ void RollbackLobbyDialog::onClientStateChanged(LobbyClient::ConnectionState s)
         if (m_chatViewLobby) m_chatViewLobby->clear();
         if (matchTransportInProgress())
         {
-            // The room UI is useful as a non-modal status surface and its ICE
-            // agents are still the running game's data plane. Preserve match
-            // bookkeeping until emulation really finishes.
+            // Only the active match and its established ICE agents survive a
+            // lobby outage. The room identity and roster are server-owned and
+            // are already stale, so remove them from the UI immediately.
             showMatchConnectionLostNotice();
+            clearServerRoomSnapshot();
         }
         else
         {
-            m_currentRoomId = 0;
-            m_currentRoomState.clear();
             m_currentMatchId = 0;
             m_awaitingEmulationStart = false;
             m_emulationActive = false;
-            if (m_chatViewRoom) m_chatViewRoom->clear();
-            if (m_roomChatInput) m_roomChatInput->setEnabled(false);
-            switchToRoomsView();
+            clearServerRoomSnapshot();
         }
     }
     updateServerMeta();
@@ -2776,6 +2777,52 @@ void RollbackLobbyDialog::switchToRoomsView()
 void RollbackLobbyDialog::switchToInRoomView()
 {
     if (m_roomsStack) m_roomsStack->setCurrentIndex(1);
+}
+
+void RollbackLobbyDialog::clearServerRoomSnapshot()
+{
+    // None of this state owns gameplay transport. Once the lobby connection is
+    // gone, retaining it can only display a room/roster that may no longer exist
+    // (the server keeps rooms in memory and loses them across a restart).
+    for (auto& seat : m_seats)
+    {
+        renderSeatEmpty(seat);
+        if (seat.dragHandle)
+            seat.dragHandle->setVisible(false);
+    }
+    m_canReorderSeats = false;
+
+    m_currentRoomId = 0;
+    m_currentRoomGame.clear();
+    m_currentRoomMd5.clear();
+    m_currentRoomRegion.clear();
+    m_currentRoomState.clear();
+    m_currentRoomDelay = 2;
+    m_currentRoomPrediction = kDefaultPredictionWindow;
+    m_currentRoomPacing = 0;
+    m_currentRoomHostId = 0;
+    m_iceWaitingMatchId = 0;
+    m_iceMatchDeadlineMs = 0;
+    m_knownSeatedUsers.clear();
+    m_roomSeatsSeen = false;
+    m_localDelayPublished = false;
+    m_probeFailureAnnounced.clear();
+
+    if (m_roomTitle) m_roomTitle->setText(QStringLiteral("—"));
+    if (m_roomSubtitle) m_roomSubtitle->setText(QStringLiteral("—"));
+    if (m_roomMetaLabel) m_roomMetaLabel->setText(QStringLiteral("—"));
+    if (m_chatViewRoom) m_chatViewRoom->clear();
+    if (m_roomChatInput)
+    {
+        m_roomChatInput->clear();
+        m_roomChatInput->setEnabled(false);
+    }
+    if (m_startBtn) m_startBtn->setEnabled(false);
+    if (m_dropBtn) m_dropBtn->setEnabled(false);
+    if (m_leaveBtn) m_leaveBtn->setEnabled(true);
+
+    switchToRoomsView();
+    updateInRoomBanner();
 }
 
 void RollbackLobbyDialog::refreshRoomRow(QTreeWidgetItem* item, const LobbyClient::LobbyRoomSummary& r)

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -235,6 +235,10 @@ private:
     void    notifyPlayerJoined();
     void    switchToRoomsView();
     void    switchToInRoomView();
+    // The room roster and metadata are server-owned and become invalid as soon
+    // as the WebSocket drops. Clear them without touching an active match's
+    // ICE ownership or lifecycle bookkeeping.
+    void    clearServerRoomSnapshot();
     void    enterRoom(quint64 roomId, const QString& greetingChatLine);
     void    updateStatusIndicator(LobbyClient::ConnectionState s);
     // Render the in-room state label as a colored pill (Waiting / Connecting /

--- a/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/Lobby/RollbackLobbyDialog.hpp
@@ -85,6 +85,10 @@ signals:
     // Fired when the user clicks "Close Game" mid-match or when a peer drops.
     void closeMatchRequested();
 
+    // Non-modal in-game warning: lobby-backed services (including chat) are
+    // offline, but the established peer-to-peer match transport is intact.
+    void matchServerConnectionLost(QString message);
+
     // Fired for every *remote* room-channel chat message (own messages are
     // filtered out — the overlay echoes those locally). MainWindow routes this
     // to the in-game chat overlay.
@@ -206,6 +210,8 @@ private:
     // No server connection is attempted until the prompt is accepted.
     void     promptForUsername(const QString& statusMessage = QString());
     QString  prefillUsername() const;
+    bool     matchTransportInProgress() const;
+    void     showMatchConnectionLostNotice();
 
     void refreshPlayerRow(QTreeWidgetItem* item, const LobbyClient::LobbyUser& u);
     void refreshRoomRow(QTreeWidgetItem* item, const LobbyClient::LobbyRoomSummary& r);
@@ -318,6 +324,7 @@ private:
 
     bool    m_connectPromptOpen = false;
     QString m_connectPromptMessage;
+    bool    m_matchConnectionLostNoticeShown = false;
 
     // ── Marquee bar ──
     QFrame*  m_marquee     = nullptr;

--- a/Source/RMG/UserInterface/MainWindow.cpp
+++ b/Source/RMG/UserInterface/MainWindow.cpp
@@ -4754,6 +4754,11 @@ void MainWindow::ensureRollbackLobbyDialog()
                 if (this->emulationThread && this->emulationThread->isRunning())
                     CoreStopEmulation();
             });
+    connect(this->rollbackLobbyDialog, &Dialog::RollbackLobbyDialog::matchServerConnectionLost,
+            this, [this](const QString& message) {
+                if (this->emulationThread && this->emulationThread->isRunning())
+                    OnScreenDisplaySetMessage(message.toStdString());
+            });
     // Remote room chat → in-game chat overlay (mirrors the P2P chat overlay).
     connect(this->rollbackLobbyDialog, &Dialog::RollbackLobbyDialog::roomChatReceived,
             this, &MainWindow::on_Lobby_RoomChatReceived);


### PR DESCRIPTION
Resolve an issue introduced in #188 where games would not be able to continue when the server restarted, despite there being p2p connections between users.

Now, the game continues, although chat does not. Users are notified they lost connection to the server. Only upon the game ending, it brings up the dialog allowing them to reconnect to the server. This way the dialog doesn't interrupt gameplay.

No server changes are required.