### PR TITLE
Enable cheats by default for Vanilla

### DIFF
--- a/Data/Cheats/Generated/916B8B5B-780B85A4-45.cht
+++ b/Data/Cheats/Generated/916B8B5B-780B85A4-45.cht
@@ -26,10 +26,6 @@ Note=Only put this on after you have alreay Chose your Character on the Main Men
 18 Polygon Kirby
 1A Giant Donkey Kong
 
-$Enable Item Switch Menu  (All Modes)
-Note=Go into Vs Mode & then Vs Options & then Press Up On the D-Pad Or Analogue Stick & then click the A Button to enter the Item Switch Menu. This Cheat Works For All Modes
-811348E2 0004
-
 $Give Kirby A Wierd Blow-Up
 8025E158 000A
 

--- a/Source/3rdParty/mupen64plus-core/data/mupencheat.txt
+++ b/Source/3rdParty/mupen64plus-core/data/mupencheat.txt
@@ -15739,9 +15739,6 @@ gn SMASH BROTHERS
  cn Bonus Stage Character Modifier (Training Mode)
   cd Only put this on after you have alreay Chose your Character on the Main Menu,& Do not use more then 1 Character Modifier at a time.Using this Code This could also result freezing at the end of the Level.
   8018F1D3 ???? 0000:"Mario",0001:"Fox",0002:"DK",0003:"Samus",0004:"Luigi",0005:"Link",0006:"Yoshi",0007:"C. Falcon",0008:"Kirby",0009:"Pikachu",000A:"Jigglypuff",000B:"Ness",000C:"Master Hand",000D:"Metal Mario",000E:"Polygon Mario",0010:"Polygon DK",0013:"Polygon Link",0014:"Polygon Yoshi",0015:"Polygon Samus",0018:"Polygon Kirby",001A:"Giant Donkey Kong"
- cn Enable Item Switch Menu  (All Modes)
-  cd Go into Vs Mode & then Vs Options & then Press Up On the D-Pad Or Analogue Stick & then click the A Button to enter the Item Switch Menu. This Cheat Works For All Modes
-  811348E2 0004
  cn Story Mode\Player 1\Stage Select
   D1045188 0010
   800A4AE7 ???? 0000:"Stage 1 (Vs Link)",0001:"Stage 2 (Vs Yoshi Team vs 18)",0002:"Stage 3 (Vs Fox McCloud)",0003:"Bonus Stage 1",0004:"Stage 4 (Freezes?)",0005:"Stage 5 (Vs Pikachu)",0006:"Stage 6 (Freezes?)",0007:"Bonus Stage 2",0008:"Stage 7 (Vs Kirby Team vs8)",0009:"Stage 8 (Vs Samus Aran)",000A:"Stage 9 (Vs Metal Mario)",000B:"Bonus Stage 3 (Race To The Finish)",000C:"Stage 10 (Fighting Polygon Team vs30)",000D:"Final Stage (Vs Master Hand)"

--- a/Source/RMG-Core/Cheats.cpp
+++ b/Source/RMG-Core/Cheats.cpp
@@ -872,12 +872,7 @@ CORE_EXPORT bool CoreEnableCheat(std::filesystem::path file, CoreCheat cheat, bo
     settingSection = romSettings.MD5 + " Cheats";
     settingKey = "Cheat \"" + cheat.Name + "\" Enabled";
 
-    // if the cheat is disabled and the settings key doesn't exist, do nothing
-    if (!enabled && !CoreSettingsKeyExists(settingSection, settingKey))
-    {
-        return true;
-    }
-
+    // Always save explicit choices, including disabling a default-enabled cheat.
     return CoreSettingsSetValue(settingSection, settingKey, enabled);
 }
 
@@ -896,7 +891,19 @@ CORE_EXPORT bool CoreIsCheatEnabled(std::filesystem::path file, CoreCheat cheat)
     settingSection = romSettings.MD5 + " Cheats";
     settingKey = "Cheat \"" + cheat.Name + "\" Enabled";
 
-    return CoreSettingsGetBoolValue(settingSection, settingKey, false);
+    // Default to the two unlock cheats bundled for Super Smash Bros. (U) and (J).
+    // Saved choices take precedence over these defaults.
+    const bool isSmashUS = romHeader.CRC1 == 0x916B8B5B &&
+                          romHeader.CRC2 == 0x780B85A4 &&
+                          romHeader.CountryCode == 0x45;
+    const bool isSmashJP = romHeader.CRC1 == 0x67D20729 &&
+                          romHeader.CRC2 == 0xF696774C &&
+                          romHeader.CountryCode == 0x4A;
+    const bool defaultEnabled = (isSmashUS || isSmashJP) &&
+                                (cheat.Name == "Have All Characters" ||
+                                 cheat.Name == "VS. Mode\\Have Mushroom Kindom");
+
+    return CoreSettingsGetBoolValue(settingSection, settingKey, defaultEnabled);
 }
 
 CORE_EXPORT bool CoreHasCheatOptionSet(std::filesystem::path file, CoreCheat cheat)

--- a/Source/Script/GenerateCheatFiles.sh
+++ b/Source/Script/GenerateCheatFiles.sh
@@ -62,4 +62,9 @@ do
     done < "$file"
 done
 
+# This Smash Bros. (U) code can hang the game during startup.
+# Keep it excluded when regenerating the bundled cheat database.
+sed -i '/^\$Enable Item Switch Menu  (All Modes)/,/^[[:space:]]*$/d' \
+    "$target_cheat_dir/916B8B5B-780B85A4-45.cht"
+
 rm -rf "$tmp_dir"


### PR DESCRIPTION
## Summary
- Turn on unlock everything cheats by default in U and J version
- Remove a broken cheat that was froze at startup
- Exclude the unsafe cheat during future cheat database generation
